### PR TITLE
NOTICE: comprehensive third-party attribution refresh

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -881,8 +881,8 @@ See mercata/ui/package-lock.json:2195.
 https://www.npmjs.com/package/@metamask/safe-event-emitter
 
 @metamask/sdk
-Upstream authors (npm metadata): danfinlay <dan@danfinlay.com>, kumavis <aaron@kumavis.me>, metamaskbot <metamask-npm@consensys.net>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Copyright ConsenSys Software Inc. 2022. All rights reserved.
+Licensed under a custom ConsenSys Software Inc. license with Non-Commercial Use restrictions (per npm package LICENSE).
 See mercata/ui/package-lock.json:2204.
 https://www.npmjs.com/package/@metamask/sdk
 
@@ -893,14 +893,14 @@ See mercata/ui/package-lock.json:2231.
 https://www.npmjs.com/package/@metamask/sdk-analytics
 
 @metamask/sdk-communication-layer
-Upstream authors (npm metadata): danfinlay <dan@danfinlay.com>, kumavis <aaron@kumavis.me>, mcmire <elliot.winkler@gmail.com> (and others).
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Copyright ConsenSys Software Inc. 2022. All rights reserved.
+Licensed under a custom ConsenSys Software Inc. license with Non-Commercial Use restrictions (per npm package LICENSE).
 See mercata/ui/package-lock.json:2240.
 https://www.npmjs.com/package/@metamask/sdk-communication-layer
 
 @metamask/sdk-install-modal-web
-Upstream author (npm metadata): MetaMask.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Copyright ConsenSys Software Inc. 2022. All rights reserved.
+Licensed under a custom ConsenSys Software Inc. license with Non-Commercial Use restrictions (per npm package LICENSE).
 See mercata/ui/package-lock.json:2299.
 https://www.npmjs.com/package/@metamask/sdk-install-modal-web
 
@@ -3762,7 +3762,7 @@ https://www.npmjs.com/package/bech32
 
 better-assert
 Upstream authors (npm metadata): TJ Holowaychuk <tj@vision-media.ca>, TonyHe <coolhzb@163.com>, ForbesLindesay.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See apex/api/package-lock.json:285.
 https://www.npmjs.com/package/better-assert
 
@@ -4110,7 +4110,7 @@ https://www.npmjs.com/package/caller-path
 
 callsite
 Upstream author (npm metadata): TJ Holowaychuk <tj@vision-media.ca>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See apex/api/package-lock.json:398.
 https://www.npmjs.com/package/callsite
 
@@ -4494,19 +4494,19 @@ https://www.npmjs.com/package/compare-versions
 
 component-bind
 Upstream author (npm metadata): tootallnate <nathan@tootallnate.net>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See apex/api/package-lock.json:574.
 https://www.npmjs.com/package/component-bind
 
 component-emitter
-Copyright information is provided by the upstream package authors.
+Copyright (c) 2014 Component contributors <dev@component.io>.
 Licensed under the MIT License (per npm registry metadata).
 See apex/api/package-lock.json:579.
 https://www.npmjs.com/package/component-emitter
 
 component-inherit
 Upstream author (npm metadata): coreh <thecoreh@gmail.com>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package metadata).
 See apex/api/package-lock.json:584.
 https://www.npmjs.com/package/component-inherit
 
@@ -4901,8 +4901,8 @@ See smd-ui/package-lock.json:3527.
 https://www.npmjs.com/package/currently-unhandled
 
 cycle
-Upstream author (npm metadata): dscape <nunojobpinto@gmail.com>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Upstream project metadata lists Douglas Crockford and Nuno Job as contributors.
+Licensed under Public-Domain terms (per upstream package.json metadata).
 See apex/api/package-lock.json:728.
 https://www.npmjs.com/package/cycle
 
@@ -7098,7 +7098,7 @@ https://www.npmjs.com/package/indexes-of
 
 indexof
 Upstream author (npm metadata): tjholowaychuk <tj@vision-media.ca>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See apex/api/package-lock.json:2131.
 https://www.npmjs.com/package/indexof
 
@@ -8969,8 +8969,8 @@ See apex/api/package-lock.json:2754.
 https://www.npmjs.com/package/nodemailer
 
 nomnom
-Upstream author (npm metadata): Heather Arthur <fayearthur@gmail.com>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Copyright (c) 2010 Heather Arthur.
+Licensed under the MIT License (per upstream LICENSE file).
 See smd-ui/package-lock.json:9511.
 https://www.npmjs.com/package/nomnom
 
@@ -9090,7 +9090,7 @@ https://www.npmjs.com/package/object-assign
 
 object-component
 Upstream author (npm metadata): tjholowaychuk <tj@vision-media.ca>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See apex/api/package-lock.json:2878.
 https://www.npmjs.com/package/object-component
 
@@ -12155,8 +12155,8 @@ See strato/extraFiles/strato/licenses/text.
 https://hackage.haskell.org/package/text
 
 text-encoding-utf-8
-Upstream authors (npm metadata): Erik Arvidsson <erik.arvidsson@gmail.com>, Rick Eyre <rick.eyre@outlook.com>, Joshua Bell <inexorabletash@gmail.com>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+In jurisdictions that recognize copyright laws, the author or authors.
+Licensed under The Unlicense / public-domain dedication (per npm package LICENSE.md).
 See mercata/services/bridge/package-lock.json:6450.
 https://www.npmjs.com/package/text-encoding-utf-8
 
@@ -12738,7 +12738,7 @@ https://www.npmjs.com/package/util-deprecate
 
 util-inspect
 Upstream author (npm metadata): rauchg <rauchg@gmail.com>.
-License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+Licensed under the MIT License (per npm package page metadata).
 See smd-ui/package-lock.json:14423.
 https://www.npmjs.com/package/util-inspect
 

--- a/NOTICE
+++ b/NOTICE
@@ -11,40 +11,1110 @@ subject to BlockApps' trademark policy and does not imply endorsement.
 
 Third-Party Notices
 
-json-rpc-server
-Copyright (c) 2013 Kristen Kozak
-Licensed under the MIT License. See strato/libs/json-rpc-server/LICENSE.
+aeson
+Copyright (c) 2011, MailRank, Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/aeson.
+
+aeson-casing
+Copyright (c) 2015 Andrew Rademacher
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/aeson-casing.
+
+aeson-extra
+Copyright (c) 2015, Oleg Grenrus
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/aeson-extra.
+
+aeson-pretty
+Copyright (c)2011, Falko Peters
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/aeson-pretty.
+
+ansi-wl-pprint
+Copyright 2008, Daan Leijen and Max Bolingbroke. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/ansi-wl-pprint.
+
+arithmoi
+Copyright (c) 2011 Daniel Fischer, 2016-2017 Andrew Lelechenko, Carter Schonwald, Google Inc.
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/arithmoi.
+
+array
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/array.
+
+base16-bytestring
+Copyright (c) 2011 MailRank, Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/base16-bytestring.
+
+bcrypt
+Copyright (c) 2010 Nicholas Campbell
+Licensed under the MIT License.
+See apex/api/licenses/bcrypt.
+
+big-integer
+In jurisdictions that recognize copyright laws, the author or authors
+Licensed under terms in the referenced file.
+See apex/api/licenses/big-integer.
+
+bignumber.js
+Copyright (c) 2018 Michael Mclaughlin
+Licensed under the MIT License.
+See smd-ui/licenses/bignumber.js.
+
+bimap
+Copyright Stuart Cook and contributors 2008
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/bimap.
+
+binary
+Copyright (c) Lennart Kolmodin
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/binary.
+
+blaze-builder
+Copyright Jasper Van der Jeugt 2010, Simon Meier 2010 & 2011
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/blaze-builder.
+
+blaze-html
+Copyright Jasper Van der Jeugt 2010
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/blaze-html.
+
+blaze-markup
+Copyright Jasper Van der Jeugt 2010
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/blaze-markup.
+
+bloomfilter
+Copyright 2008 Bryan O'Sullivan <bos@serpentine.com>.
+Licensed under the BSD License.
+See strato/libs/bloomfilter/LICENSE.
+
+blueprintjs
+"Licensor" shall mean the copyright owner or entity authorized by
+Licensed under the Apache License, Version 2.0.
+See smd-ui/licenses/blueprintjs.
+
+body-parser
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Licensed under the MIT License.
+See apex/api/licenses/body-parser.
+
+byteable
+Copyright (c) 2013 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/byteable.
+
+bytestring
+Copyright (c) Don Stewart 2005-2009
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/bytestring.
+
+bytestring-arbitrary
+Copyright (c) 2014, jay groven
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/bytestring-arbitrary.
+
+cereal
+Copyright (c) Lennart Kolmodin, Galois, Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/cereal.
+
+chai
+Copyright (c) 2017 Chai.js Assertion Library
+Licensed under the MIT License.
+See apex/api/licenses/chai.
+
+chai-http
+Copyright (c) Jake Luer jake@alogicalparadox.com
+Licensed under the MIT License.
+See apex/api/licenses/chai-http.
+
+cipher-aes
+Copyright (c) 2008-2013 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/cipher-aes.
+
+classy-prelude
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/classy-prelude.
+
+classy-prelude-yesod
+Copyright (c) 2013 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/classy-prelude-yesod.
+
+cmdargs
+Copyright Neil Mitchell 2009-2018.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/cmdargs.
+
+co
+Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+Licensed under the MIT License.
+See apex/api/licenses/co.
+
+co-mocha
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+Licensed under the MIT License.
+See apex/api/licenses/co-mocha.
+
+conduit
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/conduit.
+
+conduit-combinators
+Copyright (c) 2014 FP Complete
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/conduit-combinators.
+
+conduit-extra
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/conduit-extra.
+
+containers
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/containers.
+
+contravariant
+Copyright 2007-2015 Edward Kmett
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/contravariant.
+
+cookie-parser
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Licensed under the MIT License.
+See apex/api/licenses/cookie-parser.
+
+cors
+Copyright (c) 2013 Troy Goode <troygoode@gmail.com>
+Licensed under the MIT License.
+See apex/api/licenses/cors.
+
+Crypto
+Codec.Binary.BubbleBabble & John Meacham & Copyright © 2008, All rights
+Licensed under the GNU General Public License.
+See strato/extraFiles/strato/licenses/Crypto.
+
+crypto-pubkey
+Copyright (c) 2010-2012 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/crypto-pubkey.
+
+crypto-pubkey-types
+<th>Copyright</th>
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/crypto-pubkey-types.
+
+crypto-random
+Copyright (c) 2013 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/crypto-random.
+
+cryptohash
+Copyright (c) 2010-2014 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/cryptohash.
+
+cryptonite
+Copyright (c) 2006-2015 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/cryptonite.
+
+csv
+Copyright (c) Jaap Weel 2007.  Permission is hereby granted, free
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/csv.
+
+data-default
+Copyright (c) 2013 Lukas Mai
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/data-default.
+
+debug
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Licensed under the MIT License.
+See apex/api/licenses/debug.
+
+deepseq
+Copyright 2001-2009, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/deepseq.
+
+dequeue
+Copyright (c) 2009, Henry Bucklow
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/dequeue.
+
+derive
+Copyright Neil Mitchell 2006-2017.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/derive.
+
+diagrams-contrib
+Copyright (c) 2011-2015, various (see headers of individual source files)
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/diagrams-contrib.
+
+diagrams-html5
+Copyright (c) 2014-2016 diagrams-html5 team:
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/diagrams-html5.
+
+diagrams-lib
+Copyright (c) 2011-2016 diagrams-lib team:
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/diagrams-lib.
+
+digest
+Copyright (c) 2008-2009, Eugene Kirpichov
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/digest.
+
+directory
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/directory.
+
+dns
+Copyright (c) 2009, IIJ Innovation Institute Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/dns.
+
+either
+Copyright 2008-2014 Edward Kmett
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/either.
+
+entropy
+Copyright (c) Thomas DuBuisson
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/entropy.
+
+enzyme-adapter-react-15
+Copyright (c) 2015 Airbnb, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/enzyme-adapter-react-15.
+
+errors
+Copyright (c) 2012, 2013, Gabriel Gonzalez
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/errors.
+
+esqueleto
+Copyright (c) 2012, Felipe Lessa
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/esqueleto.
+
+ether
+Copyright (c) 2017, Vladislav Zavialov
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/ether.
+
+ethereum-rlp
+Copyright 2016 BlockApps, Inc
+Licensed under the Apache License, Version 2.0.
+See strato/extraFiles/strato/licenses/ethereum-rlp.
+
+exceptions
+Copyright 2013-2015 Edward Kmett
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/exceptions.
+
+expect
+Copyright (c) 2014-present, Facebook, Inc.
+Licensed under the MIT License.
+See apex/api/licenses/expect.
+
+express
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Licensed under the MIT License.
+See apex/api/licenses/express.
+
+extra
+Copyright Neil Mitchell 2014-2018.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/extra.
+
+fast-logger
+Copyright (c) 2009, IIJ Innovation Institute Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/fast-logger.
+
+file-embed
+Copyright 2008, Michael Snoyman. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/file-embed.
+
+filepath
+Copyright Neil Mitchell 2005-2018.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/filepath.
+
+fs-extra
+Copyright (c) 2011-2017 JP Richardson
+Licensed under the MIT License.
+See apex/api/licenses/fs-extra.
+
+generic-random
+Copyright (c) 2016 Li-yao Xia
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/generic-random.
+
+gitrev
+Copyright (c) 2015, Adam C. Foltzer
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/gitrev.
+
+hashable
+Copyright Milan Straka 2010
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/hashable.
+
+hedis
+Copyright (c)2011, Falko Peters
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/hedis.
+
+hflags
+"Licensor" shall mean the copyright owner or entity authorized by
+Licensed under the Apache License, Version 2.0.
+See strato/extraFiles/strato/licenses/hflags.
+
+hjsmin
+Copyright (c)2010, Alan Zimmerman
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/hjsmin.
+
+http-api-data
+Copyright 2015, Nickolay Kudasov. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/http-api-data.
+
+http-client
+Copyright (c) 2013 Michael Snoyman
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/http-client.
+
+http-media
+Copyright (c) 2012-2015 Timothy Jones
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/http-media.
+
+http-types
+Copyright (c) 2011, Aristid Breitkreuz
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/http-types.
+
+insert-ordered-containers
+Copyright (c) 2015, Oleg Grenrus
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/insert-ordered-containers.
+
+iproute
+Copyright (c) 2009, IIJ Innovation Institute Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/iproute.
+
+is-reachable
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Licensed under the MIT License.
+See apex/api/licenses/is-reachable.
 
 json-rpc-client
 Copyright (c) 2014 Kristen Kozak
-Licensed under the MIT License. See strato/libs/json-rpc-client/LICENSE.
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/json-rpc-client.
 
-bloomfilter
-Copyright 2008 Bryan O'Sullivan
-Licensed under the BSD 3-Clause License. See strato/libs/bloomfilter/LICENSE.
+json-rpc-server
+Copyright (c) 2013 Kristen Kozak
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/json-rpc-server.
 
-milena (Kafka client)
+json-stream
+Copyright (c) 2015, Ondrej Palkovsky
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/json-stream.
+
+largeint
+Copyright Eitan Chatav (c) 2017
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/largeint.
+
+largeword
+Copyright information in referenced file
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/largeword.
+
+lens
+Copyright 2012-2016 Edward Kmett
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/lens.
+
+lens-family
+Copyright 2012,2013,2014 Russell O'Connor
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/lens-family.
+
+lens-family-th
+Copyright (c) 2012, Dan Burton
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/lens-family-th.
+
+leveldb-haskell
+Copyright (c) 2011, Kim Altintop
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/leveldb-haskell.
+
+lifted-async
+Copyright (c) 2012-2017, Mitsutoshi Aoe
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/lifted-async.
+
+lifted-base
+Copyright © 2010-2012, Bas van Dijk, Anders Kaseorg
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/lifted-base.
+
+logging-effect
+Copyright (c) 2016, Ollie Charles
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/logging-effect.
+
+lua-resty-jwt
+"Licensor" shall mean the copyright owner or entity authorized by
+Licensed under the Apache License, Version 2.0.
+See nginx-packager/licenses/lua-resty-jwt.
+
+lua-resty-openidc
+"Licensor" shall mean the copyright owner or entity authorized by
+Licensed under the Apache License, Version 2.0.
+See nginx-packager/licenses/lua-resty-openidc.
+
+memory
+Copyright (c) 2015 Vincent Hanquez <vincent@snarc.org>
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/memory.
+
+merkle-patricia-db
+Copyright 2016 BlockApps, Inc
+Licensed under the Apache License, Version 2.0.
+See strato/extraFiles/strato/licenses/merkle-patricia-db.
+
+milena
 Copyright (c)2014, Tyler Holien
-Licensed under the BSD 3-Clause License. See strato/libs/kafka/milena/LICENSE.
+Licensed under the BSD License.
+See strato/libs/kafka/milena/LICENSE.
+
+mime-mail
+Copyright (c) 2014 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/mime-mail.
+
+mixpanel-browser
+Copyright 2015 Mixpanel, Inc.
+Licensed under the Apache License, Version 2.0.
+See smd-ui/licenses/mixpanel-browser.
+
+mmap
+Copyright (c) Gracjan Polak
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/mmap.
+
+mocha
+Copyright (c) 2011-2018 JS Foundation and contributors, https://js.foundation
+Licensed under the MIT License.
+See apex/api/licenses/mocha.
+
+moment
+Copyright (c) JS Foundation and other contributors
+Licensed under the MIT License.
+See apex/api/licenses/moment.
+
+moment-timezone
+Copyright (c) JS Foundation and other contributors
+Licensed under the MIT License.
+See smd-ui/licenses/moment-timezone.
+
+monaco-editor-vs-code
+Copyright (c) 2015 - present Microsoft Corporation
+Licensed under the MIT License.
+See smd-ui/public/vs/LICENSE.txt.
+
+monad-control
+Copyright © 2010, Bas van Dijk, Anders Kaseorg
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/monad-control.
+
+monad-logger
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/monad-logger.
+
+monadIO
+Copyright (c) 2008-2010, Galois, Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/monadIO.
+
+morgan
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Licensed under the MIT License.
+See apex/api/licenses/morgan.
+
+mtl
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/mtl.
+
+murmur-hash
+Copyright (c) 2010, Thomas Schilling
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/murmur-hash.
+
+murmur3
+In jurisdictions that recognize copyright laws, the author or authors
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/murmur3.
+
+network
+Copyright (c) 2002-2010, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/network.
+
+network-uri
+Copyright (c) 2002-2010, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/network-uri.
+
+nibblestring
+Copyright (c) 2014, Jamshid
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/nibblestring.
+
+normaldistribution
+Copyright (c) 2011, Bjorn Buckwalter.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/normaldistribution.
+
+opaleye
+Copyright (c) 2014-2018 Purely Agile Limited
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/opaleye.
+
+optparse-applicative
+Copyright (c) 2012, Paolo Capriotti
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/optparse-applicative.
+
+ordered-containers
+Copyright (c) 2016, Daniel Wagner
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/ordered-containers.
+
+parsec
+Copyright 1999-2000, Daan Leijen; 2007, Paolo Martini. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/parsec.
+
+parsec3-numbers
+Copyright information in referenced file
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/parsec3-numbers.
+
+path
+Copyright (c) 2014 Hage Yaapa <[http://www.hacksparrow.com](http://www.hacksparrow.com)>
+Licensed under the MIT License.
+See apex/api/licenses/path.
+
+path-pieces
+Copyright 2009, Michael Snoyman. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/path-pieces.
+
+pbkdf
+Copyright 2001-2005, Chris Dornan
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/pbkdf.
+
+persistent
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/persistent.
+
+persistent-postgresql
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/persistent-postgresql.
+
+persistent-template
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/persistent-template.
+
+pg
+Copyright (c) 2010 - 2018 Brian Carlson
+Licensed under the MIT License.
+See apex/api/licenses/pg.
+
+pg-hstore
+Copyright (c) 2014 Hage Yaapa <[http://www.hacksparrow.com](http://www.hacksparrow.com)>
+Licensed under the MIT License.
+See apex/api/licenses/pg-hstore.
+
+pgtools
+Copyright (c) 2010 - 2018 Brian Carlson
+Licensed under the MIT License.
+See apex/api/licenses/pgtools.
+
+plottable
+Copyright (c) 2014-2015 Palantir Technologies, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/plottable.
+
+postgresql-simple
+Copyright (c) 2011, Leon P Smith
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/postgresql-simple.
+
+postgrest
+Copyright (c) 2014 Joe Nelson
+Licensed under the MIT License.
+See postgrest-packager/licenses/postgrest.
+
+process
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/process.
+
+product-profunctors
+Copyright (c) 2013, Karamaan Group LLC; 2014-2018 Purely Agile Limited
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/product-profunctors.
+
+profunctors
+Copyright 2011-2015 Edward Kmett
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/profunctors.
+
+prometheus-packager
+Copyright 2012-2015 The Prometheus Authors
+Licensed under the Apache License, Version 2.0.
+See prometheus-packager/NOTICE.
+
+query-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Licensed under the MIT License.
+See smd-ui/licenses/query-string.
+
+QuickCheck
+Copyright (c) 2000-2017, Koen Claessen
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/QuickCheck.
+
+quickcheck-instances
+Copyright (c)2012, Antoine Latter
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/quickcheck-instances.
+
+random
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/random.
 
 rapidsnark
-Copyright iden3
-Licensed under the GNU Lesser General Public License v3. See
-strato/libs/groth16-rapidsnark/vendor/rapidsnark/COPYING.
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Licensed under the GNU Lesser General Public License.
+See strato/libs/groth16-rapidsnark/vendor/rapidsnark/COPYING.
+
+raw-strings-qq
+Copyright (c) 2013, Mikhail Glushenkov
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/raw-strings-qq.
+
+react
+Copyright (c) 2013-present, Facebook, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/react.
+
+react-addons-css-transition-group
+Copyright (c) 2013-present, Facebook, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/react-addons-css-transition-group.
+
+react-copy-to-clipboard
+Copyright (c) 2016 Nik Butenko
+Licensed under the MIT License.
+See smd-ui/licenses/react-copy-to-clipboard.
+
+react-dom
+Copyright (c) 2013-present, Facebook, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/react-dom.
+
+react-dropzone
+Copyright (c) 2014 Param Aggarwal
+Licensed under the MIT License.
+See smd-ui/licenses/react-dropzone.
+
+react-joyride
+Copyright (c) 2015, Gil Barbara
+Licensed under the MIT License.
+See smd-ui/licenses/react-joyride.
+
+react-loading
+Copyright information in referenced file
+Licensed under terms in the referenced file.
+See smd-ui/licenses/react-loading.
+
+react-monaco-editor
+Copyright (c) 2016-present Leon Shi
+Licensed under the MIT License.
+See smd-ui/licenses/react-monaco-editor.
+
+react-redux
+Copyright (c) 2015-present Dan Abramov
+Licensed under the MIT License.
+See smd-ui/licenses/react-redux.
+
+react-router-dom
+Copyright (c) React Training 2016-2018
+Licensed under the MIT License.
+See smd-ui/licenses/react-router-dom.
+
+react-router-redux
+Copyright (c) 2015-present James Long
+Licensed under the MIT License.
+See smd-ui/licenses/react-router-redux.
+
+redux
+Copyright (c) 2015-present Dan Abramov
+Licensed under the MIT License.
+See smd-ui/licenses/redux.
+
+redux-form
+Copyright (c) 2015 Erik Rasmussen
+Licensed under the MIT License.
+See smd-ui/licenses/redux-form.
+
+redux-saga
+Copyright (c) 2015 Yassine Elouafi
+Licensed under the MIT License.
+See smd-ui/licenses/redux-saga.
+
+redux-saga-test-plan
+Copyright (c) 2016 Jeremy Fairbank
+Licensed under the MIT License.
+See smd-ui/licenses/redux-saga-test-plan.
+
+redux-saga-testing
+Copyright (c) 2016 Antoine Jaussoin
+Licensed under the MIT License.
+See smd-ui/licenses/redux-saga-testing.
+
+relapse
+Copyright (c) 2016 Ilya Ostrovskiy
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/relapse.
+
+request
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+Licensed under terms in the referenced file.
+See apex/api/licenses/request.
+
+request-promise
+Copyright (c) 2017, Nicolai Kamenzky, Ty Abonil, and contributors
+Licensed under the ISC License.
+See apex/api/licenses/request-promise.
+
+reselect
+Copyright (c) 2015-2018 Reselect Contributors
+Licensed under the MIT License.
+See smd-ui/licenses/reselect.
+
+resource-pool
+Copyright (c) 2011, MailRank, Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/resource-pool.
+
+resourcet
+Copyright (c)2011, Michael Snoyman
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/resourcet.
+
+route-parser
+Copyright (c) 2014 Ryan Sorensen
+Licensed under the MIT License.
+See apex/api/licenses/route-parser.
+
+SafeSemaphore
+Copyright (c)2011, Chris Kuklewicz
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/SafeSemaphore.
+
+saltine
+Copyright (c) 2013 Joseph Abrahamson
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/saltine.
+
+scientific
+Copyright (c) 2013, Bas van Dijk
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/scientific.
+
+secp256k1
+In jurisdictions that recognize copyright laws, the author or authors
+Licensed under terms in the referenced file.
+See strato/extraFiles/strato/licenses/secp256k1.
+
+sequelize
+Copyright (c) 2014-present Sequelize contributors
+Licensed under the MIT License.
+See apex/api/licenses/sequelize.
+
+sequelize-cli
+Copyright (c) 2017 sequelize
+Licensed under the MIT License.
+See apex/api/licenses/sequelize-cli.
+
+servant
+Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant.
+
+servant-client
+Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant-client.
+
+servant-docs
+Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant-docs.
+
+servant-mock
+Copyright (c) 2015-2016, Servant Contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant-mock.
+
+servant-options
+Copyright 2017 Lyndon Maydwell
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/servant-options.
+
+servant-server
+Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant-server.
+
+servant-swagger
+Copyright (c) 2015-2016, Servant contributors
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/servant-swagger.
+
+servant-swagger-ui
+Copyright (c) 2016, Oleg Grenrus
+Licensed under the Apache License, Version 2.0.
+See strato/extraFiles/strato/licenses/servant-swagger-ui.
+
+serve
+Copyright (c) 2018 ZEIT, Inc.
+Licensed under the MIT License.
+See smd-ui/licenses/serve.
+
+serve-favicon
+Copyright (c) 2010 Sencha Inc.
+Licensed under the MIT License.
+See apex/api/licenses/serve-favicon.
+
+shakespeare
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/shakespeare.
+
+socket.io
+Copyright (c) 2014-2018 Automattic <dev@cloudup.com>
+Licensed under the MIT License.
+See apex/api/licenses/socket.io.
+
+socket.io-client
+Copyright (c) 2014 Guillermo Rauch
+Licensed under the MIT License.
+See smd-ui/licenses/socket.io-client.
+
+solidity
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Licensed under the GNU Lesser General Public License.
+See strato/extraFiles/strato/licenses/solidity.
+
+stm
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/stm.
+
+stm-conduit
+Copyright (c)2012, Clark Gaebel
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/stm-conduit.
+
+streaming-commons
+Copyright (c) 2014 FP Complete
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/streaming-commons.
+
+swagger2
+Copyright (c) 2015-2017, GetShopTV
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/swagger2.
+
+sync-request
+Copyright (c) 2014 Forbes Lindesay
+Licensed under the MIT License.
+See apex/api/licenses/sync-request.
+
+template-haskell
+Copyright 2002-2007, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/template-haskell.
+
+temporary
+Copyright
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/temporary.
+
+text
+Copyright (c) 2008-2009, Tom Harper
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/text.
+
+time
+TimeLib is Copyright (c) Ashley Yakeley, 2004-2014. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/time.
+
+transformers
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/transformers.
+
+transformers-base
+Copyright (c) 2011, Mikhail Vorozhtsov, Bas van Dijk
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/transformers-base.
+
+transformers-lift
+Copyright (c) 2015, Vladislav Zavialov
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/transformers-lift.
+
+underscore
+Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
+Licensed under the MIT License.
+See apex/api/licenses/underscore.
+
+unix
+Copyright 2004, The University Court of the University of Glasgow.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/unix.
+
+unordered-containers
+Copyright (c) 2010, Johan Tibell
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/unordered-containers.
+
+utf8-string
+* Copyright (c) 2007, Galois Inc.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/utf8-string.
+
+vector
+Copyright (c) 2008-2012, Roman Leshchinskiy
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/vector.
+
+vscode
+Copyright (c) 2015 - present Microsoft Corporation
+Licensed under the MIT License.
+See smd-ui/licenses/vscode.
+
+wai
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/wai.
+
+wai-cors
+Copyright (c) 2015 Lars Kuhtz <lakuhtz@gmail.com>
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/wai-cors.
+
+wai-extra
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/wai-extra.
+
+warp
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/warp.
+
+warp-tls
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/warp-tls.
 
 wasm3
 Copyright (c) 2019 Steven Massey, Volodymyr Shymanskyy
-Licensed under the MIT License. See
-strato/libs/groth16-rapidsnark/vendor/wasm3/LICENSE.
+Licensed under the MIT License.
+See strato/libs/groth16-rapidsnark/vendor/wasm3/LICENSE.
 
-Monaco Editor (VS Code)
-Copyright (c) 2015-present Microsoft Corporation
-Licensed under the MIT License. See smd-ui/public/vs/LICENSE.txt.
+winston-color
+Copyright (c) 2016 Arturo Arevalo
+Licensed under the MIT License.
+See apex/api/licenses/winston-color.
 
-Prometheus Packager
-Contains additional third-party components and notices. See
-prometheus-packager/NOTICE.
+wl-pprint-text
+Copyright (c)2010, Ivan Lazar Miljenovic
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/wl-pprint-text.
 
+yaml
+Copyright 2008, Michael Snoyman. All rights reserved.
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/yaml.
+
+yesod
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/yesod.
+
+yesod-core
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/yesod-core.
+
+yesod-raml
+Copyright (c) 2015 Junji Hashimoto
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/yesod-raml.
+
+yesod-static
+Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
+Licensed under the MIT License.
+See strato/extraFiles/strato/licenses/yesod-static.
+
+zlib
+Copyright (c) 2006-2016, Duncan Coutts
+Licensed under the BSD License.
+See strato/extraFiles/strato/licenses/zlib.
 
 -------------------------------------------------------------------------------
 WORK IN PROGRESS:

--- a/NOTICE
+++ b/NOTICE
@@ -81,7 +81,6 @@ Status:
 Evidence:
 - mercata/services/bridge/package-lock.json:1503
 - mercata/services/bridge/package-lock.json:6155
-- mercata/services/referral/package-lock.json:1503
 - mercata/services/referral/package-lock.json:6155
 Risk:
 - High.
@@ -122,32 +121,16 @@ Recommendation:
 Status:
 - sharp optional dependency chain includes LGPL libvips platform packages.
 Evidence:
-- mercata/ui/package-lock.json:12999
 - mercata/ui/package-lock.json:1366
-- mercata/ui/package-lock.json:1478
-- mercata/ui/package-lock.json:15041
+- mercata/ui/package-lock.json:12999
+- mercata/ui/package-lock.json:14865
 Risk:
 - Medium (optional/platform-dependent install path).
 Recommendation:
 - If Apache-only distribution is required, disable sharp-dependent path or
   provide separate compliance handling for LGPL components.
 
-6) legacy/pre-erc20-Jun2025/marketplace/ui node-forge
-   (BSD-3-Clause OR GPL-2.0)
-Status:
-- node-forge appears in lockfile as dual-license package, pulled by listhen and
-  selfsigned.
-Evidence:
-- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:16330
-- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:17055
-- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:21706
-Risk:
-- Low to Medium. Dual license permits BSD-3-Clause path (Apache-compatible), but
-  item should still be documented.
-Recommendation:
-- Keep only if legacy scope is still distributed.
-
-7) strato/extraFiles license bundle contains GPL texts
+6) strato/extraFiles license bundle contains GPL texts
 Status:
 - Build copies strato/extraFiles into STRATO image build context.
 Evidence:
@@ -168,7 +151,3 @@ Priority order:
 3. Minimize dev-tool LGPL path in mercata/ethereum.
 4. Audit and prune strato/extraFiles license bundle.
 5. Re-generate NOTICE and SBOM after dependency lock updates.
-
-Repository scope note:
-- In this checkout, legacy/ is present. If legacy/ is removed from distributed
-  artifacts in a future revision, remove item (6) and related evidence lines.

--- a/NOTICE
+++ b/NOTICE
@@ -10,6 +10,7 @@ BlockApps and STRATO are trademarks of BlockApps, Inc. Use of these trademarks i
 subject to BlockApps' trademark policy and does not imply endorsement.
 
 Third-Party Notices
+
 @adraffy/ens-normalize
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
@@ -3814,6 +3815,12 @@ Licensed under the MIT License (per npm registry metadata).
 See apex/api/package-lock.json:304.
 https://www.npmjs.com/package/bintrees
 
+bitwise
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:101.
+https://hackage.haskell.org/package/bitwise
+
 blaze-builder
 Copyright Jasper Van der Jeugt 2010, Simon Meier 2010 & 2011
 Licensed under the BSD License.
@@ -4480,6 +4487,12 @@ Licensed under the MIT License (per package-lock metadata).
 See apex/api/package-lock.json:569.
 https://www.npmjs.com/package/commander
 
+common
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:12.
+https://hackage.haskell.org/package/common
+
 commondir
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per npm registry metadata).
@@ -4623,6 +4636,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per npm registry metadata).
 See smd-ui/package-lock.json:3127.
 https://www.npmjs.com/package/content-type-parser
+
+contra-tracer
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:103.
+https://hackage.haskell.org/package/contra-tracer
 
 contravariant
 Copyright 2007-2015 Edward Kmett
@@ -5140,6 +5159,12 @@ Licensed under the MIT License (per package-lock metadata).
 See apex/api/package-lock.json:763.
 https://www.npmjs.com/package/decamelize
 
+decimal
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:105.
+https://hackage.haskell.org/package/decimal
+
 decimal.js-light
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
@@ -5265,6 +5290,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
 See apex/api/package-lock.json:802.
 https://www.npmjs.com/package/depd
+
+dependent-sum
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:30.
+https://hackage.haskell.org/package/dependent-sum
 
 dequeue
 Copyright (c) 2009, Henry Bucklow
@@ -5427,6 +5458,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
 See mercata/ui/package-lock.json:10944.
 https://www.npmjs.com/package/dom-helpers
+
+dom-lt
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:106.
+https://hackage.haskell.org/package/dom-lt
 
 dom-serializer
 Copyright information is provided by the upstream package authors.
@@ -6412,6 +6449,12 @@ Licensed under the MIT License (per npm registry metadata).
 See smd-ui/package-lock.json:5131.
 https://www.npmjs.com/package/fragment-cache
 
+free
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:14.
+https://hackage.haskell.org/package/free
+
 fresh
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
@@ -6573,6 +6616,30 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per npm registry metadata).
 See apex/api/package-lock.json:1940.
 https://www.npmjs.com/package/getpass
+
+ghc-debug-client
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:107.
+https://hackage.haskell.org/package/ghc-debug-client
+
+ghc-debug-common
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:108.
+https://hackage.haskell.org/package/ghc-debug-common
+
+ghc-debug-convention
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:109.
+https://hackage.haskell.org/package/ghc-debug-convention
+
+ghcjs-dom
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:15.
+https://hackage.haskell.org/package/ghcjs-dom
 
 gitrev
 Copyright (c) 2015, Adam C. Foltzer
@@ -6886,6 +6953,12 @@ Licensed under the MIT License (per package-lock metadata).
 See mercata/ui/package-lock.json:12121.
 https://www.npmjs.com/package/hono
 
+hoogle
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:112.
+https://hackage.haskell.org/package/hoogle
+
 hosted-git-info
 Copyright information is provided by the upstream package authors.
 Licensed under the ISC License (per package-lock metadata).
@@ -6897,6 +6970,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per npm registry metadata).
 See smd-ui/package-lock.json:6556.
 https://www.npmjs.com/package/hpack.js
+
+hspec
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/secp256k1-haskell/blockapps-secp256k1-haskell.cabal:89.
+https://hackage.haskell.org/package/hspec
 
 html-comment-regex
 Copyright information is provided by the upstream package authors.
@@ -7023,6 +7102,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
 See mercata/services/bridge/package-lock.json:2640.
 https://www.npmjs.com/package/humanize-ms
+
+hunit
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/json-rpc-server/json-rpc-server.cabal:78.
+https://hackage.haskell.org/package/hunit
 
 iconv-lite
 Copyright information is provided by the upstream package authors.
@@ -7858,6 +7943,12 @@ Licensed under the MIT License (per package-lock metadata).
 See mercata/backend/package-lock.json:1461.
 https://www.npmjs.com/package/js-yaml
 
+jsaddle
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:19.
+https://hackage.haskell.org/package/jsaddle
+
 jsbn
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
@@ -8061,6 +8152,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
 See mercata/backend/package-lock.json:1482.
 https://www.npmjs.com/package/kuler
+
+labeled-error
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/secp256k1-haskell/blockapps-secp256k1-haskell.cabal:90.
+https://hackage.haskell.org/package/labeled-error
 
 largeint
 Copyright Eitan Chatav (c) 2017
@@ -8716,6 +8813,12 @@ Licensed under the MIT License (per package-lock metadata).
 See mercata/ui/package-lock.json:12918.
 https://www.npmjs.com/package/modern-ahocorasick
 
+modern-uri
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:27.
+https://hackage.haskell.org/package/modern-uri
+
 moment
 Copyright (c) JS Foundation and other contributors
 Licensed under the MIT License.
@@ -9075,6 +9178,30 @@ Copyright information is provided by the upstream package authors.
 Licensed under the Apache-2.0 License (per npm registry metadata).
 See apex/api/package-lock.json:2862.
 https://www.npmjs.com/package/oauth-sign
+
+obelisk-executable-config-lookup
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:23.
+https://hackage.haskell.org/package/obelisk-executable-config-lookup
+
+obelisk-frontend
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:17.
+https://hackage.haskell.org/package/obelisk-frontend
+
+obelisk-generated-static
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:24.
+https://hackage.haskell.org/package/obelisk-generated-static
+
+obelisk-route
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:18.
+https://hackage.haskell.org/package/obelisk-route
 
 obj-multiplex
 Copyright information is provided by the upstream package authors.
@@ -10882,6 +11009,18 @@ Licensed under the MIT License.
 See smd-ui/licenses/redux-saga-testing.
 https://www.npmjs.com/package/redux-saga-testing
 
+reflex
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:20.
+https://hackage.haskell.org/package/reflex
+
+reflex-dom
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:21.
+https://hackage.haskell.org/package/reflex-dom
+
 regenerate
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per npm registry metadata).
@@ -11205,6 +11344,12 @@ Copyright information is provided by the upstream package authors.
 Licensed under the Apache License, Version 2.0 License (per npm registry metadata).
 See smd-ui/package-lock.json:12239.
 https://www.npmjs.com/package/rx-lite-aggregates
+
+safe
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/stack.yaml:117.
+https://hackage.haskell.org/package/safe
 
 safe-buffer
 Copyright information is provided by the upstream package authors.
@@ -11854,6 +11999,12 @@ Licensed under the MIT License (per package-lock metadata).
 See mercata/ui/package-lock.json:15204.
 https://www.npmjs.com/package/strict-uri-encode
 
+string-conversions
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/secp256k1-haskell/blockapps-secp256k1-haskell.cabal:64.
+https://hackage.haskell.org/package/string-conversions
+
 string-convert
 Copyright information is provided by the upstream package authors.
 Licensed under the MIT License (per package-lock metadata).
@@ -12141,6 +12292,24 @@ Copyright information is provided by the upstream package authors.
 Licensed under the ISC License (per npm registry metadata).
 See smd-ui/package-lock.json:1290.
 https://www.npmjs.com/package/test-exclude
+
+test-framework
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/json-rpc-server/json-rpc-server.cabal:79.
+https://hackage.haskell.org/package/test-framework
+
+test-framework-hunit
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/json-rpc-server/json-rpc-server.cabal:80.
+https://hackage.haskell.org/package/test-framework-hunit
+
+test-framework-quickcheck2
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/bloomfilter/bloomfilter.cabal:62.
+https://hackage.haskell.org/package/test-framework-quickcheck2
 
 tether
 Copyright information is provided by the upstream package authors.
@@ -12580,6 +12749,12 @@ Licensed under the MIT License (per package-lock metadata).
 See apex/api/package-lock.json:4216.
 https://www.npmjs.com/package/universalify
 
+universe
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/simulator/strato-obelisk/frontend/frontend.cabal:32.
+https://hackage.haskell.org/package/universe
+
 unix
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
@@ -12807,6 +12982,12 @@ Copyright (c) 2008-2012, Roman Leshchinskiy
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/vector.
 https://hackage.haskell.org/package/vector
+
+vector-algorithms
+Copyright information is provided by the upstream package authors.
+Licensed under terms in the referenced package metadata.
+See strato/libs/json-rpc-client/json-rpc-client.cabal:51.
+https://hackage.haskell.org/package/vector-algorithms
 
 vendors
 Copyright information is provided by the upstream package authors.

--- a/NOTICE
+++ b/NOTICE
@@ -50,74 +50,125 @@ prometheus-packager/NOTICE.
 WORK IN PROGRESS:
 -------------------------------------------------------------------------------
 
-Appendix: License Audit Notes (detailed with evidence)
+Appendix: License Audit Notes and Recommendation Matrix (refreshed 2026-03-03)
 
-1. strato/libs/groth16-rapidsnark/vendor/rapidsnark (LGPL-3.0)
-Vendored C++ source is compiled as part of the groth16-rapidsnark Haskell
-package and linked into the Airlock CLI. Evidence:
-strato/libs/groth16-rapidsnark/package.yaml:7
-strato/libs/groth16-rapidsnark/package.yaml:14
-strato/libs/groth16-rapidsnark/package.yaml:74
-strato/tools/airlock/src/Railgun/Prover.hs:25
-strato/tools/airlock/src/Railgun/Prover.hs:26
-strato/tools/airlock/src/Railgun/Prover.hs:111
-strato/tools/airlock/src/Railgun/Prover.hs:118
+Goal for this appendix:
+- Identify components that may be incompatible with Apache-2.0-only
+  distribution posture.
+- Capture mitigation recommendations and implementation priority.
 
-2. legacy/pre-erc20-Jun2025/marketplace/ui node-forge (BSD-3-Clause OR GPL-2.0)
-node-forge is a transitive dependency of listhen and selfsigned (dev HTTPS
-helpers). Evidence:
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:16330
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:16347
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:17051
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:17055
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:21699
-legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:21706
+1) strato/libs/groth16-rapidsnark/vendor/rapidsnark (LGPL-3.0)
+Status:
+- Vendored C++ source is compiled as part of groth16-rapidsnark and used by
+  Airlock prover path.
+Evidence:
+- strato/libs/groth16-rapidsnark/package.yaml:14
+- strato/libs/groth16-rapidsnark/package.yaml:74
+- strato/tools/airlock/src/Railgun/Prover.hs:25
+- strato/tools/airlock/src/Railgun/Prover.hs:117
+Risk:
+- High (copyleft obligations apply to distributed combined work path).
+Recommendation:
+- Preferred: remove rapidsnark build/use path and rely on non-LGPL prover
+  alternatives for Apache-only distributions.
+- Alternative: keep as explicitly optional external component with separate
+  compliance path.
 
-3. mercata/ethereum solidity-coverage and web3-utils (LGPL-3.0)
-solidity-coverage is pulled in as a peer dependency of
-@nomicfoundation/hardhat-toolbox and brings web3-utils (LGPL-3.0). Evidence:
-mercata/ethereum/package.json:18
-mercata/ethereum/package-lock.json:1765
-mercata/ethereum/package-lock.json:1785
-mercata/ethereum/package-lock.json:7942
-mercata/ethereum/package-lock.json:7968
-mercata/ethereum/package-lock.json:8928
-mercata/ethereum/package-lock.json:8933
+2) mercata/services/bridge and mercata/services/referral rpc-websockets
+   (LGPL-3.0-only) via alchemy-sdk -> @solana/web3.js
+Status:
+- rpc-websockets is present in both service lockfiles with LGPL-3.0-only.
+Evidence:
+- mercata/services/bridge/package-lock.json:1503
+- mercata/services/bridge/package-lock.json:6155
+- mercata/services/referral/package-lock.json:1503
+- mercata/services/referral/package-lock.json:6155
+Risk:
+- High.
+Recommendation:
+- Preferred: remove alchemy-sdk dependency chain and use direct JSON-RPC
+  clients to avoid @solana/web3.js/rpc-websockets pull-in.
 
-4. mercata/services/bridge and mercata/services/referral rpc-websockets
-(LGPL-3.0-only) via @solana/web3.js and alchemy-sdk
-alchemy-sdk is a declared dependency; it depends on @solana/web3.js, which in
-turn depends on rpc-websockets. The bridge service fetches chain data via raw
-JSON-RPC (eth_blockNumber/eth_getLogs). Evidence:
-mercata/services/bridge/package.json:20
-mercata/services/referral/package.json:20
-mercata/services/bridge/package-lock.json:1140
-mercata/services/bridge/package-lock.json:1503
-mercata/services/bridge/package-lock.json:6151
-mercata/services/bridge/package-lock.json:6155
-mercata/services/referral/package-lock.json:1140
-mercata/services/referral/package-lock.json:1503
-mercata/services/referral/package-lock.json:6151
-mercata/services/referral/package-lock.json:6155
-mercata/services/bridge/src/services/rpcService.ts:13
-mercata/services/bridge/src/services/rpcService.ts:35
+3) mercata/ui rpc-websockets (LGPL-3.0-only) via @base-org/account ->
+   @coinbase/cdp-sdk -> @solana/web3.js
+Status:
+- rpc-websockets is present in Mercata UI lockfile.
+Evidence:
+- mercata/ui/package-lock.json:243
+- mercata/ui/package-lock.json:349
+- mercata/ui/package-lock.json:7253
+- mercata/ui/package-lock.json:14865
+Risk:
+- High.
+Recommendation:
+- Preferred: replace SDK path introducing Solana websocket stack for Apache-only
+  distribution profile.
 
-5. mercata/ui rpc-websockets (LGPL-3.0-only) via @coinbase/cdp-sdk and
-@solana/web3.js
-@base-org/account depends on @coinbase/cdp-sdk, which depends on
-@solana/web3.js, which depends on rpc-websockets. Evidence:
-mercata/ui/package-lock.json:243
-mercata/ui/package-lock.json:349
-mercata/ui/package-lock.json:352
-mercata/ui/package-lock.json:358
-mercata/ui/package-lock.json:7253
-mercata/ui/package-lock.json:14861
-mercata/ui/package-lock.json:14865
+4) mercata/ethereum web3-utils (LGPL-3.0) via solidity-coverage
+Status:
+- web3-utils appears as dev dependency path from hardhat-toolbox peer set.
+Evidence:
+- mercata/ethereum/package-lock.json:1785
+- mercata/ethereum/package-lock.json:7968
+- mercata/ethereum/package-lock.json:8933
+Risk:
+- Medium (dev/test scope, but still relevant for distributed source/binaries
+  and SBOM posture).
+Recommendation:
+- Preferred: remove solidity-coverage/hardhat-toolbox aggregate if not required;
+  install only specific hardhat plugins needed.
 
-6. mercata/ui sharp / @img/sharp-* / @img/sharp-libvips-* (LGPL-3.0-or-later)
-Next lists sharp as an optional dependency, and sharp pulls @img/sharp-* and
-@img/sharp-libvips-* platform packages with LGPL-3.0-or-later licenses. Evidence:
-mercata/ui/package-lock.json:12999
-mercata/ui/package-lock.json:1315
-mercata/ui/package-lock.json:1359
-mercata/ui/package-lock.json:1366
+5) mercata/ui sharp/libvips platform packages (LGPL-3.0-or-later)
+Status:
+- sharp optional dependency chain includes LGPL libvips platform packages.
+Evidence:
+- mercata/ui/package-lock.json:12999
+- mercata/ui/package-lock.json:1366
+- mercata/ui/package-lock.json:1478
+- mercata/ui/package-lock.json:15041
+Risk:
+- Medium (optional/platform-dependent install path).
+Recommendation:
+- If Apache-only distribution is required, disable sharp-dependent path or
+  provide separate compliance handling for LGPL components.
+
+6) legacy/pre-erc20-Jun2025/marketplace/ui node-forge
+   (BSD-3-Clause OR GPL-2.0)
+Status:
+- node-forge appears in lockfile as dual-license package, pulled by listhen and
+  selfsigned.
+Evidence:
+- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:16330
+- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:17055
+- legacy/pre-erc20-Jun2025/marketplace/ui/package-lock.json:21706
+Risk:
+- Low to Medium. Dual license permits BSD-3-Clause path (Apache-compatible), but
+  item should still be documented.
+Recommendation:
+- Keep only if legacy scope is still distributed.
+
+7) strato/extraFiles license bundle contains GPL texts
+Status:
+- Build copies strato/extraFiles into STRATO image build context.
+Evidence:
+- Makefile:190
+- strato/extraFiles/strato/licenses/solidity:1
+- strato/extraFiles/strato/licenses/Crypto:44
+Risk:
+- Medium to High (needs provenance mapping; may be stale notice bundle or
+  active component notice).
+Recommendation:
+- Audit each file in strato/extraFiles/strato/licenses and keep only those
+  required by actually shipped dependencies; remove stale GPL notice files if
+  no corresponding shipped GPL component exists.
+
+Priority order:
+1. Remove LGPL rpc-websockets paths from bridge/referral/ui.
+2. Decide rapidsnark policy (remove or isolate externally).
+3. Minimize dev-tool LGPL path in mercata/ethereum.
+4. Audit and prune strato/extraFiles license bundle.
+5. Re-generate NOTICE and SBOM after dependency lock updates.
+
+Repository scope note:
+- In this checkout, legacy/ is present. If legacy/ is removed from distributed
+  artifacts in a future revision, remove item (6) and related evidence lines.

--- a/NOTICE
+++ b/NOTICE
@@ -10,1111 +10,13235 @@ BlockApps and STRATO are trademarks of BlockApps, Inc. Use of these trademarks i
 subject to BlockApps' trademark policy and does not imply endorsement.
 
 Third-Party Notices
+@adraffy/ens-normalize
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:52.
+https://www.npmjs.com/package/@adraffy/ens-normalize
+
+@alloc/quick-lru
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:117.
+https://www.npmjs.com/package/@alloc/quick-lru
+
+@ant-design/colors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:129.
+https://www.npmjs.com/package/@ant-design/colors
+
+@ant-design/cssinjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:138.
+https://www.npmjs.com/package/@ant-design/cssinjs
+
+@ant-design/cssinjs-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:157.
+https://www.npmjs.com/package/@ant-design/cssinjs-utils
+
+@ant-design/fast-color
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:178.
+https://www.npmjs.com/package/@ant-design/fast-color
+
+@ant-design/icons
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:187.
+https://www.npmjs.com/package/@ant-design/icons
+
+@ant-design/icons-svg
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:206.
+https://www.npmjs.com/package/@ant-design/icons-svg
+
+@ant-design/react-slick
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:212.
+https://www.npmjs.com/package/@ant-design/react-slick
+
+@apidevtools/json-schema-ref-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:49.
+https://www.npmjs.com/package/@apidevtools/json-schema-ref-parser
+
+@apidevtools/openapi-schemas
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:61.
+https://www.npmjs.com/package/@apidevtools/openapi-schemas
+
+@apidevtools/swagger-methods
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:70.
+https://www.npmjs.com/package/@apidevtools/swagger-methods
+
+@apidevtools/swagger-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:76.
+https://www.npmjs.com/package/@apidevtools/swagger-parser
+
+@aws-crypto/sha256-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:30.
+https://www.npmjs.com/package/@aws-crypto/sha256-browser
+
+@aws-crypto/sha256-js
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:83.
+https://www.npmjs.com/package/@aws-crypto/sha256-js
+
+@aws-crypto/supports-web-crypto
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:97.
+https://www.npmjs.com/package/@aws-crypto/supports-web-crypto
+
+@aws-crypto/util
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:106.
+https://www.npmjs.com/package/@aws-crypto/util
+
+@aws-sdk/client-cloudwatch
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:155.
+https://www.npmjs.com/package/@aws-sdk/client-cloudwatch
+
+@aws-sdk/client-sso
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:207.
+https://www.npmjs.com/package/@aws-sdk/client-sso
+
+@aws-sdk/core
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:256.
+https://www.npmjs.com/package/@aws-sdk/core
+
+@aws-sdk/credential-provider-env
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:280.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-env
+
+@aws-sdk/credential-provider-http
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:296.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-http
+
+@aws-sdk/credential-provider-ini
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:317.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-ini
+
+@aws-sdk/credential-provider-login
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:342.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-login
+
+@aws-sdk/credential-provider-node
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:361.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-node
+
+@aws-sdk/credential-provider-process
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:384.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-process
+
+@aws-sdk/credential-provider-sso
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:401.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-sso
+
+@aws-sdk/credential-provider-web-identity
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:420.
+https://www.npmjs.com/package/@aws-sdk/credential-provider-web-identity
+
+@aws-sdk/middleware-host-header
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:438.
+https://www.npmjs.com/package/@aws-sdk/middleware-host-header
+
+@aws-sdk/middleware-logger
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:453.
+https://www.npmjs.com/package/@aws-sdk/middleware-logger
+
+@aws-sdk/middleware-recursion-detection
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:467.
+https://www.npmjs.com/package/@aws-sdk/middleware-recursion-detection
+
+@aws-sdk/middleware-user-agent
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:483.
+https://www.npmjs.com/package/@aws-sdk/middleware-user-agent
+
+@aws-sdk/nested-clients
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:501.
+https://www.npmjs.com/package/@aws-sdk/nested-clients
+
+@aws-sdk/region-config-resolver
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:550.
+https://www.npmjs.com/package/@aws-sdk/region-config-resolver
+
+@aws-sdk/token-providers
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:566.
+https://www.npmjs.com/package/@aws-sdk/token-providers
+
+@aws-sdk/types
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:584.
+https://www.npmjs.com/package/@aws-sdk/types
+
+@aws-sdk/util-endpoints
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:597.
+https://www.npmjs.com/package/@aws-sdk/util-endpoints
+
+@aws-sdk/util-locate-window
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:613.
+https://www.npmjs.com/package/@aws-sdk/util-locate-window
+
+@aws-sdk/util-user-agent-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:625.
+https://www.npmjs.com/package/@aws-sdk/util-user-agent-browser
+
+@aws-sdk/util-user-agent-node
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:637.
+https://www.npmjs.com/package/@aws-sdk/util-user-agent-node
+
+@aws-sdk/xml-builder
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:661.
+https://www.npmjs.com/package/@aws-sdk/xml-builder
+
+@aws/lambda-invoke-store
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:675.
+https://www.npmjs.com/package/@aws/lambda-invoke-store
+
+@babel/runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:58.
+https://www.npmjs.com/package/@babel/runtime
+
+@base-org/account
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:237.
+https://www.npmjs.com/package/@base-org/account
+
+@blueprintjs/core
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:21.
+https://www.npmjs.com/package/@blueprintjs/core
+
+@blueprintjs/icons
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:36.
+https://www.npmjs.com/package/@blueprintjs/icons
+
+@blueprintjs/select
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:52.
+https://www.npmjs.com/package/@blueprintjs/select
+
+@blueprintjs/table
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:102.
+https://www.npmjs.com/package/@blueprintjs/table
+
+@coinbase/cdp-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:349.
+https://www.npmjs.com/package/@coinbase/cdp-sdk
+
+@coinbase/wallet-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:390.
+https://www.npmjs.com/package/@coinbase/wallet-sdk
+
+@colors/colors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:93.
+https://www.npmjs.com/package/@colors/colors
+
+@dabh/diagnostics
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:115.
+https://www.npmjs.com/package/@dabh/diagnostics
+
+@ecies/ciphers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:501.
+https://www.npmjs.com/package/@ecies/ciphers
+
+@emnapi/runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:515.
+https://www.npmjs.com/package/@emnapi/runtime
+
+@emotion/hash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:172.
+https://www.npmjs.com/package/@emotion/hash
+
+@emotion/unitless
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:531.
+https://www.npmjs.com/package/@emotion/unitless
+
+@ethereumjs/common
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1136.
+https://www.npmjs.com/package/@ethereumjs/common
+
+@ethereumjs/rlp
+Copyright information is provided by the upstream package authors.
+Licensed under the MPL-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1146.
+https://www.npmjs.com/package/@ethereumjs/rlp
+
+@ethereumjs/tx
+Copyright information is provided by the upstream package authors.
+Licensed under the MPL-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1158.
+https://www.npmjs.com/package/@ethereumjs/tx
+
+@ethereumjs/util
+Copyright information is provided by the upstream package authors.
+Licensed under the MPL-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1173.
+https://www.npmjs.com/package/@ethereumjs/util
+
+@ethersproject/abi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:80.
+https://www.npmjs.com/package/@ethersproject/abi
+
+@ethersproject/abstract-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:107.
+https://www.npmjs.com/package/@ethersproject/abstract-provider
+
+@ethersproject/abstract-signer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:132.
+https://www.npmjs.com/package/@ethersproject/abstract-signer
+
+@ethersproject/address
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:155.
+https://www.npmjs.com/package/@ethersproject/address
+
+@ethersproject/base64
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:178.
+https://www.npmjs.com/package/@ethersproject/base64
+
+@ethersproject/basex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:197.
+https://www.npmjs.com/package/@ethersproject/basex
+
+@ethersproject/bignumber
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:217.
+https://www.npmjs.com/package/@ethersproject/bignumber
+
+@ethersproject/bytes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:238.
+https://www.npmjs.com/package/@ethersproject/bytes
+
+@ethersproject/constants
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:257.
+https://www.npmjs.com/package/@ethersproject/constants
+
+@ethersproject/contracts
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:276.
+https://www.npmjs.com/package/@ethersproject/contracts
+
+@ethersproject/hash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:304.
+https://www.npmjs.com/package/@ethersproject/hash
+
+@ethersproject/hdnode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:331.
+https://www.npmjs.com/package/@ethersproject/hdnode
+
+@ethersproject/json-wallets
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:361.
+https://www.npmjs.com/package/@ethersproject/json-wallets
+
+@ethersproject/keccak256
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:392.
+https://www.npmjs.com/package/@ethersproject/keccak256
+
+@ethersproject/logger
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:412.
+https://www.npmjs.com/package/@ethersproject/logger
+
+@ethersproject/networks
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:428.
+https://www.npmjs.com/package/@ethersproject/networks
+
+@ethersproject/pbkdf2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:447.
+https://www.npmjs.com/package/@ethersproject/pbkdf2
+
+@ethersproject/properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:467.
+https://www.npmjs.com/package/@ethersproject/properties
+
+@ethersproject/providers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:486.
+https://www.npmjs.com/package/@ethersproject/providers
+
+@ethersproject/random
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:545.
+https://www.npmjs.com/package/@ethersproject/random
+
+@ethersproject/rlp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:565.
+https://www.npmjs.com/package/@ethersproject/rlp
+
+@ethersproject/sha2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:585.
+https://www.npmjs.com/package/@ethersproject/sha2
+
+@ethersproject/signing-key
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:606.
+https://www.npmjs.com/package/@ethersproject/signing-key
+
+@ethersproject/strings
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:630.
+https://www.npmjs.com/package/@ethersproject/strings
+
+@ethersproject/transactions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:651.
+https://www.npmjs.com/package/@ethersproject/transactions
+
+@ethersproject/units
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:678.
+https://www.npmjs.com/package/@ethersproject/units
+
+@ethersproject/wallet
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:699.
+https://www.npmjs.com/package/@ethersproject/wallet
+
+@ethersproject/web
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:732.
+https://www.npmjs.com/package/@ethersproject/web
+
+@ethersproject/wordlists
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:755.
+https://www.npmjs.com/package/@ethersproject/wordlists
+
+@floating-ui/core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1187.
+https://www.npmjs.com/package/@floating-ui/core
+
+@floating-ui/dom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1196.
+https://www.npmjs.com/package/@floating-ui/dom
+
+@floating-ui/react-dom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1206.
+https://www.npmjs.com/package/@floating-ui/react-dom
+
+@floating-ui/utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1219.
+https://www.npmjs.com/package/@floating-ui/utils
+
+@gemini-wallet/core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1225.
+https://www.npmjs.com/package/@gemini-wallet/core
+
+@hapi/address
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:126.
+https://www.npmjs.com/package/@hapi/address
+
+@hapi/boom
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:778.
+https://www.npmjs.com/package/@hapi/boom
+
+@hapi/bourne
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:787.
+https://www.npmjs.com/package/@hapi/bourne
+
+@hapi/formula
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:136.
+https://www.npmjs.com/package/@hapi/formula
+
+@hapi/hoek
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:143.
+https://www.npmjs.com/package/@hapi/hoek
+
+@hapi/joi
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:149.
+https://www.npmjs.com/package/@hapi/joi
+
+@hapi/pinpoint
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:163.
+https://www.npmjs.com/package/@hapi/pinpoint
+
+@hapi/topo
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:169.
+https://www.npmjs.com/package/@hapi/topo
+
+@hapi/wreck
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:814.
+https://www.npmjs.com/package/@hapi/wreck
+
+@hookform/resolvers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1244.
+https://www.npmjs.com/package/@hookform/resolvers
+
+@hypnosphi/create-react-context
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:114.
+https://www.npmjs.com/package/@hypnosphi/create-react-context
+
+@img/colour
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1305.
+https://www.npmjs.com/package/@img/colour
+
+@img/sharp-darwin-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1315.
+https://www.npmjs.com/package/@img/sharp-darwin-arm64
+
+@img/sharp-darwin-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1337.
+https://www.npmjs.com/package/@img/sharp-darwin-x64
+
+@img/sharp-libvips-darwin-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1359.
+https://www.npmjs.com/package/@img/sharp-libvips-darwin-arm64
+
+@img/sharp-libvips-darwin-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1375.
+https://www.npmjs.com/package/@img/sharp-libvips-darwin-x64
+
+@img/sharp-libvips-linux-arm
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1391.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-arm
+
+@img/sharp-libvips-linux-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1407.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-arm64
+
+@img/sharp-libvips-linux-ppc64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1423.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-ppc64
+
+@img/sharp-libvips-linux-riscv64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1439.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-riscv64
+
+@img/sharp-libvips-linux-s390x
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1455.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-s390x
+
+@img/sharp-libvips-linux-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1471.
+https://www.npmjs.com/package/@img/sharp-libvips-linux-x64
+
+@img/sharp-libvips-linuxmusl-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1487.
+https://www.npmjs.com/package/@img/sharp-libvips-linuxmusl-arm64
+
+@img/sharp-libvips-linuxmusl-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1503.
+https://www.npmjs.com/package/@img/sharp-libvips-linuxmusl-x64
+
+@img/sharp-linux-arm
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1519.
+https://www.npmjs.com/package/@img/sharp-linux-arm
+
+@img/sharp-linux-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1541.
+https://www.npmjs.com/package/@img/sharp-linux-arm64
+
+@img/sharp-linux-ppc64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1563.
+https://www.npmjs.com/package/@img/sharp-linux-ppc64
+
+@img/sharp-linux-riscv64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1585.
+https://www.npmjs.com/package/@img/sharp-linux-riscv64
+
+@img/sharp-linux-s390x
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1607.
+https://www.npmjs.com/package/@img/sharp-linux-s390x
+
+@img/sharp-linux-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1629.
+https://www.npmjs.com/package/@img/sharp-linux-x64
+
+@img/sharp-linuxmusl-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1651.
+https://www.npmjs.com/package/@img/sharp-linuxmusl-arm64
+
+@img/sharp-linuxmusl-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:1673.
+https://www.npmjs.com/package/@img/sharp-linuxmusl-x64
+
+@img/sharp-wasm32
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 AND LGPL-3.0-or-later AND MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1695.
+https://www.npmjs.com/package/@img/sharp-wasm32
+
+@img/sharp-win32-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 AND LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1714.
+https://www.npmjs.com/package/@img/sharp-win32-arm64
+
+@img/sharp-win32-ia32
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 AND LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1733.
+https://www.npmjs.com/package/@img/sharp-win32-ia32
+
+@img/sharp-win32-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 AND LGPL-3.0-or-later License (per package-lock metadata).
+See mercata/ui/package-lock.json:1752.
+https://www.npmjs.com/package/@img/sharp-win32-x64
+
+@jridgewell/gen-mapping
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1771.
+https://www.npmjs.com/package/@jridgewell/gen-mapping
+
+@jridgewell/resolve-uri
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1781.
+https://www.npmjs.com/package/@jridgewell/resolve-uri
+
+@jridgewell/sourcemap-codec
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1790.
+https://www.npmjs.com/package/@jridgewell/sourcemap-codec
+
+@jridgewell/trace-mapping
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1796.
+https://www.npmjs.com/package/@jridgewell/trace-mapping
+
+@jsdevtools/ono
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:206.
+https://www.npmjs.com/package/@jsdevtools/ono
+
+@lit-labs/ssr-dom-shim
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:1806.
+https://www.npmjs.com/package/@lit-labs/ssr-dom-shim
+
+@lit/reactive-element
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:1812.
+https://www.npmjs.com/package/@lit/reactive-element
+
+@metamask/eth-json-rpc-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See mercata/ui/package-lock.json:1825.
+https://www.npmjs.com/package/@metamask/eth-json-rpc-provider
+
+@metamask/json-rpc-engine
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:1838.
+https://www.npmjs.com/package/@metamask/json-rpc-engine
+
+@metamask/json-rpc-middleware-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:2023.
+https://www.npmjs.com/package/@metamask/json-rpc-middleware-stream
+
+@metamask/object-multiplex
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:2071.
+https://www.npmjs.com/package/@metamask/object-multiplex
+
+@metamask/onboarding
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2084.
+https://www.npmjs.com/package/@metamask/onboarding
+
+@metamask/providers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2093.
+https://www.npmjs.com/package/@metamask/providers
+
+@metamask/rpc-errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:1872.
+https://www.npmjs.com/package/@metamask/rpc-errors
+
+@metamask/safe-event-emitter
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:2195.
+https://www.npmjs.com/package/@metamask/safe-event-emitter
+
+@metamask/sdk
+Upstream authors (npm metadata): danfinlay <dan@danfinlay.com>, kumavis <aaron@kumavis.me>, metamaskbot <metamask-npm@consensys.net>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See mercata/ui/package-lock.json:2204.
+https://www.npmjs.com/package/@metamask/sdk
+
+@metamask/sdk-analytics
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2231.
+https://www.npmjs.com/package/@metamask/sdk-analytics
+
+@metamask/sdk-communication-layer
+Upstream authors (npm metadata): danfinlay <dan@danfinlay.com>, kumavis <aaron@kumavis.me>, mcmire <elliot.winkler@gmail.com> (and others).
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See mercata/ui/package-lock.json:2240.
+https://www.npmjs.com/package/@metamask/sdk-communication-layer
+
+@metamask/sdk-install-modal-web
+Upstream author (npm metadata): MetaMask.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See mercata/ui/package-lock.json:2299.
+https://www.npmjs.com/package/@metamask/sdk-install-modal-web
+
+@metamask/superstruct
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2330.
+https://www.npmjs.com/package/@metamask/superstruct
+
+@metamask/utils
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:1852.
+https://www.npmjs.com/package/@metamask/utils
+
+@next/env
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2374.
+https://www.npmjs.com/package/@next/env
+
+@next/swc-darwin-arm64
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2380.
+https://www.npmjs.com/package/@next/swc-darwin-arm64
+
+@next/swc-darwin-x64
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2396.
+https://www.npmjs.com/package/@next/swc-darwin-x64
+
+@next/swc-linux-arm64-gnu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2412.
+https://www.npmjs.com/package/@next/swc-linux-arm64-gnu
+
+@next/swc-linux-arm64-musl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2428.
+https://www.npmjs.com/package/@next/swc-linux-arm64-musl
+
+@next/swc-linux-x64-gnu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2444.
+https://www.npmjs.com/package/@next/swc-linux-x64-gnu
+
+@next/swc-linux-x64-musl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2460.
+https://www.npmjs.com/package/@next/swc-linux-x64-musl
+
+@next/swc-win32-arm64-msvc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2476.
+https://www.npmjs.com/package/@next/swc-win32-arm64-msvc
+
+@next/swc-win32-x64-msvc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2492.
+https://www.npmjs.com/package/@next/swc-win32-x64-msvc
+
+@noble/ciphers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:853.
+https://www.npmjs.com/package/@noble/ciphers
+
+@noble/curves
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:865.
+https://www.npmjs.com/package/@noble/curves
+
+@noble/hashes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:880.
+https://www.npmjs.com/package/@noble/hashes
+
+@nodelib/fs.scandir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2544.
+https://www.npmjs.com/package/@nodelib/fs.scandir
+
+@nodelib/fs.stat
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2557.
+https://www.npmjs.com/package/@nodelib/fs.stat
+
+@nodelib/fs.walk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2566.
+https://www.npmjs.com/package/@nodelib/fs.walk
+
+@paulmillr/qr
+Copyright information is provided by the upstream package authors.
+Licensed under the (MIT OR Apache-2.0) License (per package-lock metadata).
+See mercata/ui/package-lock.json:2579.
+https://www.npmjs.com/package/@paulmillr/qr
+
+@peculiar/asn1-schema
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:892.
+https://www.npmjs.com/package/@peculiar/asn1-schema
+
+@promster/express
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:39.
+https://www.npmjs.com/package/@promster/express
+
+@promster/metrics
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:48.
+https://www.npmjs.com/package/@promster/metrics
+
+@radix-ui/number
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2589.
+https://www.npmjs.com/package/@radix-ui/number
+
+@radix-ui/primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2595.
+https://www.npmjs.com/package/@radix-ui/primitive
+
+@radix-ui/react-accordion
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2601.
+https://www.npmjs.com/package/@radix-ui/react-accordion
+
+@radix-ui/react-alert-dialog
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2632.
+https://www.npmjs.com/package/@radix-ui/react-alert-dialog
+
+@radix-ui/react-arrow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2678.
+https://www.npmjs.com/package/@radix-ui/react-arrow
+
+@radix-ui/react-aspect-ratio
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2701.
+https://www.npmjs.com/package/@radix-ui/react-aspect-ratio
+
+@radix-ui/react-avatar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2747.
+https://www.npmjs.com/package/@radix-ui/react-avatar
+
+@radix-ui/react-checkbox
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2812.
+https://www.npmjs.com/package/@radix-ui/react-checkbox
+
+@radix-ui/react-collapsible
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2842.
+https://www.npmjs.com/package/@radix-ui/react-collapsible
+
+@radix-ui/react-collection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2872.
+https://www.npmjs.com/package/@radix-ui/react-collection
+
+@radix-ui/react-compose-refs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2916.
+https://www.npmjs.com/package/@radix-ui/react-compose-refs
+
+@radix-ui/react-context
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2774.
+https://www.npmjs.com/package/@radix-ui/react-context
+
+@radix-ui/react-context-menu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2946.
+https://www.npmjs.com/package/@radix-ui/react-context-menu
+
+@radix-ui/react-dialog
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2974.
+https://www.npmjs.com/package/@radix-ui/react-dialog
+
+@radix-ui/react-direction
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3028.
+https://www.npmjs.com/package/@radix-ui/react-direction
+
+@radix-ui/react-dismissable-layer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3043.
+https://www.npmjs.com/package/@radix-ui/react-dismissable-layer
+
+@radix-ui/react-dropdown-menu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3070.
+https://www.npmjs.com/package/@radix-ui/react-dropdown-menu
+
+@radix-ui/react-focus-guards
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3099.
+https://www.npmjs.com/package/@radix-ui/react-focus-guards
+
+@radix-ui/react-focus-scope
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3114.
+https://www.npmjs.com/package/@radix-ui/react-focus-scope
+
+@radix-ui/react-hover-card
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3139.
+https://www.npmjs.com/package/@radix-ui/react-hover-card
+
+@radix-ui/react-id
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3170.
+https://www.npmjs.com/package/@radix-ui/react-id
+
+@radix-ui/react-label
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3188.
+https://www.npmjs.com/package/@radix-ui/react-label
+
+@radix-ui/react-menu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3234.
+https://www.npmjs.com/package/@radix-ui/react-menu
+
+@radix-ui/react-menubar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3292.
+https://www.npmjs.com/package/@radix-ui/react-menubar
+
+@radix-ui/react-navigation-menu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3324.
+https://www.npmjs.com/package/@radix-ui/react-navigation-menu
+
+@radix-ui/react-popover
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3360.
+https://www.npmjs.com/package/@radix-ui/react-popover
+
+@radix-ui/react-popper
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3415.
+https://www.npmjs.com/package/@radix-ui/react-popper
+
+@radix-ui/react-portal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3447.
+https://www.npmjs.com/package/@radix-ui/react-portal
+
+@radix-ui/react-presence
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3471.
+https://www.npmjs.com/package/@radix-ui/react-presence
+
+@radix-ui/react-primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2724.
+https://www.npmjs.com/package/@radix-ui/react-primitive
+
+@radix-ui/react-progress
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3536.
+https://www.npmjs.com/package/@radix-ui/react-progress
+
+@radix-ui/react-radio-group
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3598.
+https://www.npmjs.com/package/@radix-ui/react-radio-group
+
+@radix-ui/react-roving-focus
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3630.
+https://www.npmjs.com/package/@radix-ui/react-roving-focus
+
+@radix-ui/react-scroll-area
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3661.
+https://www.npmjs.com/package/@radix-ui/react-scroll-area
+
+@radix-ui/react-select
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3692.
+https://www.npmjs.com/package/@radix-ui/react-select
+
+@radix-ui/react-separator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3753.
+https://www.npmjs.com/package/@radix-ui/react-separator
+
+@radix-ui/react-slider
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3799.
+https://www.npmjs.com/package/@radix-ui/react-slider
+
+@radix-ui/react-slot
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2660.
+https://www.npmjs.com/package/@radix-ui/react-slot
+
+@radix-ui/react-switch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3850.
+https://www.npmjs.com/package/@radix-ui/react-switch
+
+@radix-ui/react-tabs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3879.
+https://www.npmjs.com/package/@radix-ui/react-tabs
+
+@radix-ui/react-toast
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3909.
+https://www.npmjs.com/package/@radix-ui/react-toast
+
+@radix-ui/react-toggle
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3943.
+https://www.npmjs.com/package/@radix-ui/react-toggle
+
+@radix-ui/react-toggle-group
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3968.
+https://www.npmjs.com/package/@radix-ui/react-toggle-group
+
+@radix-ui/react-tooltip
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:3997.
+https://www.npmjs.com/package/@radix-ui/react-tooltip
+
+@radix-ui/react-use-callback-ref
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4049.
+https://www.npmjs.com/package/@radix-ui/react-use-callback-ref
+
+@radix-ui/react-use-controllable-state
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4064.
+https://www.npmjs.com/package/@radix-ui/react-use-controllable-state
+
+@radix-ui/react-use-effect-event
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4083.
+https://www.npmjs.com/package/@radix-ui/react-use-effect-event
+
+@radix-ui/react-use-escape-keydown
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4101.
+https://www.npmjs.com/package/@radix-ui/react-use-escape-keydown
+
+@radix-ui/react-use-is-hydrated
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4119.
+https://www.npmjs.com/package/@radix-ui/react-use-is-hydrated
+
+@radix-ui/react-use-layout-effect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4137.
+https://www.npmjs.com/package/@radix-ui/react-use-layout-effect
+
+@radix-ui/react-use-previous
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4152.
+https://www.npmjs.com/package/@radix-ui/react-use-previous
+
+@radix-ui/react-use-rect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4167.
+https://www.npmjs.com/package/@radix-ui/react-use-rect
+
+@radix-ui/react-use-size
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4185.
+https://www.npmjs.com/package/@radix-ui/react-use-size
+
+@radix-ui/react-visually-hidden
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4203.
+https://www.npmjs.com/package/@radix-ui/react-visually-hidden
+
+@radix-ui/rect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4226.
+https://www.npmjs.com/package/@radix-ui/rect
+
+@rainbow-me/rainbowkit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4232.
+https://www.npmjs.com/package/@rainbow-me/rainbowkit
+
+@rc-component/async-validator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4282.
+https://www.npmjs.com/package/@rc-component/async-validator
+
+@rc-component/color-picker
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4294.
+https://www.npmjs.com/package/@rc-component/color-picker
+
+@rc-component/context
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4322.
+https://www.npmjs.com/package/@rc-component/context
+
+@rc-component/mini-decimal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4336.
+https://www.npmjs.com/package/@rc-component/mini-decimal
+
+@rc-component/mutate-observer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4348.
+https://www.npmjs.com/package/@rc-component/mutate-observer
+
+@rc-component/portal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4366.
+https://www.npmjs.com/package/@rc-component/portal
+
+@rc-component/qrcode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4384.
+https://www.npmjs.com/package/@rc-component/qrcode
+
+@rc-component/tour
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4400.
+https://www.npmjs.com/package/@rc-component/tour
+
+@rc-component/trigger
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4420.
+https://www.npmjs.com/package/@rc-component/trigger
+
+@rc-component/util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4441.
+https://www.npmjs.com/package/@rc-component/util
+
+@remix-run/router
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4455.
+https://www.npmjs.com/package/@remix-run/router
+
+@reown/appkit
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4464.
+https://www.npmjs.com/package/@reown/appkit
+
+@reown/appkit-common
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4485.
+https://www.npmjs.com/package/@reown/appkit-common
+
+@reown/appkit-controllers
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4502.
+https://www.npmjs.com/package/@reown/appkit-controllers
+
+@reown/appkit-pay
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4967.
+https://www.npmjs.com/package/@reown/appkit-pay
+
+@reown/appkit-polyfills
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4981.
+https://www.npmjs.com/package/@reown/appkit-polyfills
+
+@reown/appkit-scaffold-ui
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4990.
+https://www.npmjs.com/package/@reown/appkit-scaffold-ui
+
+@reown/appkit-ui
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:5004.
+https://www.npmjs.com/package/@reown/appkit-ui
+
+@reown/appkit-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:5017.
+https://www.npmjs.com/package/@reown/appkit-utils
+
+@reown/appkit-wallet
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:5488.
+https://www.npmjs.com/package/@reown/appkit-wallet
+
+@safe-global/api-kit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:904.
+https://www.npmjs.com/package/@safe-global/api-kit
+
+@safe-global/protocol-kit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:916.
+https://www.npmjs.com/package/@safe-global/protocol-kit
+
+@safe-global/safe-apps-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6318.
+https://www.npmjs.com/package/@safe-global/safe-apps-provider
+
+@safe-global/safe-apps-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6328.
+https://www.npmjs.com/package/@safe-global/safe-apps-sdk
+
+@safe-global/safe-deployments
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:934.
+https://www.npmjs.com/package/@safe-global/safe-deployments
+
+@safe-global/safe-gateway-typescript-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6338.
+https://www.npmjs.com/package/@safe-global/safe-gateway-typescript-sdk
+
+@safe-global/safe-modules-deployments
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:943.
+https://www.npmjs.com/package/@safe-global/safe-modules-deployments
+
+@safe-global/types-kit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:949.
+https://www.npmjs.com/package/@safe-global/types-kit
+
+@scarf/scarf
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/backend/package-lock.json:216.
+https://www.npmjs.com/package/@scarf/scarf
+
+@scure/base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:958.
+https://www.npmjs.com/package/@scure/base
+
+@scure/bip32
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:967.
+https://www.npmjs.com/package/@scure/bip32
+
+@scure/bip39
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:981.
+https://www.npmjs.com/package/@scure/bip39
+
+@sendgrid/client
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:994.
+https://www.npmjs.com/package/@sendgrid/client
+
+@sendgrid/helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1007.
+https://www.npmjs.com/package/@sendgrid/helpers
+
+@sendgrid/mail
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1019.
+https://www.npmjs.com/package/@sendgrid/mail
+
+@sideway/address
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1032.
+https://www.npmjs.com/package/@sideway/address
+
+@sideway/formula
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1047.
+https://www.npmjs.com/package/@sideway/formula
+
+@sideway/pinpoint
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1053.
+https://www.npmjs.com/package/@sideway/pinpoint
+
+@slack/logger
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:721.
+https://www.npmjs.com/package/@slack/logger
+
+@slack/types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:734.
+https://www.npmjs.com/package/@slack/types
+
+@slack/web-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:744.
+https://www.npmjs.com/package/@slack/web-api
+
+@smithy/abort-controller
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:768.
+https://www.npmjs.com/package/@smithy/abort-controller
+
+@smithy/config-resolver
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:781.
+https://www.npmjs.com/package/@smithy/config-resolver
+
+@smithy/core
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:798.
+https://www.npmjs.com/package/@smithy/core
+
+@smithy/credential-provider-imds
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:819.
+https://www.npmjs.com/package/@smithy/credential-provider-imds
+
+@smithy/fetch-http-handler
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:835.
+https://www.npmjs.com/package/@smithy/fetch-http-handler
+
+@smithy/hash-node
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:851.
+https://www.npmjs.com/package/@smithy/hash-node
+
+@smithy/invalid-dependency
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:866.
+https://www.npmjs.com/package/@smithy/invalid-dependency
+
+@smithy/is-array-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:45.
+https://www.npmjs.com/package/@smithy/is-array-buffer
+
+@smithy/middleware-compression
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:891.
+https://www.npmjs.com/package/@smithy/middleware-compression
+
+@smithy/middleware-content-length
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:912.
+https://www.npmjs.com/package/@smithy/middleware-content-length
+
+@smithy/middleware-endpoint
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:926.
+https://www.npmjs.com/package/@smithy/middleware-endpoint
+
+@smithy/middleware-retry
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:945.
+https://www.npmjs.com/package/@smithy/middleware-retry
+
+@smithy/middleware-serde
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:965.
+https://www.npmjs.com/package/@smithy/middleware-serde
+
+@smithy/middleware-stack
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:979.
+https://www.npmjs.com/package/@smithy/middleware-stack
+
+@smithy/node-config-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:992.
+https://www.npmjs.com/package/@smithy/node-config-provider
+
+@smithy/node-http-handler
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1007.
+https://www.npmjs.com/package/@smithy/node-http-handler
+
+@smithy/property-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1023.
+https://www.npmjs.com/package/@smithy/property-provider
+
+@smithy/protocol-http
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1036.
+https://www.npmjs.com/package/@smithy/protocol-http
+
+@smithy/querystring-builder
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1049.
+https://www.npmjs.com/package/@smithy/querystring-builder
+
+@smithy/querystring-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1063.
+https://www.npmjs.com/package/@smithy/querystring-parser
+
+@smithy/service-error-classification
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1076.
+https://www.npmjs.com/package/@smithy/service-error-classification
+
+@smithy/shared-ini-file-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1088.
+https://www.npmjs.com/package/@smithy/shared-ini-file-loader
+
+@smithy/signature-v4
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1101.
+https://www.npmjs.com/package/@smithy/signature-v4
+
+@smithy/smithy-client
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1120.
+https://www.npmjs.com/package/@smithy/smithy-client
+
+@smithy/types
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1138.
+https://www.npmjs.com/package/@smithy/types
+
+@smithy/url-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1150.
+https://www.npmjs.com/package/@smithy/url-parser
+
+@smithy/util-base64
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1164.
+https://www.npmjs.com/package/@smithy/util-base64
+
+@smithy/util-body-length-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1178.
+https://www.npmjs.com/package/@smithy/util-body-length-browser
+
+@smithy/util-body-length-node
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1190.
+https://www.npmjs.com/package/@smithy/util-body-length-node
+
+@smithy/util-buffer-from
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:57.
+https://www.npmjs.com/package/@smithy/util-buffer-from
+
+@smithy/util-config-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1215.
+https://www.npmjs.com/package/@smithy/util-config-provider
+
+@smithy/util-defaults-mode-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1227.
+https://www.npmjs.com/package/@smithy/util-defaults-mode-browser
+
+@smithy/util-defaults-mode-node
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1242.
+https://www.npmjs.com/package/@smithy/util-defaults-mode-node
+
+@smithy/util-endpoints
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1260.
+https://www.npmjs.com/package/@smithy/util-endpoints
+
+@smithy/util-hex-encoding
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1274.
+https://www.npmjs.com/package/@smithy/util-hex-encoding
+
+@smithy/util-middleware
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1286.
+https://www.npmjs.com/package/@smithy/util-middleware
+
+@smithy/util-retry
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1299.
+https://www.npmjs.com/package/@smithy/util-retry
+
+@smithy/util-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1313.
+https://www.npmjs.com/package/@smithy/util-stream
+
+@smithy/util-uri-escape
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1332.
+https://www.npmjs.com/package/@smithy/util-uri-escape
+
+@smithy/util-utf8
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:70.
+https://www.npmjs.com/package/@smithy/util-utf8
+
+@smithy/util-waiter
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1357.
+https://www.npmjs.com/package/@smithy/util-waiter
+
+@smithy/uuid
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1371.
+https://www.npmjs.com/package/@smithy/uuid
+
+@socket.io/component-emitter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6422.
+https://www.npmjs.com/package/@socket.io/component-emitter
+
+@solana-program/system
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:6428.
+https://www.npmjs.com/package/@solana-program/system
+
+@solana-program/token
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:6437.
+https://www.npmjs.com/package/@solana-program/token
+
+@solana/accounts
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6446.
+https://www.npmjs.com/package/@solana/accounts
+
+@solana/addresses
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6466.
+https://www.npmjs.com/package/@solana/addresses
+
+@solana/assertions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6485.
+https://www.npmjs.com/package/@solana/assertions
+
+@solana/buffer-layout
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1059.
+https://www.npmjs.com/package/@solana/buffer-layout
+
+@solana/codecs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6512.
+https://www.npmjs.com/package/@solana/codecs
+
+@solana/codecs-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1071.
+https://www.npmjs.com/package/@solana/codecs-core
+
+@solana/codecs-data-structures
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6546.
+https://www.npmjs.com/package/@solana/codecs-data-structures
+
+@solana/codecs-numbers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1086.
+https://www.npmjs.com/package/@solana/codecs-numbers
+
+@solana/codecs-strings
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6579.
+https://www.npmjs.com/package/@solana/codecs-strings
+
+@solana/errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1102.
+https://www.npmjs.com/package/@solana/errors
+
+@solana/fast-stable-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6642.
+https://www.npmjs.com/package/@solana/fast-stable-stringify
+
+@solana/functional
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6654.
+https://www.npmjs.com/package/@solana/functional
+
+@solana/instruction-plans
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6666.
+https://www.npmjs.com/package/@solana/instruction-plans
+
+@solana/instructions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6686.
+https://www.npmjs.com/package/@solana/instructions
+
+@solana/keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6702.
+https://www.npmjs.com/package/@solana/keys
+
+@solana/kit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6721.
+https://www.npmjs.com/package/@solana/kit
+
+@solana/nominal-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6757.
+https://www.npmjs.com/package/@solana/nominal-types
+
+@solana/offchain-messages
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6769.
+https://www.npmjs.com/package/@solana/offchain-messages
+
+@solana/options
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6791.
+https://www.npmjs.com/package/@solana/options
+
+@solana/plugin-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6810.
+https://www.npmjs.com/package/@solana/plugin-core
+
+@solana/programs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6822.
+https://www.npmjs.com/package/@solana/programs
+
+@solana/promises
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6838.
+https://www.npmjs.com/package/@solana/promises
+
+@solana/rpc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6850.
+https://www.npmjs.com/package/@solana/rpc
+
+@solana/rpc-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6873.
+https://www.npmjs.com/package/@solana/rpc-api
+
+@solana/rpc-parsed-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6898.
+https://www.npmjs.com/package/@solana/rpc-parsed-types
+
+@solana/rpc-spec
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6910.
+https://www.npmjs.com/package/@solana/rpc-spec
+
+@solana/rpc-spec-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6926.
+https://www.npmjs.com/package/@solana/rpc-spec-types
+
+@solana/rpc-subscriptions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6938.
+https://www.npmjs.com/package/@solana/rpc-subscriptions
+
+@solana/rpc-subscriptions-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6963.
+https://www.npmjs.com/package/@solana/rpc-subscriptions-api
+
+@solana/rpc-subscriptions-channel-websocket
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:6984.
+https://www.npmjs.com/package/@solana/rpc-subscriptions-channel-websocket
+
+@solana/rpc-subscriptions-spec
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7024.
+https://www.npmjs.com/package/@solana/rpc-subscriptions-spec
+
+@solana/rpc-transformers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7042.
+https://www.npmjs.com/package/@solana/rpc-transformers
+
+@solana/rpc-transport-http
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7061.
+https://www.npmjs.com/package/@solana/rpc-transport-http
+
+@solana/rpc-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7085.
+https://www.npmjs.com/package/@solana/rpc-types
+
+@solana/signers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7105.
+https://www.npmjs.com/package/@solana/signers
+
+@solana/subscribable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7128.
+https://www.npmjs.com/package/@solana/subscribable
+
+@solana/sysvars
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7143.
+https://www.npmjs.com/package/@solana/sysvars
+
+@solana/transaction-confirmation
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7161.
+https://www.npmjs.com/package/@solana/transaction-confirmation
+
+@solana/transaction-messages
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7185.
+https://www.npmjs.com/package/@solana/transaction-messages
+
+@solana/transactions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7208.
+https://www.npmjs.com/package/@solana/transactions
+
+@solana/web3.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1121.
+https://www.npmjs.com/package/@solana/web3.js
+
+@swc/helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1144.
+https://www.npmjs.com/package/@swc/helpers
+
+@tanstack/query-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7603.
+https://www.npmjs.com/package/@tanstack/query-core
+
+@tanstack/react-query
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7613.
+https://www.npmjs.com/package/@tanstack/react-query
+
+@timer/detect-port
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:133.
+https://www.npmjs.com/package/@timer/detect-port
+
+@types/body-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1191.
+https://www.npmjs.com/package/@types/body-parser
+
+@types/connect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1201.
+https://www.npmjs.com/package/@types/connect
+
+@types/d3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:154.
+https://www.npmjs.com/package/@types/d3
+
+@types/d3-array
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7638.
+https://www.npmjs.com/package/@types/d3-array
+
+@types/d3-axis
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:160.
+https://www.npmjs.com/package/@types/d3-axis
+
+@types/d3-brush
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:161.
+https://www.npmjs.com/package/@types/d3-brush
+
+@types/d3-chord
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:162.
+https://www.npmjs.com/package/@types/d3-chord
+
+@types/d3-collection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:163.
+https://www.npmjs.com/package/@types/d3-collection
+
+@types/d3-color
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7644.
+https://www.npmjs.com/package/@types/d3-color
+
+@types/d3-dispatch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:165.
+https://www.npmjs.com/package/@types/d3-dispatch
+
+@types/d3-drag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:166.
+https://www.npmjs.com/package/@types/d3-drag
+
+@types/d3-dsv
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:167.
+https://www.npmjs.com/package/@types/d3-dsv
+
+@types/d3-ease
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7650.
+https://www.npmjs.com/package/@types/d3-ease
+
+@types/d3-force
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:169.
+https://www.npmjs.com/package/@types/d3-force
+
+@types/d3-format
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:170.
+https://www.npmjs.com/package/@types/d3-format
+
+@types/d3-geo
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:171.
+https://www.npmjs.com/package/@types/d3-geo
+
+@types/d3-hierarchy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:172.
+https://www.npmjs.com/package/@types/d3-hierarchy
+
+@types/d3-interpolate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7656.
+https://www.npmjs.com/package/@types/d3-interpolate
+
+@types/d3-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7665.
+https://www.npmjs.com/package/@types/d3-path
+
+@types/d3-polygon
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:175.
+https://www.npmjs.com/package/@types/d3-polygon
+
+@types/d3-quadtree
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:176.
+https://www.npmjs.com/package/@types/d3-quadtree
+
+@types/d3-queue
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:177.
+https://www.npmjs.com/package/@types/d3-queue
+
+@types/d3-random
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:178.
+https://www.npmjs.com/package/@types/d3-random
+
+@types/d3-request
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:179.
+https://www.npmjs.com/package/@types/d3-request
+
+@types/d3-scale
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7671.
+https://www.npmjs.com/package/@types/d3-scale
+
+@types/d3-selection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:181.
+https://www.npmjs.com/package/@types/d3-selection
+
+@types/d3-shape
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7680.
+https://www.npmjs.com/package/@types/d3-shape
+
+@types/d3-time
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7689.
+https://www.npmjs.com/package/@types/d3-time
+
+@types/d3-time-format
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:184.
+https://www.npmjs.com/package/@types/d3-time-format
+
+@types/d3-timer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7695.
+https://www.npmjs.com/package/@types/d3-timer
+
+@types/d3-transition
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:186.
+https://www.npmjs.com/package/@types/d3-transition
+
+@types/d3-voronoi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:187.
+https://www.npmjs.com/package/@types/d3-voronoi
+
+@types/d3-zoom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:188.
+https://www.npmjs.com/package/@types/d3-zoom
+
+@types/debug
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7701.
+https://www.npmjs.com/package/@types/debug
+
+@types/dom4
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:26.
+https://www.npmjs.com/package/@types/dom4
+
+@types/express
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1227.
+https://www.npmjs.com/package/@types/express
+
+@types/express-serve-static-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1239.
+https://www.npmjs.com/package/@types/express-serve-static-core
+
+@types/geojson
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:265.
+https://www.npmjs.com/package/@types/geojson
+
+@types/http-errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1251.
+https://www.npmjs.com/package/@types/http-errors
+
+@types/json-bigint
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:321.
+https://www.npmjs.com/package/@types/json-bigint
+
+@types/json-schema
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:327.
+https://www.npmjs.com/package/@types/json-schema
+
+@types/jsonwebtoken
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1257.
+https://www.npmjs.com/package/@types/jsonwebtoken
+
+@types/lodash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7724.
+https://www.npmjs.com/package/@types/lodash
+
+@types/mime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1284.
+https://www.npmjs.com/package/@types/mime
+
+@types/ms
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1290.
+https://www.npmjs.com/package/@types/ms
+
+@types/node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:81.
+https://www.npmjs.com/package/@types/node
+
+@types/prop-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7755.
+https://www.npmjs.com/package/@types/prop-types
+
+@types/qs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1326.
+https://www.npmjs.com/package/@types/qs
+
+@types/range-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1332.
+https://www.npmjs.com/package/@types/range-parser
+
+@types/react
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7762.
+https://www.npmjs.com/package/@types/react
+
+@types/react-dom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7773.
+https://www.npmjs.com/package/@types/react-dom
+
+@types/retry
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1488.
+https://www.npmjs.com/package/@types/retry
+
+@types/send
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1348.
+https://www.npmjs.com/package/@types/send
+
+@types/serve-static
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1368.
+https://www.npmjs.com/package/@types/serve-static
+
+@types/tether
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:27.
+https://www.npmjs.com/package/@types/tether
+
+@types/triple-beam
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:419.
+https://www.npmjs.com/package/@types/triple-beam
+
+@types/trusted-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:7783.
+https://www.npmjs.com/package/@types/trusted-types
+
+@types/uuid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1393.
+https://www.npmjs.com/package/@types/uuid
+
+@types/ws
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1399.
+https://www.npmjs.com/package/@types/ws
+
+@vanilla-extract/css
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8060.
+https://www.npmjs.com/package/@vanilla-extract/css
+
+@vanilla-extract/dynamic
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8080.
+https://www.npmjs.com/package/@vanilla-extract/dynamic
+
+@vanilla-extract/private
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8089.
+https://www.npmjs.com/package/@vanilla-extract/private
+
+@vanilla-extract/sprinkles
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8095.
+https://www.npmjs.com/package/@vanilla-extract/sprinkles
+
+@wagmi/connectors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8118.
+https://www.npmjs.com/package/@wagmi/connectors
+
+@wagmi/core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8281.
+https://www.npmjs.com/package/@wagmi/core
+
+@walletconnect/core
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4581.
+https://www.npmjs.com/package/@walletconnect/core
+
+@walletconnect/environment
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8514.
+https://www.npmjs.com/package/@walletconnect/environment
+
+@walletconnect/ethereum-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:8529.
+https://www.npmjs.com/package/@walletconnect/ethereum-provider
+
+@walletconnect/events
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8692.
+https://www.npmjs.com/package/@walletconnect/events
+
+@walletconnect/heartbeat
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8708.
+https://www.npmjs.com/package/@walletconnect/heartbeat
+
+@walletconnect/jsonrpc-http-connection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8719.
+https://www.npmjs.com/package/@walletconnect/jsonrpc-http-connection
+
+@walletconnect/jsonrpc-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8740.
+https://www.npmjs.com/package/@walletconnect/jsonrpc-provider
+
+@walletconnect/jsonrpc-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8751.
+https://www.npmjs.com/package/@walletconnect/jsonrpc-types
+
+@walletconnect/jsonrpc-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8761.
+https://www.npmjs.com/package/@walletconnect/jsonrpc-utils
+
+@walletconnect/jsonrpc-ws-connection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8778.
+https://www.npmjs.com/package/@walletconnect/jsonrpc-ws-connection
+
+@walletconnect/keyvaluestorage
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4609.
+https://www.npmjs.com/package/@walletconnect/keyvaluestorage
+
+@walletconnect/logger
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8811.
+https://www.npmjs.com/package/@walletconnect/logger
+
+@walletconnect/relay-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8821.
+https://www.npmjs.com/package/@walletconnect/relay-api
+
+@walletconnect/relay-auth
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8830.
+https://www.npmjs.com/package/@walletconnect/relay-auth
+
+@walletconnect/safe-json
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8870.
+https://www.npmjs.com/package/@walletconnect/safe-json
+
+@walletconnect/sign-client
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4628.
+https://www.npmjs.com/package/@walletconnect/sign-client
+
+@walletconnect/time
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8903.
+https://www.npmjs.com/package/@walletconnect/time
+
+@walletconnect/types
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4646.
+https://www.npmjs.com/package/@walletconnect/types
+
+@walletconnect/universal-provider
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4660.
+https://www.npmjs.com/package/@walletconnect/universal-provider
+
+@walletconnect/utils
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:4681.
+https://www.npmjs.com/package/@walletconnect/utils
+
+@walletconnect/window-getters
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9610.
+https://www.npmjs.com/package/@walletconnect/window-getters
+
+@walletconnect/window-metadata
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9625.
+https://www.npmjs.com/package/@walletconnect/window-metadata
+
+abab
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:393.
+https://www.npmjs.com/package/abab
+
+abbrev
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:86.
+https://www.npmjs.com/package/abbrev
+
+abitype
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1408.
+https://www.npmjs.com/package/abitype
+
+accepts
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:91.
+https://www.npmjs.com/package/accepts
+
+acorn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:426.
+https://www.npmjs.com/package/acorn
+
+acorn-dynamic-import
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:432.
+https://www.npmjs.com/package/acorn-dynamic-import
+
+acorn-globals
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:441.
+https://www.npmjs.com/package/acorn-globals
+
+acorn-jsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:450.
+https://www.npmjs.com/package/acorn-jsx
+
+address
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:139.
+https://www.npmjs.com/package/address
+
+aes-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1468.
+https://www.npmjs.com/package/aes-js
 
 aeson
 Copyright (c) 2011, MailRank, Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/aeson.
+https://hackage.haskell.org/package/aeson
 
 aeson-casing
 Copyright (c) 2015 Andrew Rademacher
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/aeson-casing.
+https://hackage.haskell.org/package/aeson-casing
 
 aeson-extra
 Copyright (c) 2015, Oleg Grenrus
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/aeson-extra.
+https://hackage.haskell.org/package/aeson-extra
 
 aeson-pretty
 Copyright (c)2011, Falko Peters
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/aeson-pretty.
+https://hackage.haskell.org/package/aeson-pretty
+
+after
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:103.
+https://www.npmjs.com/package/after
+
+agentkeepalive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1474.
+https://www.npmjs.com/package/agentkeepalive
+
+ajv
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:108.
+https://www.npmjs.com/package/ajv
+
+ajv-keywords
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:490.
+https://www.npmjs.com/package/ajv-keywords
+
+alchemy-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1486.
+https://www.npmjs.com/package/alchemy-sdk
+
+align-text
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:496.
+https://www.npmjs.com/package/align-text
+
+alphanum-sort
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:518.
+https://www.npmjs.com/package/alphanum-sort
+
+amdefine
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause OR MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:524.
+https://www.npmjs.com/package/amdefine
+
+anser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:530.
+https://www.npmjs.com/package/anser
+
+ansi-align
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See smd-ui/package-lock.json:536.
+https://www.npmjs.com/package/ansi-align
+
+ansi-escapes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:545.
+https://www.npmjs.com/package/ansi-escapes
+
+ansi-html
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:551.
+https://www.npmjs.com/package/ansi-html
+
+ansi-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:119.
+https://www.npmjs.com/package/ansi-regex
+
+ansi-styles
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:127.
+https://www.npmjs.com/package/ansi-styles
 
 ansi-wl-pprint
 Copyright 2008, Daan Leijen and Max Bolingbroke. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/ansi-wl-pprint.
+https://hackage.haskell.org/package/ansi-wl-pprint
+
+antd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9744.
+https://www.npmjs.com/package/antd
+
+any-promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:138.
+https://www.npmjs.com/package/any-promise
+
+anymatch
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:9856.
+https://www.npmjs.com/package/anymatch
+
+append-transform
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:579.
+https://www.npmjs.com/package/append-transform
+
+aproba
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1312.
+https://www.npmjs.com/package/aproba
+
+are-we-there-yet
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1318.
+https://www.npmjs.com/package/are-we-there-yet
+
+arg
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9869.
+https://www.npmjs.com/package/arg
+
+argparse
+Copyright information is provided by the upstream package authors.
+Licensed under the Python-2.0 License (per package-lock metadata).
+See mercata/backend/package-lock.json:496.
+https://www.npmjs.com/package/argparse
+
+aria-hidden
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9882.
+https://www.npmjs.com/package/aria-hidden
+
+aria-query
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:597.
+https://www.npmjs.com/package/aria-query
 
 arithmoi
 Copyright (c) 2011 Daniel Fischer, 2016-2017 Andrew Lelechenko, Carter Schonwald, Google Inc.
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/arithmoi.
+https://hackage.haskell.org/package/arithmoi
+
+arr-diff
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:606.
+https://www.npmjs.com/package/arr-diff
+
+arr-flatten
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:612.
+https://www.npmjs.com/package/arr-flatten
+
+arr-union
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:618.
+https://www.npmjs.com/package/arr-union
 
 array
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/array.
+https://hackage.haskell.org/package/array
+
+array-equal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:624.
+https://www.npmjs.com/package/array-equal
+
+array-filter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:143.
+https://www.npmjs.com/package/array-filter
+
+array-find-index
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:636.
+https://www.npmjs.com/package/array-find-index
+
+array-flatten
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:148.
+https://www.npmjs.com/package/array-flatten
+
+array-includes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:648.
+https://www.npmjs.com/package/array-includes
+
+array-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:153.
+https://www.npmjs.com/package/array-map
+
+array-reduce
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:158.
+https://www.npmjs.com/package/array-reduce
+
+array-union
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:787.
+https://www.npmjs.com/package/array-union
+
+array-uniq
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:793.
+https://www.npmjs.com/package/array-uniq
+
+array-unique
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:802.
+https://www.npmjs.com/package/array-unique
+
+arraybuffer.slice
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:163.
+https://www.npmjs.com/package/arraybuffer.slice
+
+arrify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:813.
+https://www.npmjs.com/package/arrify
+
+asap
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:168.
+https://www.npmjs.com/package/asap
+
+asn1
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:173.
+https://www.npmjs.com/package/asn1
+
+asn1.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1536.
+https://www.npmjs.com/package/asn1.js
+
+asn1js
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1554.
+https://www.npmjs.com/package/asn1js
+
+assert
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:850.
+https://www.npmjs.com/package/assert
+
+assert-plus
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:178.
+https://www.npmjs.com/package/assert-plus
+
+assertion-error
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:186.
+https://www.npmjs.com/package/assertion-error
+
+assign-symbols
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:883.
+https://www.npmjs.com/package/assign-symbols
+
+ast-types-flow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:603.
+https://www.npmjs.com/package/ast-types-flow
+
+astral-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:895.
+https://www.npmjs.com/package/astral-regex
+
+async
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:194.
+https://www.npmjs.com/package/async
+
+async-each
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:910.
+https://www.npmjs.com/package/async-each
+
+async-limiter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:199.
+https://www.npmjs.com/package/async-limiter
+
+async-mutex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9894.
+https://www.npmjs.com/package/async-mutex
+
+asynckit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:204.
+https://www.npmjs.com/package/asynckit
+
+atob
+Copyright information is provided by the upstream package authors.
+Licensed under the (MIT OR Apache-2.0) License (per npm registry metadata).
+See smd-ui/package-lock.json:927.
+https://www.npmjs.com/package/atob
+
+atomic-sleep
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9909.
+https://www.npmjs.com/package/atomic-sleep
+
+attr-accept
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:933.
+https://www.npmjs.com/package/attr-accept
+
+autoprefixer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:948.
+https://www.npmjs.com/package/autoprefixer
+
+available-typed-arrays
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:9955.
+https://www.npmjs.com/package/available-typed-arrays
+
+aws-sign2
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See apex/api/package-lock.json:209.
+https://www.npmjs.com/package/aws-sign2
+
+aws4
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:217.
+https://www.npmjs.com/package/aws4
+
+axios
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:222.
+https://www.npmjs.com/package/axios
+
+axios-retry
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:9981.
+https://www.npmjs.com/package/axios-retry
+
+axobject-query
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:974.
+https://www.npmjs.com/package/axobject-query
+
+babel-code-frame
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:983.
+https://www.npmjs.com/package/babel-code-frame
+
+babel-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:994.
+https://www.npmjs.com/package/babel-core
+
+babel-eslint
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1032.
+https://www.npmjs.com/package/babel-eslint
+
+babel-generator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1001.
+https://www.npmjs.com/package/babel-generator
+
+babel-helper-bindify-decorators
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1060.
+https://www.npmjs.com/package/babel-helper-bindify-decorators
+
+babel-helper-builder-binary-assignment-operator-visitor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1071.
+https://www.npmjs.com/package/babel-helper-builder-binary-assignment-operator-visitor
+
+babel-helper-builder-react-jsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1082.
+https://www.npmjs.com/package/babel-helper-builder-react-jsx
+
+babel-helper-call-delegate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1093.
+https://www.npmjs.com/package/babel-helper-call-delegate
+
+babel-helper-define-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1105.
+https://www.npmjs.com/package/babel-helper-define-map
+
+babel-helper-explode-assignable-expression
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1077.
+https://www.npmjs.com/package/babel-helper-explode-assignable-expression
+
+babel-helper-explode-class
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1128.
+https://www.npmjs.com/package/babel-helper-explode-class
+
+babel-helper-function-name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1111.
+https://www.npmjs.com/package/babel-helper-function-name
+
+babel-helper-get-function-arity
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1146.
+https://www.npmjs.com/package/babel-helper-get-function-arity
+
+babel-helper-hoist-variables
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1099.
+https://www.npmjs.com/package/babel-helper-hoist-variables
+
+babel-helper-optimise-call-expression
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1173.
+https://www.npmjs.com/package/babel-helper-optimise-call-expression
+
+babel-helper-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1183.
+https://www.npmjs.com/package/babel-helper-regex
+
+babel-helper-remap-async-to-generator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1194.
+https://www.npmjs.com/package/babel-helper-remap-async-to-generator
+
+babel-helper-replace-supers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1207.
+https://www.npmjs.com/package/babel-helper-replace-supers
+
+babel-helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1002.
+https://www.npmjs.com/package/babel-helpers
+
+babel-jest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1231.
+https://www.npmjs.com/package/babel-jest
+
+babel-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1241.
+https://www.npmjs.com/package/babel-loader
+
+babel-messages
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1003.
+https://www.npmjs.com/package/babel-messages
+
+babel-plugin-check-es2015-constants
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1261.
+https://www.npmjs.com/package/babel-plugin-check-es2015-constants
+
+babel-plugin-dynamic-import-node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1270.
+https://www.npmjs.com/package/babel-plugin-dynamic-import-node
+
+babel-plugin-istanbul
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:1237.
+https://www.npmjs.com/package/babel-plugin-istanbul
+
+babel-plugin-jest-hoist
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1293.
+https://www.npmjs.com/package/babel-plugin-jest-hoist
+
+babel-plugin-syntax-async-functions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1299.
+https://www.npmjs.com/package/babel-plugin-syntax-async-functions
+
+babel-plugin-syntax-async-generators
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1305.
+https://www.npmjs.com/package/babel-plugin-syntax-async-generators
+
+babel-plugin-syntax-class-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1311.
+https://www.npmjs.com/package/babel-plugin-syntax-class-properties
+
+babel-plugin-syntax-decorators
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1317.
+https://www.npmjs.com/package/babel-plugin-syntax-decorators
+
+babel-plugin-syntax-dynamic-import
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1276.
+https://www.npmjs.com/package/babel-plugin-syntax-dynamic-import
+
+babel-plugin-syntax-exponentiation-operator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1329.
+https://www.npmjs.com/package/babel-plugin-syntax-exponentiation-operator
+
+babel-plugin-syntax-flow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1335.
+https://www.npmjs.com/package/babel-plugin-syntax-flow
+
+babel-plugin-syntax-jsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1341.
+https://www.npmjs.com/package/babel-plugin-syntax-jsx
+
+babel-plugin-syntax-object-rest-spread
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1287.
+https://www.npmjs.com/package/babel-plugin-syntax-object-rest-spread
+
+babel-plugin-syntax-trailing-function-commas
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1353.
+https://www.npmjs.com/package/babel-plugin-syntax-trailing-function-commas
+
+babel-plugin-transform-async-generator-functions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1359.
+https://www.npmjs.com/package/babel-plugin-transform-async-generator-functions
+
+babel-plugin-transform-async-to-generator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1370.
+https://www.npmjs.com/package/babel-plugin-transform-async-to-generator
+
+babel-plugin-transform-class-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1381.
+https://www.npmjs.com/package/babel-plugin-transform-class-properties
+
+babel-plugin-transform-decorators
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1393.
+https://www.npmjs.com/package/babel-plugin-transform-decorators
+
+babel-plugin-transform-es2015-arrow-functions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1406.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-arrow-functions
+
+babel-plugin-transform-es2015-block-scoped-functions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1415.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-block-scoped-functions
+
+babel-plugin-transform-es2015-block-scoping
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1424.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-block-scoping
+
+babel-plugin-transform-es2015-classes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1437.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-classes
+
+babel-plugin-transform-es2015-computed-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1454.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-computed-properties
+
+babel-plugin-transform-es2015-destructuring
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1464.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-destructuring
+
+babel-plugin-transform-es2015-duplicate-keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1473.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-duplicate-keys
+
+babel-plugin-transform-es2015-for-of
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1483.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-for-of
+
+babel-plugin-transform-es2015-function-name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1492.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-function-name
+
+babel-plugin-transform-es2015-literals
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1503.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-literals
+
+babel-plugin-transform-es2015-modules-amd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1512.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-amd
+
+babel-plugin-transform-es2015-modules-commonjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1518.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-commonjs
+
+babel-plugin-transform-es2015-modules-systemjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1535.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-systemjs
+
+babel-plugin-transform-es2015-modules-umd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1546.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-umd
+
+babel-plugin-transform-es2015-object-super
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1557.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-object-super
+
+babel-plugin-transform-es2015-parameters
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1567.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-parameters
+
+babel-plugin-transform-es2015-shorthand-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1581.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-shorthand-properties
+
+babel-plugin-transform-es2015-spread
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1591.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-spread
+
+babel-plugin-transform-es2015-sticky-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1600.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-sticky-regex
+
+babel-plugin-transform-es2015-template-literals
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1611.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-template-literals
+
+babel-plugin-transform-es2015-typeof-symbol
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1620.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-typeof-symbol
+
+babel-plugin-transform-es2015-unicode-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1629.
+https://www.npmjs.com/package/babel-plugin-transform-es2015-unicode-regex
+
+babel-plugin-transform-exponentiation-operator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1640.
+https://www.npmjs.com/package/babel-plugin-transform-exponentiation-operator
+
+babel-plugin-transform-flow-strip-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1651.
+https://www.npmjs.com/package/babel-plugin-transform-flow-strip-types
+
+babel-plugin-transform-object-rest-spread
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1661.
+https://www.npmjs.com/package/babel-plugin-transform-object-rest-spread
+
+babel-plugin-transform-react-constant-elements
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1671.
+https://www.npmjs.com/package/babel-plugin-transform-react-constant-elements
+
+babel-plugin-transform-react-display-name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1680.
+https://www.npmjs.com/package/babel-plugin-transform-react-display-name
+
+babel-plugin-transform-react-jsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1689.
+https://www.npmjs.com/package/babel-plugin-transform-react-jsx
+
+babel-plugin-transform-react-jsx-self
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1700.
+https://www.npmjs.com/package/babel-plugin-transform-react-jsx-self
+
+babel-plugin-transform-react-jsx-source
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1710.
+https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source
+
+babel-plugin-transform-regenerator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1720.
+https://www.npmjs.com/package/babel-plugin-transform-regenerator
+
+babel-plugin-transform-runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1729.
+https://www.npmjs.com/package/babel-plugin-transform-runtime
+
+babel-plugin-transform-strict-mode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1529.
+https://www.npmjs.com/package/babel-plugin-transform-strict-mode
+
+babel-preset-env
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1748.
+https://www.npmjs.com/package/babel-preset-env
+
+babel-preset-es2015
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1786.
+https://www.npmjs.com/package/babel-preset-es2015
+
+babel-preset-flow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1818.
+https://www.npmjs.com/package/babel-preset-flow
+
+babel-preset-jest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1238.
+https://www.npmjs.com/package/babel-preset-jest
+
+babel-preset-react
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1837.
+https://www.npmjs.com/package/babel-preset-react
+
+babel-preset-react-app
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1851.
+https://www.npmjs.com/package/babel-preset-react-app
+
+babel-preset-stage-2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1872.
+https://www.npmjs.com/package/babel-preset-stage-2
+
+babel-preset-stage-3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1881.
+https://www.npmjs.com/package/babel-preset-stage-3
+
+babel-register
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1004.
+https://www.npmjs.com/package/babel-register
+
+babel-runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:230.
+https://www.npmjs.com/package/babel-runtime
+
+babel-template
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1006.
+https://www.npmjs.com/package/babel-template
+
+babel-traverse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1007.
+https://www.npmjs.com/package/babel-traverse
+
+babel-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1008.
+https://www.npmjs.com/package/babel-types
+
+babylon
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1009.
+https://www.npmjs.com/package/babylon
+
+backo2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:239.
+https://www.npmjs.com/package/backo2
+
+balanced-match
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:244.
+https://www.npmjs.com/package/balanced-match
+
+base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2008.
+https://www.npmjs.com/package/base
+
+base-x
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1593.
+https://www.npmjs.com/package/base-x
 
 base16-bytestring
 Copyright (c) 2011 MailRank, Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/base16-bytestring.
+https://hackage.haskell.org/package/base16-bytestring
+
+base64-arraybuffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:249.
+https://www.npmjs.com/package/base64-arraybuffer
+
+base64-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1602.
+https://www.npmjs.com/package/base64-js
+
+base64id
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:257.
+https://www.npmjs.com/package/base64id
+
+basic-auth
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:265.
+https://www.npmjs.com/package/basic-auth
+
+batch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2074.
+https://www.npmjs.com/package/batch
 
 bcrypt
 Copyright (c) 2010 Nicholas Campbell
 Licensed under the MIT License.
 See apex/api/licenses/bcrypt.
+https://www.npmjs.com/package/bcrypt
+
+bcrypt-pbkdf
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:276.
+https://www.npmjs.com/package/bcrypt-pbkdf
+
+bech32
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1622.
+https://www.npmjs.com/package/bech32
+
+better-assert
+Upstream authors (npm metadata): TJ Holowaychuk <tj@vision-media.ca>, TonyHe <coolhzb@163.com>, ForbesLindesay.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:285.
+https://www.npmjs.com/package/better-assert
 
 big-integer
 In jurisdictions that recognize copyright laws, the author or authors
 Licensed under terms in the referenced file.
 See apex/api/licenses/big-integer.
+https://www.npmjs.com/package/big-integer
+
+big.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10039.
+https://www.npmjs.com/package/big.js
 
 bignumber.js
 Copyright (c) 2018 Michael Mclaughlin
 Licensed under the MIT License.
 See smd-ui/licenses/bignumber.js.
+https://www.npmjs.com/package/bignumber.js
 
 bimap
 Copyright Stuart Cook and contributors 2008
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/bimap.
+https://hackage.haskell.org/package/bimap
 
 binary
 Copyright (c) Lennart Kolmodin
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/binary.
+https://hackage.haskell.org/package/binary
+
+binary-extensions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10061.
+https://www.npmjs.com/package/binary-extensions
+
+bindings
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2110.
+https://www.npmjs.com/package/bindings
+
+bintrees
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:304.
+https://www.npmjs.com/package/bintrees
 
 blaze-builder
 Copyright Jasper Van der Jeugt 2010, Simon Meier 2010 & 2011
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/blaze-builder.
+https://hackage.haskell.org/package/blaze-builder
 
 blaze-html
 Copyright Jasper Van der Jeugt 2010
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/blaze-html.
+https://hackage.haskell.org/package/blaze-html
 
 blaze-markup
 Copyright Jasper Van der Jeugt 2010
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/blaze-markup.
+https://hackage.haskell.org/package/blaze-markup
+
+blob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:310.
+https://www.npmjs.com/package/blob
+
+block-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:12813.
+https://www.npmjs.com/package/block-stream
 
 bloomfilter
 Copyright 2008 Bryan O'Sullivan <bos@serpentine.com>.
 Licensed under the BSD License.
 See strato/libs/bloomfilter/LICENSE.
+https://hackage.haskell.org/package/bloomfilter
+
+bluebird
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:315.
+https://www.npmjs.com/package/bluebird
 
 blueprintjs
 "Licensor" shall mean the copyright owner or entity authorized by
 Licensed under the Apache License, Version 2.0.
 See smd-ui/licenses/blueprintjs.
+https://www.npmjs.com/package/blueprintjs
+
+bn.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1548.
+https://www.npmjs.com/package/bn.js
 
 body-parser
 Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
 Licensed under the MIT License.
 See apex/api/licenses/body-parser.
+https://www.npmjs.com/package/body-parser
+
+boolbase
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:2187.
+https://www.npmjs.com/package/boolbase
+
+boom
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:348.
+https://www.npmjs.com/package/boom
+
+bootstrap
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2202.
+https://www.npmjs.com/package/bootstrap
+
+borsh
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1671.
+https://www.npmjs.com/package/borsh
+
+bowser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1615.
+https://www.npmjs.com/package/bowser
+
+boxen
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2207.
+https://www.npmjs.com/package/boxen
+
+brace-expansion
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:360.
+https://www.npmjs.com/package/brace-expansion
+
+braces
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10107.
+https://www.npmjs.com/package/braces
+
+brorand
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1706.
+https://www.npmjs.com/package/brorand
+
+browser-resolve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2304.
+https://www.npmjs.com/package/browser-resolve
+
+browser-stdout
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:369.
+https://www.npmjs.com/package/browser-stdout
+
+browserify-aes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2313.
+https://www.npmjs.com/package/browserify-aes
+
+browserify-cipher
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2327.
+https://www.npmjs.com/package/browserify-cipher
+
+browserify-des
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2334.
+https://www.npmjs.com/package/browserify-des
+
+browserify-rsa
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2350.
+https://www.npmjs.com/package/browserify-rsa
+
+browserify-sign
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:2360.
+https://www.npmjs.com/package/browserify-sign
+
+browserify-zlib
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2402.
+https://www.npmjs.com/package/browserify-zlib
+
+browserslist
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:954.
+https://www.npmjs.com/package/browserslist
+
+bs58
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1712.
+https://www.npmjs.com/package/bs58
+
+bser
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:2421.
+https://www.npmjs.com/package/bser
+
+buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1721.
+https://www.npmjs.com/package/buffer
+
+buffer-equal-constant-time
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1745.
+https://www.npmjs.com/package/buffer-equal-constant-time
+
+buffer-from
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2449.
+https://www.npmjs.com/package/buffer-from
+
+buffer-shims
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12841.
+https://www.npmjs.com/package/buffer-shims
+
+buffer-writer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:374.
+https://www.npmjs.com/package/buffer-writer
+
+buffer-xor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2319.
+https://www.npmjs.com/package/buffer-xor
+
+bufferutil
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1751.
+https://www.npmjs.com/package/bufferutil
+
+builtin-modules
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:382.
+https://www.npmjs.com/package/builtin-modules
+
+builtin-status-codes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2467.
+https://www.npmjs.com/package/builtin-status-codes
 
 byteable
 Copyright (c) 2013 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/byteable.
+https://hackage.haskell.org/package/byteable
+
+bytes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:390.
+https://www.npmjs.com/package/bytes
 
 bytestring
 Copyright (c) Don Stewart 2005-2009
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/bytestring.
+https://hackage.haskell.org/package/bytestring
 
 bytestring-arbitrary
 Copyright (c) 2014, jay groven
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/bytestring-arbitrary.
+https://hackage.haskell.org/package/bytestring-arbitrary
+
+cache-base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2014.
+https://www.npmjs.com/package/cache-base
+
+call-bind
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10199.
+https://www.npmjs.com/package/call-bind
+
+call-bind-apply-helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:612.
+https://www.npmjs.com/package/call-bind-apply-helpers
+
+call-bound
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:625.
+https://www.npmjs.com/package/call-bound
+
+call-me-maybe
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:641.
+https://www.npmjs.com/package/call-me-maybe
+
+caller-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2505.
+https://www.npmjs.com/package/caller-path
+
+callsite
+Upstream author (npm metadata): TJ Holowaychuk <tj@vision-media.ca>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:398.
+https://www.npmjs.com/package/callsite
+
+callsites
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2511.
+https://www.npmjs.com/package/callsites
+
+camel-case
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2533.
+https://www.npmjs.com/package/camel-case
+
+camelcase
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4450.
+https://www.npmjs.com/package/camelcase
+
+camelcase-css
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10265.
+https://www.npmjs.com/package/camelcase-css
+
+camelcase-keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2549.
+https://www.npmjs.com/package/camelcase-keys
+
+caniuse-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2567.
+https://www.npmjs.com/package/caniuse-api
+
+caniuse-db
+Copyright information is provided by the upstream package authors.
+Licensed under the CC-BY-4.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:2574.
+https://www.npmjs.com/package/caniuse-db
+
+caniuse-lite
+Copyright information is provided by the upstream package authors.
+Licensed under the CC-BY-4.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:10274.
+https://www.npmjs.com/package/caniuse-lite
+
+capture-stack-trace
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2603.
+https://www.npmjs.com/package/capture-stack-trace
+
+case-sensitive-paths-webpack-plugin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2609.
+https://www.npmjs.com/package/case-sensitive-paths-webpack-plugin
+
+caseless
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See apex/api/package-lock.json:406.
+https://www.npmjs.com/package/caseless
+
+cbw-sdk
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:10294.
+https://www.npmjs.com/package/cbw-sdk
+
+center-align
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2621.
+https://www.npmjs.com/package/center-align
 
 cereal
 Copyright (c) Lennart Kolmodin, Galois, Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/cereal.
+https://hackage.haskell.org/package/cereal
 
 chai
 Copyright (c) 2017 Chai.js Assertion Library
 Licensed under the MIT License.
 See apex/api/licenses/chai.
+https://www.npmjs.com/package/chai
 
 chai-http
 Copyright (c) Jake Luer jake@alogicalparadox.com
 Licensed under the MIT License.
 See apex/api/licenses/chai-http.
+https://www.npmjs.com/package/chai-http
+
+chain-function
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2631.
+https://www.npmjs.com/package/chain-function
+
+chalk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:442.
+https://www.npmjs.com/package/chalk
+
+chardet
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2649.
+https://www.npmjs.com/package/chardet
+
+charenc
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:10344.
+https://www.npmjs.com/package/charenc
+
+check-error
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:474.
+https://www.npmjs.com/package/check-error
+
+cheerio
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2655.
+https://www.npmjs.com/package/cheerio
+
+chokidar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4772.
+https://www.npmjs.com/package/chokidar
+
+chownr
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1344.
+https://www.npmjs.com/package/chownr
+
+ci-info
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2767.
+https://www.npmjs.com/package/ci-info
 
 cipher-aes
 Copyright (c) 2008-2013 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/cipher-aes.
+https://hackage.haskell.org/package/cipher-aes
+
+cipher-base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2320.
+https://www.npmjs.com/package/cipher-base
+
+circular-json
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2783.
+https://www.npmjs.com/package/circular-json
+
+clap
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2789.
+https://www.npmjs.com/package/clap
+
+class-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2015.
+https://www.npmjs.com/package/class-utils
+
+class-variance-authority
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:10389.
+https://www.npmjs.com/package/class-variance-authority
+
+classnames
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10401.
+https://www.npmjs.com/package/classnames
 
 classy-prelude
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/classy-prelude.
+https://hackage.haskell.org/package/classy-prelude
 
 classy-prelude-yesod
 Copyright (c) 2013 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/classy-prelude-yesod.
+https://hackage.haskell.org/package/classy-prelude-yesod
+
+clean-css
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2826.
+https://www.npmjs.com/package/clean-css
+
+cli-boxes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2216.
+https://www.npmjs.com/package/cli-boxes
+
+cli-color
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:482.
+https://www.npmjs.com/package/cli-color
+
+cli-cursor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2849.
+https://www.npmjs.com/package/cli-cursor
+
+cli-width
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:2858.
+https://www.npmjs.com/package/cli-width
+
+client-only
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10407.
+https://www.npmjs.com/package/client-only
+
+cliui
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:495.
+https://www.npmjs.com/package/cliui
+
+clone
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2883.
+https://www.npmjs.com/package/clone
+
+cls-bluebird
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:505.
+https://www.npmjs.com/package/cls-bluebird
+
+clsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:293.
+https://www.npmjs.com/package/clsx
 
 cmdargs
 Copyright Neil Mitchell 2009-2018.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/cmdargs.
+https://hackage.haskell.org/package/cmdargs
+
+cmdk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10433.
+https://www.npmjs.com/package/cmdk
 
 co
 Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
 Licensed under the MIT License.
 See apex/api/licenses/co.
+https://www.npmjs.com/package/co
 
 co-mocha
 Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
 Licensed under the MIT License.
 See apex/api/licenses/co-mocha.
+https://www.npmjs.com/package/co-mocha
+
+coa
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2895.
+https://www.npmjs.com/package/coa
+
+code-point-at
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:523.
+https://www.npmjs.com/package/code-point-at
+
+collection-visit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2485.
+https://www.npmjs.com/package/collection-visit
+
+color
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:672.
+https://www.npmjs.com/package/color
+
+color-convert
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:531.
+https://www.npmjs.com/package/color-convert
+
+color-name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:539.
+https://www.npmjs.com/package/color-name
+
+color-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:697.
+https://www.npmjs.com/package/color-string
+
+colormin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2955.
+https://www.npmjs.com/package/colormin
+
+colors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:544.
+https://www.npmjs.com/package/colors
+
+colorspace
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:707.
+https://www.npmjs.com/package/colorspace
+
+combined-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:552.
+https://www.npmjs.com/package/combined-stream
+
+command-exists
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:563.
+https://www.npmjs.com/package/command-exists
+
+commander
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:569.
+https://www.npmjs.com/package/commander
+
+commondir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2986.
+https://www.npmjs.com/package/commondir
+
+compare-versions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2992.
+https://www.npmjs.com/package/compare-versions
+
+component-bind
+Upstream author (npm metadata): tootallnate <nathan@tootallnate.net>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:574.
+https://www.npmjs.com/package/component-bind
+
+component-emitter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:579.
+https://www.npmjs.com/package/component-emitter
+
+component-inherit
+Upstream author (npm metadata): coreh <thecoreh@gmail.com>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:584.
+https://www.npmjs.com/package/component-inherit
+
+compressible
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3013.
+https://www.npmjs.com/package/compressible
+
+compression
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3030.
+https://www.npmjs.com/package/compression
+
+compute-scroll-into-view
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10488.
+https://www.npmjs.com/package/compute-scroll-into-view
+
+concat-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:589.
+https://www.npmjs.com/package/concat-map
+
+concat-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:594.
+https://www.npmjs.com/package/concat-stream
 
 conduit
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/conduit.
+https://hackage.haskell.org/package/conduit
 
 conduit-combinators
 Copyright (c) 2014 FP Complete
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/conduit-combinators.
+https://hackage.haskell.org/package/conduit-combinators
 
 conduit-extra
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/conduit-extra.
+https://hackage.haskell.org/package/conduit-extra
+
+config-chain
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:607.
+https://www.npmjs.com/package/config-chain
+
+configstore
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3074.
+https://www.npmjs.com/package/configstore
+
+connect-history-api-fallback
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3088.
+https://www.npmjs.com/package/connect-history-api-fallback
+
+console-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3094.
+https://www.npmjs.com/package/console-browserify
+
+console-control-strings
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1365.
+https://www.npmjs.com/package/console-control-strings
+
+constants-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3100.
+https://www.npmjs.com/package/constants-browserify
 
 containers
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/containers.
+https://hackage.haskell.org/package/containers
+
+contains-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3106.
+https://www.npmjs.com/package/contains-path
+
+content-disposition
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:616.
+https://www.npmjs.com/package/content-disposition
+
+content-type
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:624.
+https://www.npmjs.com/package/content-type
+
+content-type-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3127.
+https://www.npmjs.com/package/content-type-parser
 
 contravariant
 Copyright 2007-2015 Edward Kmett
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/contravariant.
+https://hackage.haskell.org/package/contravariant
+
+convert-source-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1010.
+https://www.npmjs.com/package/convert-source-map
+
+cookie
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:632.
+https://www.npmjs.com/package/cookie
+
+cookie-es
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10501.
+https://www.npmjs.com/package/cookie-es
 
 cookie-parser
 Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
 Licensed under the MIT License.
 See apex/api/licenses/cookie-parser.
+https://www.npmjs.com/package/cookie-parser
+
+cookie-signature
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:652.
+https://www.npmjs.com/package/cookie-signature
+
+cookiejar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:657.
+https://www.npmjs.com/package/cookiejar
+
+copy-descriptor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3151.
+https://www.npmjs.com/package/copy-descriptor
+
+copy-to-clipboard
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10507.
+https://www.npmjs.com/package/copy-to-clipboard
+
+core-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:662.
+https://www.npmjs.com/package/core-js
+
+core-util-is
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:668.
+https://www.npmjs.com/package/core-util-is
 
 cors
 Copyright (c) 2013 Troy Goode <troygoode@gmail.com>
 Licensed under the MIT License.
 See apex/api/licenses/cors.
+https://www.npmjs.com/package/cors
+
+cosmiconfig
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3176.
+https://www.npmjs.com/package/cosmiconfig
+
+crc-32
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:10522.
+https://www.npmjs.com/package/crc-32
+
+create-ecdh
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3199.
+https://www.npmjs.com/package/create-ecdh
+
+create-error-class
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3217.
+https://www.npmjs.com/package/create-error-class
+
+create-hash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2321.
+https://www.npmjs.com/package/create-hash
+
+create-hmac
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2369.
+https://www.npmjs.com/package/create-hmac
+
+create-react-class
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3253.
+https://www.npmjs.com/package/create-react-class
+
+cross-fetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8731.
+https://www.npmjs.com/package/cross-fetch
+
+cross-spawn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:685.
+https://www.npmjs.com/package/cross-spawn
+
+crossws
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10558.
+https://www.npmjs.com/package/crossws
+
+crypt
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:10567.
+https://www.npmjs.com/package/crypt
+
+cryptiles
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:704.
+https://www.npmjs.com/package/cryptiles
 
 Crypto
 Codec.Binary.BubbleBabble & John Meacham & Copyright © 2008, All rights
 Licensed under the GNU General Public License.
 See strato/extraFiles/strato/licenses/Crypto.
+https://hackage.haskell.org/package/Crypto
+
+crypto-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3294.
+https://www.npmjs.com/package/crypto-browserify
 
 crypto-pubkey
 Copyright (c) 2010-2012 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/crypto-pubkey.
+https://hackage.haskell.org/package/crypto-pubkey
 
 crypto-pubkey-types
 <th>Copyright</th>
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/crypto-pubkey-types.
+https://hackage.haskell.org/package/crypto-pubkey-types
 
 crypto-random
 Copyright (c) 2013 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/crypto-random.
+https://hackage.haskell.org/package/crypto-random
+
+crypto-random-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3313.
+https://www.npmjs.com/package/crypto-random-string
 
 cryptohash
 Copyright (c) 2010-2014 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/cryptohash.
+https://hackage.haskell.org/package/cryptohash
 
 cryptonite
 Copyright (c) 2006-2015 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/cryptonite.
+https://hackage.haskell.org/package/cryptonite
+
+css-color-names
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2962.
+https://www.npmjs.com/package/css-color-names
+
+css-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3325.
+https://www.npmjs.com/package/css-loader
+
+css-select
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:2661.
+https://www.npmjs.com/package/css-select
+
+css-selector-tokenizer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3332.
+https://www.npmjs.com/package/css-selector-tokenizer
+
+css-what
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:10576.
+https://www.npmjs.com/package/css-what
+
+cssesc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10588.
+https://www.npmjs.com/package/cssesc
+
+cssnano
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3333.
+https://www.npmjs.com/package/cssnano
+
+csso
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3502.
+https://www.npmjs.com/package/csso
+
+cssom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3512.
+https://www.npmjs.com/package/cssom
+
+cssstyle
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3518.
+https://www.npmjs.com/package/cssstyle
+
+csstype
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10600.
+https://www.npmjs.com/package/csstype
 
 csv
 Copyright (c) Jaap Weel 2007.  Permission is hereby granted, free
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/csv.
+https://hackage.haskell.org/package/csv
+
+cuer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10606.
+https://www.npmjs.com/package/cuer
+
+currently-unhandled
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3527.
+https://www.npmjs.com/package/currently-unhandled
+
+cycle
+Upstream author (npm metadata): dscape <nunojobpinto@gmail.com>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:728.
+https://www.npmjs.com/package/cycle
+
+d
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:736.
+https://www.npmjs.com/package/d
+
+d3
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3546.
+https://www.npmjs.com/package/d3
+
+d3-array
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10631.
+https://www.npmjs.com/package/d3-array
+
+d3-axis
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3552.
+https://www.npmjs.com/package/d3-axis
+
+d3-brush
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3553.
+https://www.npmjs.com/package/d3-brush
+
+d3-chord
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3554.
+https://www.npmjs.com/package/d3-chord
+
+d3-collection
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3555.
+https://www.npmjs.com/package/d3-collection
+
+d3-color
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10643.
+https://www.npmjs.com/package/d3-color
+
+d3-dispatch
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3557.
+https://www.npmjs.com/package/d3-dispatch
+
+d3-drag
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3558.
+https://www.npmjs.com/package/d3-drag
+
+d3-dsv
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3559.
+https://www.npmjs.com/package/d3-dsv
+
+d3-ease
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:10652.
+https://www.npmjs.com/package/d3-ease
+
+d3-force
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3561.
+https://www.npmjs.com/package/d3-force
+
+d3-format
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10661.
+https://www.npmjs.com/package/d3-format
+
+d3-geo
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3563.
+https://www.npmjs.com/package/d3-geo
+
+d3-hierarchy
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3564.
+https://www.npmjs.com/package/d3-hierarchy
+
+d3-interpolate
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10670.
+https://www.npmjs.com/package/d3-interpolate
+
+d3-path
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10682.
+https://www.npmjs.com/package/d3-path
+
+d3-polygon
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3567.
+https://www.npmjs.com/package/d3-polygon
+
+d3-quadtree
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3568.
+https://www.npmjs.com/package/d3-quadtree
+
+d3-queue
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3569.
+https://www.npmjs.com/package/d3-queue
+
+d3-random
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3570.
+https://www.npmjs.com/package/d3-random
+
+d3-request
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3571.
+https://www.npmjs.com/package/d3-request
+
+d3-scale
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10691.
+https://www.npmjs.com/package/d3-scale
+
+d3-selection
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3573.
+https://www.npmjs.com/package/d3-selection
+
+d3-shape
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10707.
+https://www.npmjs.com/package/d3-shape
+
+d3-time
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10719.
+https://www.npmjs.com/package/d3-time
+
+d3-time-format
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10731.
+https://www.npmjs.com/package/d3-time-format
+
+d3-timer
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10743.
+https://www.npmjs.com/package/d3-timer
+
+d3-transition
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3578.
+https://www.npmjs.com/package/d3-transition
+
+d3-voronoi
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3579.
+https://www.npmjs.com/package/d3-voronoi
+
+d3-zoom
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3580.
+https://www.npmjs.com/package/d3-zoom
+
+damerau-levenshtein
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3801.
+https://www.npmjs.com/package/damerau-levenshtein
+
+dashdash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:744.
+https://www.npmjs.com/package/dashdash
 
 data-default
 Copyright (c) 2013 Lukas Mai
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/data-default.
+https://hackage.haskell.org/package/data-default
+
+date-fns
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:2260.
+https://www.npmjs.com/package/date-fns
+
+dayjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4496.
+https://www.npmjs.com/package/dayjs
 
 debug
 Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
 Licensed under the MIT License.
 See apex/api/licenses/debug.
+https://www.npmjs.com/package/debug
+
+decamelize
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:763.
+https://www.npmjs.com/package/decamelize
+
+decimal.js-light
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10794.
+https://www.npmjs.com/package/decimal.js-light
+
+decode-uri-component
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10800.
+https://www.npmjs.com/package/decode-uri-component
+
+dedent
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10809.
+https://www.npmjs.com/package/dedent
+
+deep-eql
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:771.
+https://www.npmjs.com/package/deep-eql
+
+deep-equal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3836.
+https://www.npmjs.com/package/deep-equal
+
+deep-extend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1386.
+https://www.npmjs.com/package/deep-extend
+
+deep-is
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3847.
+https://www.npmjs.com/package/deep-is
+
+deep-object-diff
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10830.
+https://www.npmjs.com/package/deep-object-diff
+
+deepmerge
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1945.
+https://www.npmjs.com/package/deepmerge
 
 deepseq
 Copyright 2001-2009, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/deepseq.
+https://hackage.haskell.org/package/deepseq
+
+default-require-extensions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:585.
+https://www.npmjs.com/package/default-require-extensions
+
+define-data-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10845.
+https://www.npmjs.com/package/define-data-property
+
+define-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:782.
+https://www.npmjs.com/package/define-properties
+
+define-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2017.
+https://www.npmjs.com/package/define-property
+
+defined
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3417.
+https://www.npmjs.com/package/defined
+
+defu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10862.
+https://www.npmjs.com/package/defu
+
+del
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3918.
+https://www.npmjs.com/package/del
+
+delay
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:1954.
+https://www.npmjs.com/package/delay
+
+delayed-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:794.
+https://www.npmjs.com/package/delayed-stream
+
+delegates
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1395.
+https://www.npmjs.com/package/delegates
+
+depd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:802.
+https://www.npmjs.com/package/depd
 
 dequeue
 Copyright (c) 2009, Henry Bucklow
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/dequeue.
+https://hackage.haskell.org/package/dequeue
 
 derive
 Copyright Neil Mitchell 2006-2017.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/derive.
+https://hackage.haskell.org/package/derive
+
+derive-valtio
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10889.
+https://www.npmjs.com/package/derive-valtio
+
+des.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2345.
+https://www.npmjs.com/package/des.js
+
+destr
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10898.
+https://www.npmjs.com/package/destr
+
+destroy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:810.
+https://www.npmjs.com/package/destroy
+
+detect-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10904.
+https://www.npmjs.com/package/detect-browser
+
+detect-indent
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1053.
+https://www.npmjs.com/package/detect-indent
+
+detect-libc
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See apex/api/package-lock.json:1401.
+https://www.npmjs.com/package/detect-libc
+
+detect-node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3970.
+https://www.npmjs.com/package/detect-node
+
+detect-node-es
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10920.
+https://www.npmjs.com/package/detect-node-es
+
+detect-port-alt
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12198.
+https://www.npmjs.com/package/detect-port-alt
 
 diagrams-contrib
 Copyright (c) 2011-2015, various (see headers of individual source files)
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/diagrams-contrib.
+https://hackage.haskell.org/package/diagrams-contrib
 
 diagrams-html5
 Copyright (c) 2014-2016 diagrams-html5 team:
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/diagrams-html5.
+https://hackage.haskell.org/package/diagrams-html5
 
 diagrams-lib
 Copyright (c) 2011-2016 diagrams-lib team:
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/diagrams-lib.
+https://hackage.haskell.org/package/diagrams-lib
+
+didyoumean
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:10926.
+https://www.npmjs.com/package/didyoumean
+
+diff
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:2645.
+https://www.npmjs.com/package/diff
+
+diffie-hellman
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3305.
+https://www.npmjs.com/package/diffie-hellman
 
 digest
 Copyright (c) 2008-2009, Eugene Kirpichov
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/digest.
+https://hackage.haskell.org/package/digest
+
+dijkstrajs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10932.
+https://www.npmjs.com/package/dijkstrajs
 
 directory
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/directory.
+https://hackage.haskell.org/package/directory
+
+discontinuous-range
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4001.
+https://www.npmjs.com/package/discontinuous-range
+
+dlv
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10938.
+https://www.npmjs.com/package/dlv
 
 dns
 Copyright (c) 2009, IIJ Innovation Institute Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/dns.
+https://hackage.haskell.org/package/dns
+
+doctrine
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/backend/package-lock.json:848.
+https://www.npmjs.com/package/doctrine
+
+dom-converter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4016.
+https://www.npmjs.com/package/dom-converter
+
+dom-helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10944.
+https://www.npmjs.com/package/dom-helpers
+
+dom-serializer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2662.
+https://www.npmjs.com/package/dom-serializer
+
+dom-urls
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4051.
+https://www.npmjs.com/package/dom-urls
+
+dom-walk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4060.
+https://www.npmjs.com/package/dom-walk
+
+dom4
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:29.
+https://www.npmjs.com/package/dom4
+
+domain-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the Artistic-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:4070.
+https://www.npmjs.com/package/domain-browser
+
+domelementtype
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4039.
+https://www.npmjs.com/package/domelementtype
+
+domhandler
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4082.
+https://www.npmjs.com/package/domhandler
+
+domutils
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3383.
+https://www.npmjs.com/package/domutils
+
+dot-prop
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3080.
+https://www.npmjs.com/package/dot-prop
+
+dotenv
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:860.
+https://www.npmjs.com/package/dotenv
+
+dottie
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:815.
+https://www.npmjs.com/package/dottie
+
+dunder-proto
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:872.
+https://www.npmjs.com/package/dunder-proto
+
+duplexer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:820.
+https://www.npmjs.com/package/duplexer
+
+duplexer3
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4122.
+https://www.npmjs.com/package/duplexer3
+
+duplexify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10968.
+https://www.npmjs.com/package/duplexify
+
+ecc-jsbn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:825.
+https://www.npmjs.com/package/ecc-jsbn
+
+ecdsa-sig-formatter
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2030.
+https://www.npmjs.com/package/ecdsa-sig-formatter
+
+eciesjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:10980.
+https://www.npmjs.com/package/eciesjs
+
+editorconfig
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:834.
+https://www.npmjs.com/package/editorconfig
+
+ee-first
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:849.
+https://www.npmjs.com/package/ee-first
 
 either
 Copyright 2008-2014 Edward Kmett
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/either.
+https://hackage.haskell.org/package/either
+
+electron-to-chromium
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See smd-ui/package-lock.json:2418.
+https://www.npmjs.com/package/electron-to-chromium
+
+elliptic
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2045.
+https://www.npmjs.com/package/elliptic
+
+embla-carousel
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11031.
+https://www.npmjs.com/package/embla-carousel
+
+embla-carousel-react
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11037.
+https://www.npmjs.com/package/embla-carousel-react
+
+embla-carousel-reactive-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11050.
+https://www.npmjs.com/package/embla-carousel-reactive-utils
+
+emoji-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:854.
+https://www.npmjs.com/package/emoji-regex
+
+emojis-list
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4185.
+https://www.npmjs.com/package/emojis-list
+
+enabled
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:902.
+https://www.npmjs.com/package/enabled
+
+encode-utf8
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11065.
+https://www.npmjs.com/package/encode-utf8
+
+encodeurl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:859.
+https://www.npmjs.com/package/encodeurl
+
+encoding
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4197.
+https://www.npmjs.com/package/encoding
+
+end-of-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11071.
+https://www.npmjs.com/package/end-of-stream
+
+engine.io
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:867.
+https://www.npmjs.com/package/engine.io
+
+engine.io-client
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:883.
+https://www.npmjs.com/package/engine.io-client
+
+engine.io-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:901.
+https://www.npmjs.com/package/engine.io-parser
+
+enhanced-resolve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4235.
+https://www.npmjs.com/package/enhanced-resolve
+
+entities
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:2663.
+https://www.npmjs.com/package/entities
 
 entropy
 Copyright (c) Thomas DuBuisson
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/entropy.
+https://hackage.haskell.org/package/entropy
+
+enzyme
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4253.
+https://www.npmjs.com/package/enzyme
 
 enzyme-adapter-react-15
 Copyright (c) 2015 Airbnb, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/enzyme-adapter-react-15.
+https://www.npmjs.com/package/enzyme-adapter-react-15
+
+enzyme-adapter-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4282.
+https://www.npmjs.com/package/enzyme-adapter-utils
+
+errno
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4299.
+https://www.npmjs.com/package/errno
+
+error-ex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:913.
+https://www.npmjs.com/package/error-ex
 
 errors
 Copyright (c) 2012, 2013, Gabriel Gonzalez
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/errors.
+https://hackage.haskell.org/package/errors
+
+es-abstract
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:921.
+https://www.npmjs.com/package/es-abstract
+
+es-define-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:917.
+https://www.npmjs.com/package/es-define-property
+
+es-errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:926.
+https://www.npmjs.com/package/es-errors
+
+es-object-atoms
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:935.
+https://www.npmjs.com/package/es-object-atoms
+
+es-set-tostringtag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:947.
+https://www.npmjs.com/package/es-set-tostringtag
+
+es-to-primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:936.
+https://www.npmjs.com/package/es-to-primitive
+
+es-toolkit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11168.
+https://www.npmjs.com/package/es-toolkit
+
+es5-ext
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:949.
+https://www.npmjs.com/package/es5-ext
+
+es6-error
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4350.
+https://www.npmjs.com/package/es6-error
+
+es6-iterator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:958.
+https://www.npmjs.com/package/es6-iterator
+
+es6-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4366.
+https://www.npmjs.com/package/es6-map
+
+es6-promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2147.
+https://www.npmjs.com/package/es6-promise
+
+es6-promisify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2153.
+https://www.npmjs.com/package/es6-promisify
+
+es6-set
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:4375.
+https://www.npmjs.com/package/es6-set
+
+es6-shim
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:109.
+https://www.npmjs.com/package/es6-shim
+
+es6-symbol
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:968.
+https://www.npmjs.com/package/es6-symbol
+
+es6-weak-map
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:977.
+https://www.npmjs.com/package/es6-weak-map
+
+escalade
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:988.
+https://www.npmjs.com/package/escalade
+
+escape-html
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:996.
+https://www.npmjs.com/package/escape-html
+
+escape-string-regexp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:455.
+https://www.npmjs.com/package/escape-string-regexp
+
+escodegen
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4450.
+https://www.npmjs.com/package/escodegen
+
+escope
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4478.
+https://www.npmjs.com/package/escope
+
+eslint
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4490.
+https://www.npmjs.com/package/eslint
+
+eslint-config-react-app
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4550.
+https://www.npmjs.com/package/eslint-config-react-app
+
+eslint-import-resolver-node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4556.
+https://www.npmjs.com/package/eslint-import-resolver-node
+
+eslint-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4578.
+https://www.npmjs.com/package/eslint-loader
+
+eslint-module-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4592.
+https://www.npmjs.com/package/eslint-module-utils
+
+eslint-plugin-flowtype
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4628.
+https://www.npmjs.com/package/eslint-plugin-flowtype
+
+eslint-plugin-import
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4637.
+https://www.npmjs.com/package/eslint-plugin-import
+
+eslint-plugin-jsx-a11y
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4682.
+https://www.npmjs.com/package/eslint-plugin-jsx-a11y
+
+eslint-plugin-react
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4697.
+https://www.npmjs.com/package/eslint-plugin-react
+
+esniff
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2181.
+https://www.npmjs.com/package/esniff
+
+espree
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4502.
+https://www.npmjs.com/package/espree
+
+esprima
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4456.
+https://www.npmjs.com/package/esprima
 
 esqueleto
 Copyright (c) 2012, Felipe Lessa
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/esqueleto.
+https://hackage.haskell.org/package/esqueleto
+
+esquery
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4503.
+https://www.npmjs.com/package/esquery
+
+esrecurse
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4486.
+https://www.npmjs.com/package/esrecurse
+
+estraverse
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4457.
+https://www.npmjs.com/package/estraverse
+
+esutils
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See mercata/backend/package-lock.json:968.
+https://www.npmjs.com/package/esutils
+
+etag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1001.
+https://www.npmjs.com/package/etag
+
+eth-block-tracker
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11435.
+https://www.npmjs.com/package/eth-block-tracker
+
+eth-json-rpc-filters
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:11485.
+https://www.npmjs.com/package/eth-json-rpc-filters
+
+eth-query
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:11513.
+https://www.npmjs.com/package/eth-query
+
+eth-rpc-errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11523.
+https://www.npmjs.com/package/eth-rpc-errors
 
 ether
 Copyright (c) 2017, Vladislav Zavialov
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/ether.
+https://hackage.haskell.org/package/ether
+
+ethereum-cryptography
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11532.
+https://www.npmjs.com/package/ethereum-cryptography
 
 ethereum-rlp
 Copyright 2016 BlockApps, Inc
 Licensed under the Apache License, Version 2.0.
 See strato/extraFiles/strato/licenses/ethereum-rlp.
+https://hackage.haskell.org/package/ethereum-rlp
+
+ethers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2205.
+https://www.npmjs.com/package/ethers
+
+event-emitter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1009.
+https://www.npmjs.com/package/event-emitter
+
+event-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1018.
+https://www.npmjs.com/package/event-stream
+
+eventemitter2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11653.
+https://www.npmjs.com/package/eventemitter2
+
+eventemitter3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2309.
+https://www.npmjs.com/package/eventemitter3
+
+events
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11665.
+https://www.npmjs.com/package/events
+
+eventsource
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4821.
+https://www.npmjs.com/package/eventsource
+
+evp_bytestokey
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2322.
+https://www.npmjs.com/package/evp_bytestokey
 
 exceptions
 Copyright 2013-2015 Edward Kmett
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/exceptions.
+https://hackage.haskell.org/package/exceptions
+
+exec-sh
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4840.
+https://www.npmjs.com/package/exec-sh
+
+execa
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1043.
+https://www.npmjs.com/package/execa
+
+exit-hook
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4864.
+https://www.npmjs.com/package/exit-hook
+
+expand-brackets
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4870.
+https://www.npmjs.com/package/expand-brackets
+
+expand-range
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4914.
+https://www.npmjs.com/package/expand-range
+
+expand-tilde
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4971.
+https://www.npmjs.com/package/expand-tilde
 
 expect
 Copyright (c) 2014-present, Facebook, Inc.
 Licensed under the MIT License.
 See apex/api/licenses/expect.
+https://www.npmjs.com/package/expect
 
 express
 Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
 Licensed under the MIT License.
 See apex/api/licenses/express.
+https://www.npmjs.com/package/express
+
+ext
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2361.
+https://www.npmjs.com/package/ext
+
+extend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1121.
+https://www.npmjs.com/package/extend
+
+extend-shallow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2277.
+https://www.npmjs.com/package/extend-shallow
+
+extension-port-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:11674.
+https://www.npmjs.com/package/extension-port-stream
+
+external-editor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5110.
+https://www.npmjs.com/package/external-editor
+
+extglob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5121.
+https://www.npmjs.com/package/extglob
 
 extra
 Copyright Neil Mitchell 2014-2018.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/extra.
+https://hackage.haskell.org/package/extra
+
+extract-text-webpack-plugin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5186.
+https://www.npmjs.com/package/extract-text-webpack-plugin
+
+extsprintf
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1126.
+https://www.npmjs.com/package/extsprintf
+
+eyes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1134.
+https://www.npmjs.com/package/eyes
+
+fast-deep-equal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1142.
+https://www.npmjs.com/package/fast-deep-equal
+
+fast-equals
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11701.
+https://www.npmjs.com/package/fast-equals
+
+fast-glob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11710.
+https://www.npmjs.com/package/fast-glob
+
+fast-json-stable-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1147.
+https://www.npmjs.com/package/fast-json-stable-stringify
+
+fast-levenshtein
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:5228.
+https://www.npmjs.com/package/fast-levenshtein
 
 fast-logger
 Copyright (c) 2009, IIJ Innovation Institute Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/fast-logger.
+https://hackage.haskell.org/package/fast-logger
+
+fast-redact
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11752.
+https://www.npmjs.com/package/fast-redact
+
+fast-safe-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11761.
+https://www.npmjs.com/package/fast-safe-stringify
+
+fast-stable-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2378.
+https://www.npmjs.com/package/fast-stable-stringify
+
+fast-xml-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1893.
+https://www.npmjs.com/package/fast-xml-parser
+
+fastparse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3394.
+https://www.npmjs.com/package/fastparse
+
+fastq
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:11773.
+https://www.npmjs.com/package/fastq
+
+faye-websocket
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:5240.
+https://www.npmjs.com/package/faye-websocket
+
+fb-watchman
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:5249.
+https://www.npmjs.com/package/fb-watchman
+
+fbjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3258.
+https://www.npmjs.com/package/fbjs
+
+fdir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15487.
+https://www.npmjs.com/package/fdir
+
+fecha
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1028.
+https://www.npmjs.com/package/fecha
+
+fflate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:1911.
+https://www.npmjs.com/package/fflate
+
+figures
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5272.
+https://www.npmjs.com/package/figures
 
 file-embed
 Copyright 2008, Michael Snoyman. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/file-embed.
+https://hackage.haskell.org/package/file-embed
+
+file-entry-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4506.
+https://www.npmjs.com/package/file-entry-cache
+
+file-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5292.
+https://www.npmjs.com/package/file-loader
+
+file-uri-to-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2117.
+https://www.npmjs.com/package/file-uri-to-path
+
+filename-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5308.
+https://www.npmjs.com/package/filename-regex
 
 filepath
 Copyright Neil Mitchell 2005-2018.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/filepath.
+https://hackage.haskell.org/package/filepath
+
+fileset
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5314.
+https://www.npmjs.com/package/fileset
+
+filesize
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:5324.
+https://www.npmjs.com/package/filesize
+
+fill-range
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11795.
+https://www.npmjs.com/package/fill-range
+
+filter-obj
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11807.
+https://www.npmjs.com/package/filter-obj
+
+finalhandler
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1152.
+https://www.npmjs.com/package/finalhandler
+
+find-cache-dir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1247.
+https://www.npmjs.com/package/find-cache-dir
+
+find-up
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4474.
+https://www.npmjs.com/package/find-up
+
+flat-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:5288.
+https://www.npmjs.com/package/flat-cache
+
+flatten
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5411.
+https://www.npmjs.com/package/flatten
+
+fn.name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1064.
+https://www.npmjs.com/package/fn.name
+
+follow-redirects
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1185.
+https://www.npmjs.com/package/follow-redirects
+
+for-each
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11874.
+https://www.npmjs.com/package/for-each
+
+for-in
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5423.
+https://www.npmjs.com/package/for-in
+
+for-own
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5429.
+https://www.npmjs.com/package/for-own
+
+foreach
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1204.
+https://www.npmjs.com/package/foreach
+
+forever-agent
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See apex/api/package-lock.json:1209.
+https://www.npmjs.com/package/forever-agent
+
+form-data
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1217.
+https://www.npmjs.com/package/form-data
+
+formidable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1230.
+https://www.npmjs.com/package/formidable
+
+forwarded
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1239.
+https://www.npmjs.com/package/forwarded
+
+fragment-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5131.
+https://www.npmjs.com/package/fragment-cache
+
+fresh
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1247.
+https://www.npmjs.com/package/fresh
+
+from
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1255.
+https://www.npmjs.com/package/from
 
 fs-extra
 Copyright (c) 2011-2017 JP Richardson
 Licensed under the MIT License.
 See apex/api/licenses/fs-extra.
+https://www.npmjs.com/package/fs-extra
+
+fs-minipass
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1413.
+https://www.npmjs.com/package/fs-minipass
+
+fs.realpath
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1270.
+https://www.npmjs.com/package/fs.realpath
+
+fsevents
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11919.
+https://www.npmjs.com/package/fsevents
+
+fsm-iterator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6052.
+https://www.npmjs.com/package/fsm-iterator
+
+fstream
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See smd-ui/package-lock.json:13019.
+https://www.npmjs.com/package/fstream
+
+fstream-ignore
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:13031.
+https://www.npmjs.com/package/fstream-ignore
+
+function-bind
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1275.
+https://www.npmjs.com/package/function-bind
+
+function.prototype.name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4260.
+https://www.npmjs.com/package/function.prototype.name
+
+gauge
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1428.
+https://www.npmjs.com/package/gauge
+
+gc-stats
+Copyright information is provided by the upstream package authors.
+Licensed under the Unlicense License (per npm registry metadata).
+See apex/api/package-lock.json:1280.
+https://www.npmjs.com/package/gc-stats
+
+generate-function
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6073.
+https://www.npmjs.com/package/generate-function
+
+generate-object-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6082.
+https://www.npmjs.com/package/generate-object-property
+
+generator-function
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11942.
+https://www.npmjs.com/package/generator-function
 
 generic-random
 Copyright (c) 2016 Li-yao Xia
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/generic-random.
+https://hackage.haskell.org/package/generic-random
+
+get-caller-file
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1911.
+https://www.npmjs.com/package/get-caller-file
+
+get-func-name
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1916.
+https://www.npmjs.com/package/get-func-name
+
+get-intrinsic
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1174.
+https://www.npmjs.com/package/get-intrinsic
+
+get-nonce
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:11984.
+https://www.npmjs.com/package/get-nonce
+
+get-port
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1924.
+https://www.npmjs.com/package/get-port
+
+get-proto
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1198.
+https://www.npmjs.com/package/get-proto
+
+get-stdin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6122.
+https://www.npmjs.com/package/get-stdin
+
+get-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1932.
+https://www.npmjs.com/package/get-stream
+
+get-value
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2487.
+https://www.npmjs.com/package/get-value
+
+getpass
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1940.
+https://www.npmjs.com/package/getpass
 
 gitrev
 Copyright (c) 2015, Adam C. Foltzer
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/gitrev.
+https://hackage.haskell.org/package/gitrev
+
+glob
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1444.
+https://www.npmjs.com/package/glob
+
+glob-base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6163.
+https://www.npmjs.com/package/glob-base
+
+glob-parent
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:10377.
+https://www.npmjs.com/package/glob-parent
+
+global
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6182.
+https://www.npmjs.com/package/global
+
+global-dirs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6191.
+https://www.npmjs.com/package/global-dirs
+
+global-modules
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6200.
+https://www.npmjs.com/package/global-modules
+
+global-prefix
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6206.
+https://www.npmjs.com/package/global-prefix
+
+globals
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:1963.
+https://www.npmjs.com/package/globals
+
+globby
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3924.
+https://www.npmjs.com/package/globby
+
+gopd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1246.
+https://www.npmjs.com/package/gopd
+
+got
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6244.
+https://www.npmjs.com/package/got
+
+graceful-fs
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1964.
+https://www.npmjs.com/package/graceful-fs
+
+graceful-readlink
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12895.
+https://www.npmjs.com/package/graceful-readlink
+
+growl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2661.
+https://www.npmjs.com/package/growl
+
+growly
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6269.
+https://www.npmjs.com/package/growly
+
+gud
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:119.
+https://www.npmjs.com/package/gud
+
+gzip-size
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6280.
+https://www.npmjs.com/package/gzip-size
+
+h3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12043.
+https://www.npmjs.com/package/h3
+
+handle-thing
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6289.
+https://www.npmjs.com/package/handle-thing
+
+handlebars
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6295.
+https://www.npmjs.com/package/handlebars
+
+har-schema
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:1972.
+https://www.npmjs.com/package/har-schema
+
+har-validator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1980.
+https://www.npmjs.com/package/har-validator
+
+harmony-reflect
+Copyright information is provided by the upstream package authors.
+Licensed under the (Apache-2.0 OR MPL-1.1) License (per npm registry metadata).
+See smd-ui/package-lock.json:6340.
+https://www.npmjs.com/package/harmony-reflect
+
+has
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1993.
+https://www.npmjs.com/package/has
+
+has-ansi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2644.
+https://www.npmjs.com/package/has-ansi
+
+has-bigints
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6363.
+https://www.npmjs.com/package/has-bigints
+
+has-binary2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2004.
+https://www.npmjs.com/package/has-binary2
+
+has-cors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2017.
+https://www.npmjs.com/package/has-cors
+
+has-flag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2022.
+https://www.npmjs.com/package/has-flag
+
+has-property-descriptors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12070.
+https://www.npmjs.com/package/has-property-descriptors
+
+has-symbols
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1258.
+https://www.npmjs.com/package/has-symbols
+
+has-tostringtag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1270.
+https://www.npmjs.com/package/has-tostringtag
+
+has-unicode
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1461.
+https://www.npmjs.com/package/has-unicode
+
+has-value
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2488.
+https://www.npmjs.com/package/has-value
+
+has-values
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6407.
+https://www.npmjs.com/package/has-values
+
+hash-base
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6432.
+https://www.npmjs.com/package/hash-base
+
+hash.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2591.
+https://www.npmjs.com/package/hash.js
 
 hashable
 Copyright Milan Straka 2010
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/hashable.
+https://hackage.haskell.org/package/hashable
+
+hasown
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1285.
+https://www.npmjs.com/package/hasown
+
+hawk
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:2030.
+https://www.npmjs.com/package/hawk
+
+he
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2045.
+https://www.npmjs.com/package/he
 
 hedis
 Copyright (c)2011, Falko Peters
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/hedis.
+https://hackage.haskell.org/package/hedis
 
 hflags
 "Licensor" shall mean the copyright owner or entity authorized by
 Licensed under the Apache License, Version 2.0.
 See strato/extraFiles/strato/licenses/hflags.
+https://hackage.haskell.org/package/hflags
+
+history
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6496.
+https://www.npmjs.com/package/history
 
 hjsmin
 Copyright (c)2010, Alan Zimmerman
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/hjsmin.
+https://hackage.haskell.org/package/hjsmin
+
+hmac-drbg
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2613.
+https://www.npmjs.com/package/hmac-drbg
+
+hoek
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:2053.
+https://www.npmjs.com/package/hoek
+
+hoist-non-react-statics
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:6526.
+https://www.npmjs.com/package/hoist-non-react-statics
+
+home-or-tmp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1906.
+https://www.npmjs.com/package/home-or-tmp
+
+homedir-polyfill
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4977.
+https://www.npmjs.com/package/homedir-polyfill
+
+hono
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12121.
+https://www.npmjs.com/package/hono
+
+hosted-git-info
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:2062.
+https://www.npmjs.com/package/hosted-git-info
+
+hpack.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6556.
+https://www.npmjs.com/package/hpack.js
+
+html-comment-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6568.
+https://www.npmjs.com/package/html-comment-regex
+
+html-encoding-sniffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6574.
+https://www.npmjs.com/package/html-encoding-sniffer
+
+html-entities
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6583.
+https://www.npmjs.com/package/html-entities
+
+html-minifier
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6589.
+https://www.npmjs.com/package/html-minifier
+
+html-webpack-plugin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6636.
+https://www.npmjs.com/package/html-webpack-plugin
+
+htmlparser2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2664.
+https://www.npmjs.com/package/htmlparser2
 
 http-api-data
 Copyright 2015, Nickolay Kudasov. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/http-api-data.
+https://hackage.haskell.org/package/http-api-data
+
+http-basic
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2067.
+https://www.npmjs.com/package/http-basic
 
 http-client
 Copyright (c) 2013 Michael Snoyman
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/http-client.
+https://hackage.haskell.org/package/http-client
+
+http-deceiver
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6690.
+https://www.npmjs.com/package/http-deceiver
+
+http-errors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2082.
+https://www.npmjs.com/package/http-errors
 
 http-media
 Copyright (c) 2012-2015 Timothy Jones
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/http-media.
+https://hackage.haskell.org/package/http-media
+
+http-parser-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6709.
+https://www.npmjs.com/package/http-parser-js
+
+http-proxy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6715.
+https://www.npmjs.com/package/http-proxy
+
+http-proxy-middleware
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6726.
+https://www.npmjs.com/package/http-proxy-middleware
+
+http-response-object
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2104.
+https://www.npmjs.com/package/http-response-object
+
+http-signature
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2109.
+https://www.npmjs.com/package/http-signature
+
+http-status-codes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1322.
+https://www.npmjs.com/package/http-status-codes
 
 http-types
 Copyright (c) 2011, Aristid Breitkreuz
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/http-types.
+https://hackage.haskell.org/package/http-types
+
+https-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6865.
+https://www.npmjs.com/package/https-browserify
+
+humanize-ms
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2640.
+https://www.npmjs.com/package/humanize-ms
+
+iconv-lite
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1467.
+https://www.npmjs.com/package/iconv-lite
+
+icss-replace-symbols
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:6879.
+https://www.npmjs.com/package/icss-replace-symbols
+
+idb-keyval
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:12139.
+https://www.npmjs.com/package/idb-keyval
+
+identity-obj-proxy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6885.
+https://www.npmjs.com/package/identity-obj-proxy
+
+ieee754
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2661.
+https://www.npmjs.com/package/ieee754
+
+ignore
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4509.
+https://www.npmjs.com/package/ignore
+
+ignore-walk
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1479.
+https://www.npmjs.com/package/ignore-walk
+
+immutable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6906.
+https://www.npmjs.com/package/immutable
+
+import-lazy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6912.
+https://www.npmjs.com/package/import-lazy
+
+imurmurhash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4510.
+https://www.npmjs.com/package/imurmurhash
+
+indent-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:6924.
+https://www.npmjs.com/package/indent-string
+
+indexes-of
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6933.
+https://www.npmjs.com/package/indexes-of
+
+indexof
+Upstream author (npm metadata): tjholowaychuk <tj@vision-media.ca>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:2131.
+https://www.npmjs.com/package/indexof
+
+inflection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2136.
+https://www.npmjs.com/package/inflection
+
+inflight
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1488.
+https://www.npmjs.com/package/inflight
+
+inherits
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1498.
+https://www.npmjs.com/package/inherits
+
+ini
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1504.
+https://www.npmjs.com/package/ini
+
+input-otp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12208.
+https://www.npmjs.com/package/input-otp
+
+inquirer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4511.
+https://www.npmjs.com/package/inquirer
 
 insert-ordered-containers
 Copyright (c) 2015, Oleg Grenrus
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/insert-ordered-containers.
+https://hackage.haskell.org/package/insert-ordered-containers
+
+internmap
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:12218.
+https://www.npmjs.com/package/internmap
+
+interpret
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:7006.
+https://www.npmjs.com/package/interpret
+
+invariant
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1782.
+https://www.npmjs.com/package/invariant
+
+invert-kv
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2167.
+https://www.npmjs.com/package/invert-kv
+
+ip-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2175.
+https://www.npmjs.com/package/ip-regex
+
+ipaddr.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2183.
+https://www.npmjs.com/package/ipaddr.js
 
 iproute
 Copyright (c) 2009, IIJ Innovation Institute Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/iproute.
+https://hackage.haskell.org/package/iproute
+
+iron-webcrypto
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12227.
+https://www.npmjs.com/package/iron-webcrypto
+
+is-absolute-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7032.
+https://www.npmjs.com/package/is-absolute-url
+
+is-accessor-descriptor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2032.
+https://www.npmjs.com/package/is-accessor-descriptor
+
+is-arguments
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12236.
+https://www.npmjs.com/package/is-arguments
+
+is-arrayish
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2191.
+https://www.npmjs.com/package/is-arrayish
+
+is-bigint
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7072.
+https://www.npmjs.com/package/is-bigint
+
+is-binary-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12252.
+https://www.npmjs.com/package/is-binary-path
+
+is-bluebird
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2196.
+https://www.npmjs.com/package/is-bluebird
+
+is-boolean-object
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4262.
+https://www.npmjs.com/package/is-boolean-object
+
+is-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12264.
+https://www.npmjs.com/package/is-buffer
+
+is-builtin-module
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2204.
+https://www.npmjs.com/package/is-builtin-module
+
+is-callable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2215.
+https://www.npmjs.com/package/is-callable
+
+is-ci
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7113.
+https://www.npmjs.com/package/is-ci
+
+is-core-module
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12282.
+https://www.npmjs.com/package/is-core-module
+
+is-data-descriptor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2041.
+https://www.npmjs.com/package/is-data-descriptor
+
+is-date-object
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2223.
+https://www.npmjs.com/package/is-date-object
+
+is-descriptor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2029.
+https://www.npmjs.com/package/is-descriptor
+
+is-directory
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3182.
+https://www.npmjs.com/package/is-directory
+
+is-dotfile
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7192.
+https://www.npmjs.com/package/is-dotfile
+
+is-electron
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2128.
+https://www.npmjs.com/package/is-electron
+
+is-equal-shallow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7198.
+https://www.npmjs.com/package/is-equal-shallow
+
+is-extendable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2293.
+https://www.npmjs.com/package/is-extendable
+
+is-extglob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12297.
+https://www.npmjs.com/package/is-extglob
+
+is-finite
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7219.
+https://www.npmjs.com/package/is-finite
+
+is-fullwidth-code-point
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1513.
+https://www.npmjs.com/package/is-fullwidth-code-point
+
+is-generator-function
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12315.
+https://www.npmjs.com/package/is-generator-function
+
+is-glob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12334.
+https://www.npmjs.com/package/is-glob
+
+is-installed-globally
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7246.
+https://www.npmjs.com/package/is-installed-globally
+
+is-ip
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2242.
+https://www.npmjs.com/package/is-ip
+
+is-mobile
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12346.
+https://www.npmjs.com/package/is-mobile
+
+is-my-ip-valid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7256.
+https://www.npmjs.com/package/is-my-ip-valid
+
+is-my-json-valid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4512.
+https://www.npmjs.com/package/is-my-json-valid
+
+is-negative-zero
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:683.
+https://www.npmjs.com/package/is-negative-zero
+
+is-npm
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7281.
+https://www.npmjs.com/package/is-npm
+
+is-number
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12352.
+https://www.npmjs.com/package/is-number
+
+is-number-object
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4264.
+https://www.npmjs.com/package/is-number-object
+
+is-obj
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4107.
+https://www.npmjs.com/package/is-obj
+
+is-odd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7319.
+https://www.npmjs.com/package/is-odd
+
+is-path-cwd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3925.
+https://www.npmjs.com/package/is-path-cwd
+
+is-path-in-cwd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3926.
+https://www.npmjs.com/package/is-path-in-cwd
+
+is-path-inside
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7253.
+https://www.npmjs.com/package/is-path-inside
+
+is-plain-obj
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2253.
+https://www.npmjs.com/package/is-plain-obj
+
+is-plain-object
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5105.
+https://www.npmjs.com/package/is-plain-object
+
+is-posix-bracket
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6770.
+https://www.npmjs.com/package/is-posix-bracket
+
+is-primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7204.
+https://www.npmjs.com/package/is-primitive
+
+is-promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2261.
+https://www.npmjs.com/package/is-promise
+
+is-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6079.
+https://www.npmjs.com/package/is-property
 
 is-reachable
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Licensed under the MIT License.
 See apex/api/licenses/is-reachable.
+https://www.npmjs.com/package/is-reachable
+
+is-redirect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6253.
+https://www.npmjs.com/package/is-redirect
+
+is-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2266.
+https://www.npmjs.com/package/is-regex
+
+is-resolvable
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:4513.
+https://www.npmjs.com/package/is-resolvable
+
+is-retry-allowed
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12379.
+https://www.npmjs.com/package/is-retry-allowed
+
+is-root
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7424.
+https://www.npmjs.com/package/is-root
+
+is-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2277.
+https://www.npmjs.com/package/is-stream
+
+is-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:658.
+https://www.npmjs.com/package/is-string
+
+is-subset
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4266.
+https://www.npmjs.com/package/is-subset
+
+is-svg
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7447.
+https://www.npmjs.com/package/is-svg
+
+is-symbol
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2285.
+https://www.npmjs.com/package/is-symbol
+
+is-typed-array
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12403.
+https://www.npmjs.com/package/is-typed-array
+
+is-typedarray
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2293.
+https://www.npmjs.com/package/is-typedarray
+
+is-utf8
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7467.
+https://www.npmjs.com/package/is-utf8
+
+is-windows
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6207.
+https://www.npmjs.com/package/is-windows
+
+is-wsl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:7479.
+https://www.npmjs.com/package/is-wsl
+
+isarray
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1525.
+https://www.npmjs.com/package/isarray
+
+isexe
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:2303.
+https://www.npmjs.com/package/isexe
+
+isobject
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2018.
+https://www.npmjs.com/package/isobject
+
+isomorphic-fetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5264.
+https://www.npmjs.com/package/isomorphic-fetch
+
+isomorphic-ws
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2755.
+https://www.npmjs.com/package/isomorphic-ws
+
+isows
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2764.
+https://www.npmjs.com/package/isows
+
+isstream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2308.
+https://www.npmjs.com/package/isstream
+
+istanbul-api
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7517.
+https://www.npmjs.com/package/istanbul-api
+
+istanbul-lib-coverage
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7526.
+https://www.npmjs.com/package/istanbul-lib-coverage
+
+istanbul-lib-hook
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7527.
+https://www.npmjs.com/package/istanbul-lib-hook
+
+istanbul-lib-instrument
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:1289.
+https://www.npmjs.com/package/istanbul-lib-instrument
+
+istanbul-lib-report
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7529.
+https://www.npmjs.com/package/istanbul-lib-report
+
+istanbul-lib-source-maps
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7530.
+https://www.npmjs.com/package/istanbul-lib-source-maps
+
+istanbul-reports
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:7531.
+https://www.npmjs.com/package/istanbul-reports
+
+jayson
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2779.
+https://www.npmjs.com/package/jayson
+
+jest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7633.
+https://www.npmjs.com/package/jest
+
+jest-changed-files
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7727.
+https://www.npmjs.com/package/jest-changed-files
+
+jest-cli
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7639.
+https://www.npmjs.com/package/jest-cli
+
+jest-config
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7728.
+https://www.npmjs.com/package/jest-config
+
+jest-diff
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4987.
+https://www.npmjs.com/package/jest-diff
+
+jest-docblock
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7907.
+https://www.npmjs.com/package/jest-docblock
+
+jest-environment-jsdom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7729.
+https://www.npmjs.com/package/jest-environment-jsdom
+
+jest-environment-node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7823.
+https://www.npmjs.com/package/jest-environment-node
+
+jest-fetch-mock
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7934.
+https://www.npmjs.com/package/jest-fetch-mock
+
+jest-get-type
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4988.
+https://www.npmjs.com/package/jest-get-type
+
+jest-haste-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7730.
+https://www.npmjs.com/package/jest-haste-map
+
+jest-jasmine2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7825.
+https://www.npmjs.com/package/jest-jasmine2
+
+jest-localstorage-mock
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:8086.
+https://www.npmjs.com/package/jest-localstorage-mock
+
+jest-matcher-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4989.
+https://www.npmjs.com/package/jest-matcher-utils
+
+jest-matchers
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:8134.
+https://www.npmjs.com/package/jest-matchers
+
+jest-message-util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4990.
+https://www.npmjs.com/package/jest-message-util
+
+jest-mock
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7919.
+https://www.npmjs.com/package/jest-mock
+
+jest-regex-util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4991.
+https://www.npmjs.com/package/jest-regex-util
+
+jest-resolve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7827.
+https://www.npmjs.com/package/jest-resolve
+
+jest-resolve-dependencies
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7733.
+https://www.npmjs.com/package/jest-resolve-dependencies
+
+jest-runner
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7734.
+https://www.npmjs.com/package/jest-runner
+
+jest-runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7735.
+https://www.npmjs.com/package/jest-runtime
+
+jest-snapshot
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7736.
+https://www.npmjs.com/package/jest-snapshot
+
+jest-util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7737.
+https://www.npmjs.com/package/jest-util
+
+jest-validate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7829.
+https://www.npmjs.com/package/jest-validate
+
+jiti
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12514.
+https://www.npmjs.com/package/jiti
+
+jodid25519
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:13240.
+https://www.npmjs.com/package/jodid25519
+
+joi
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2847.
+https://www.npmjs.com/package/joi
+
+jose
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1452.
+https://www.npmjs.com/package/jose
+
+js-base64
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3359.
+https://www.npmjs.com/package/js-base64
+
+js-beautify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2313.
+https://www.npmjs.com/package/js-beautify
+
+js-sha3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2875.
+https://www.npmjs.com/package/js-sha3
+
+js-tokens
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12532.
+https://www.npmjs.com/package/js-tokens
+
+js-yaml
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1461.
+https://www.npmjs.com/package/js-yaml
+
+jsbn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2340.
+https://www.npmjs.com/package/jsbn
+
+jsdom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7921.
+https://www.npmjs.com/package/jsdom
+
+jsesc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1054.
+https://www.npmjs.com/package/jsesc
+
+json-bigint
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1473.
+https://www.npmjs.com/package/json-bigint
+
+json-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8824.
+https://www.npmjs.com/package/json-loader
 
 json-rpc-client
 Copyright (c) 2014 Kristen Kozak
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/json-rpc-client.
+https://hackage.haskell.org/package/json-rpc-client
+
+json-rpc-engine
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:12567.
+https://www.npmjs.com/package/json-rpc-engine
+
+json-rpc-random-id
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:12586.
+https://www.npmjs.com/package/json-rpc-random-id
 
 json-rpc-server
 Copyright (c) 2013 Kristen Kozak
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/json-rpc-server.
+https://hackage.haskell.org/package/json-rpc-server
+
+json-schema
+Copyright information is provided by the upstream package authors.
+Licensed under the (AFL-2.1 OR BSD-3-Clause) License (per npm registry metadata).
+See apex/api/package-lock.json:2346.
+https://www.npmjs.com/package/json-schema
+
+json-schema-traverse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2351.
+https://www.npmjs.com/package/json-schema-traverse
+
+json-stable-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4515.
+https://www.npmjs.com/package/json-stable-stringify
 
 json-stream
 Copyright (c) 2015, Ondrej Palkovsky
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/json-stream.
+https://hackage.haskell.org/package/json-stream
+
+json-stringify-safe
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:2356.
+https://www.npmjs.com/package/json-stringify-safe
+
+json2mq
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12612.
+https://www.npmjs.com/package/json2mq
+
+json3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8857.
+https://www.npmjs.com/package/json3
+
+json5
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1012.
+https://www.npmjs.com/package/json5
+
+jsonfile
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2361.
+https://www.npmjs.com/package/jsonfile
+
+jsonify
+Copyright information is provided by the upstream package authors.
+Licensed under the Public Domain License (per npm registry metadata).
+See apex/api/package-lock.json:2369.
+https://www.npmjs.com/package/jsonify
+
+jsonpointer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7271.
+https://www.npmjs.com/package/jsonpointer
+
+jsonrepair
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:12621.
+https://www.npmjs.com/package/jsonrepair
+
+jsonwebtoken
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2887.
+https://www.npmjs.com/package/jsonwebtoken
+
+jsprim
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2377.
+https://www.npmjs.com/package/jsprim
+
+jsx-ast-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4694.
+https://www.npmjs.com/package/jsx-ast-utils
+
+jwa
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2915.
+https://www.npmjs.com/package/jwa
+
+jwk-to-pem
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2926.
+https://www.npmjs.com/package/jwk-to-pem
+
+jwks-rsa
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2937.
+https://www.npmjs.com/package/jwks-rsa
+
+jws
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2977.
+https://www.npmjs.com/package/jws
+
+jwt-decode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2391.
+https://www.npmjs.com/package/jwt-decode
+
+keccak
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12630.
+https://www.npmjs.com/package/keccak
+
+keyvaluestorage-interface
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12655.
+https://www.npmjs.com/package/keyvaluestorage-interface
+
+kind-of
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:502.
+https://www.npmjs.com/package/kind-of
+
+klaw
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8913.
+https://www.npmjs.com/package/klaw
+
+kuler
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1482.
+https://www.npmjs.com/package/kuler
 
 largeint
 Copyright Eitan Chatav (c) 2017
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/largeint.
+https://hackage.haskell.org/package/largeint
 
 largeword
 Copyright information in referenced file
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/largeword.
+https://hackage.haskell.org/package/largeword
+
+latest-version
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8922.
+https://www.npmjs.com/package/latest-version
+
+lazy-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2628.
+https://www.npmjs.com/package/lazy-cache
+
+lcid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2396.
+https://www.npmjs.com/package/lcid
 
 lens
 Copyright 2012-2016 Edward Kmett
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/lens.
+https://hackage.haskell.org/package/lens
 
 lens-family
 Copyright 2012,2013,2014 Russell O'Connor
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/lens-family.
+https://hackage.haskell.org/package/lens-family
 
 lens-family-th
 Copyright (c) 2012, Dan Burton
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/lens-family-th.
+https://hackage.haskell.org/package/lens-family-th
 
 leveldb-haskell
 Copyright (c) 2011, Kim Altintop
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/leveldb-haskell.
+https://hackage.haskell.org/package/leveldb-haskell
+
+leven
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8720.
+https://www.npmjs.com/package/leven
+
+levn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4516.
+https://www.npmjs.com/package/levn
 
 lifted-async
 Copyright (c) 2012-2017, Mitsutoshi Aoe
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/lifted-async.
+https://hackage.haskell.org/package/lifted-async
 
 lifted-base
 Copyright © 2010-2012, Bas van Dijk, Anders Kaseorg
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/lifted-base.
+https://hackage.haskell.org/package/lifted-base
+
+lilconfig
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12675.
+https://www.npmjs.com/package/lilconfig
+
+limiter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See mercata/services/bridge/package-lock.json:2996.
+https://www.npmjs.com/package/limiter
+
+lines-and-columns
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12687.
+https://www.npmjs.com/package/lines-and-columns
+
+lit
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:12693.
+https://www.npmjs.com/package/lit
+
+lit-element
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:12704.
+https://www.npmjs.com/package/lit-element
+
+lit-html
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:12715.
+https://www.npmjs.com/package/lit-html
+
+load-json-file
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2797.
+https://www.npmjs.com/package/load-json-file
+
+loader-fs-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4585.
+https://www.npmjs.com/package/loader-fs-cache
+
+loader-runner
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8985.
+https://www.npmjs.com/package/loader-runner
+
+loader-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1248.
+https://www.npmjs.com/package/loader-utils
+
+locate-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2407.
+https://www.npmjs.com/package/locate-path
+
+lodash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2427.
+https://www.npmjs.com/package/lodash
+
+lodash-es
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9034.
+https://www.npmjs.com/package/lodash-es
+
+lodash._reinterpolate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9039.
+https://www.npmjs.com/package/lodash._reinterpolate
+
+lodash.camelcase
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3335.
+https://www.npmjs.com/package/lodash.camelcase
+
+lodash.clonedeep
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3001.
+https://www.npmjs.com/package/lodash.clonedeep
+
+lodash.cond
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4650.
+https://www.npmjs.com/package/lodash.cond
+
+lodash.defaults
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9057.
+https://www.npmjs.com/package/lodash.defaults
+
+lodash.flattendeep
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9063.
+https://www.npmjs.com/package/lodash.flattendeep
+
+lodash.get
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1488.
+https://www.npmjs.com/package/lodash.get
+
+lodash.includes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3007.
+https://www.npmjs.com/package/lodash.includes
+
+lodash.isboolean
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3013.
+https://www.npmjs.com/package/lodash.isboolean
+
+lodash.isequal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1495.
+https://www.npmjs.com/package/lodash.isequal
+
+lodash.isinteger
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3019.
+https://www.npmjs.com/package/lodash.isinteger
+
+lodash.ismatch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9074.
+https://www.npmjs.com/package/lodash.ismatch
+
+lodash.isnumber
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3025.
+https://www.npmjs.com/package/lodash.isnumber
+
+lodash.isplainobject
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3031.
+https://www.npmjs.com/package/lodash.isplainobject
+
+lodash.isstring
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3037.
+https://www.npmjs.com/package/lodash.isstring
+
+lodash.memoize
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2432.
+https://www.npmjs.com/package/lodash.memoize
+
+lodash.mergewith
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1502.
+https://www.npmjs.com/package/lodash.mergewith
+
+lodash.once
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2437.
+https://www.npmjs.com/package/lodash.once
+
+lodash.template
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9091.
+https://www.npmjs.com/package/lodash.template
+
+lodash.templatesettings
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9098.
+https://www.npmjs.com/package/lodash.templatesettings
+
+lodash.uniq
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2576.
+https://www.npmjs.com/package/lodash.uniq
+
+logform
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1508.
+https://www.npmjs.com/package/logform
 
 logging-effect
 Copyright (c) 2016, Ollie Charles
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/logging-effect.
+https://hackage.haskell.org/package/logging-effect
+
+longest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:503.
+https://www.npmjs.com/package/longest
+
+loose-envify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12760.
+https://www.npmjs.com/package/loose-envify
+
+lottie-web
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12772.
+https://www.npmjs.com/package/lottie-web
+
+loud-rejection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9130.
+https://www.npmjs.com/package/loud-rejection
+
+lower-case
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9140.
+https://www.npmjs.com/package/lower-case
+
+lowercase-keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6256.
+https://www.npmjs.com/package/lowercase-keys
+
+lru-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:695.
+https://www.npmjs.com/package/lru-cache
+
+lru-memoizer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3061.
+https://www.npmjs.com/package/lru-memoizer
+
+lru-queue
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2450.
+https://www.npmjs.com/package/lru-queue
 
 lua-resty-jwt
 "Licensor" shall mean the copyright owner or entity authorized by
 Licensed under the Apache License, Version 2.0.
 See nginx-packager/licenses/lua-resty-jwt.
+https://www.npmjs.com/package/lua-resty-jwt
 
 lua-resty-openidc
 "Licensor" shall mean the copyright owner or entity authorized by
 Licensed under the Apache License, Version 2.0.
 See nginx-packager/licenses/lua-resty-openidc.
+https://www.npmjs.com/package/lua-resty-openidc
+
+lucide-react
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:12798.
+https://www.npmjs.com/package/lucide-react
+
+make-dir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3082.
+https://www.npmjs.com/package/make-dir
+
+makeerror
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:9179.
+https://www.npmjs.com/package/makeerror
+
+map-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5472.
+https://www.npmjs.com/package/map-cache
+
+map-obj
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2556.
+https://www.npmjs.com/package/map-obj
+
+map-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2458.
+https://www.npmjs.com/package/map-stream
+
+map-visit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2916.
+https://www.npmjs.com/package/map-visit
+
+math-expression-evaluator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9215.
+https://www.npmjs.com/package/math-expression-evaluator
+
+math-intrinsics
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1532.
+https://www.npmjs.com/package/math-intrinsics
+
+md5
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:12816.
+https://www.npmjs.com/package/md5
+
+md5.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3234.
+https://www.npmjs.com/package/md5.js
+
+media-query-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12827.
+https://www.npmjs.com/package/media-query-parser
+
+media-typer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2463.
+https://www.npmjs.com/package/media-typer
+
+mem
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2471.
+https://www.npmjs.com/package/mem
+
+memoizee
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:2482.
+https://www.npmjs.com/package/memoizee
 
 memory
 Copyright (c) 2015 Vincent Hanquez <vincent@snarc.org>
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/memory.
+https://hackage.haskell.org/package/memory
+
+memory-fs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4242.
+https://www.npmjs.com/package/memory-fs
+
+memory-streams
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2497.
+https://www.npmjs.com/package/memory-streams
+
+meow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9257.
+https://www.npmjs.com/package/meow
+
+merge
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4846.
+https://www.npmjs.com/package/merge
+
+merge-descriptors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2526.
+https://www.npmjs.com/package/merge-descriptors
+
+merge-options
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2531.
+https://www.npmjs.com/package/merge-options
+
+merge2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12836.
+https://www.npmjs.com/package/merge2
 
 merkle-patricia-db
 Copyright 2016 BlockApps, Inc
 Licensed under the Apache License, Version 2.0.
 See strato/extraFiles/strato/licenses/merkle-patricia-db.
+https://hackage.haskell.org/package/merkle-patricia-db
+
+methods
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2542.
+https://www.npmjs.com/package/methods
+
+micro-ftch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12845.
+https://www.npmjs.com/package/micro-ftch
+
+micromatch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12851.
+https://www.npmjs.com/package/micromatch
 
 milena
 Copyright (c)2014, Tyler Holien
 Licensed under the BSD License.
 See strato/libs/kafka/milena/LICENSE.
+https://github.com/BlockApps/milena
+
+miller-rabin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3989.
+https://www.npmjs.com/package/miller-rabin
+
+mime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2550.
+https://www.npmjs.com/package/mime
+
+mime-db
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2561.
+https://www.npmjs.com/package/mime-db
 
 mime-mail
 Copyright (c) 2014 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/mime-mail.
+https://hackage.haskell.org/package/mime-mail
+
+mime-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2569.
+https://www.npmjs.com/package/mime-types
+
+mimic-fn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2580.
+https://www.npmjs.com/package/mimic-fn
+
+min-document
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6187.
+https://www.npmjs.com/package/min-document
+
+minimalistic-assert
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3147.
+https://www.npmjs.com/package/minimalistic-assert
+
+minimalistic-crypto-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3153.
+https://www.npmjs.com/package/minimalistic-crypto-utils
+
+minimatch
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1531.
+https://www.npmjs.com/package/minimatch
+
+minimist
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1543.
+https://www.npmjs.com/package/minimist
+
+minipass
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1549.
+https://www.npmjs.com/package/minipass
+
+minizlib
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1559.
+https://www.npmjs.com/package/minizlib
+
+mipd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12898.
+https://www.npmjs.com/package/mipd
+
+mixin-deep
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2019.
+https://www.npmjs.com/package/mixin-deep
 
 mixpanel-browser
 Copyright 2015 Mixpanel, Inc.
 Licensed under the Apache License, Version 2.0.
 See smd-ui/licenses/mixpanel-browser.
+https://www.npmjs.com/package/mixpanel-browser
+
+mkdirp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1568.
+https://www.npmjs.com/package/mkdirp
 
 mmap
 Copyright (c) Gracjan Polak
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/mmap.
+https://hackage.haskell.org/package/mmap
 
 mocha
 Copyright (c) 2011-2018 JS Foundation and contributors, https://js.foundation
 Licensed under the MIT License.
 See apex/api/licenses/mocha.
+https://www.npmjs.com/package/mocha
+
+mock-socket
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9437.
+https://www.npmjs.com/package/mock-socket
+
+modern-ahocorasick
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12918.
+https://www.npmjs.com/package/modern-ahocorasick
 
 moment
 Copyright (c) JS Foundation and other contributors
 Licensed under the MIT License.
 See apex/api/licenses/moment.
+https://www.npmjs.com/package/moment
 
 moment-timezone
 Copyright (c) JS Foundation and other contributors
 Licensed under the MIT License.
 See smd-ui/licenses/moment-timezone.
+https://www.npmjs.com/package/moment-timezone
+
+monaco-editor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9456.
+https://www.npmjs.com/package/monaco-editor
 
 monaco-editor-vs-code
 Copyright (c) 2015 - present Microsoft Corporation
 Licensed under the MIT License.
 See smd-ui/public/vs/LICENSE.txt.
+https://www.npmjs.com/package/monaco-editor-vs-code
 
 monad-control
 Copyright © 2010, Bas van Dijk, Anders Kaseorg
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/monad-control.
+https://hackage.haskell.org/package/monad-control
 
 monad-logger
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/monad-logger.
+https://hackage.haskell.org/package/monad-logger
 
 monadIO
 Copyright (c) 2008-2010, Galois, Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/monadIO.
+https://hackage.haskell.org/package/monadIO
 
 morgan
 Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
 Licensed under the MIT License.
 See apex/api/licenses/morgan.
+https://www.npmjs.com/package/morgan
+
+ms
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1580.
+https://www.npmjs.com/package/ms
 
 mtl
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/mtl.
+https://hackage.haskell.org/package/mtl
+
+multiformats
+Copyright information is provided by the upstream package authors.
+Licensed under the (Apache-2.0 AND MIT) License (per package-lock metadata).
+See mercata/ui/package-lock.json:12930.
+https://www.npmjs.com/package/multiformats
 
 murmur-hash
 Copyright (c) 2010, Thomas Schilling
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/murmur-hash.
+https://hackage.haskell.org/package/murmur-hash
 
 murmur3
 In jurisdictions that recognize copyright laws, the author or authors
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/murmur3.
+https://hackage.haskell.org/package/murmur3
+
+mute-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See smd-ui/package-lock.json:9466.
+https://www.npmjs.com/package/mute-stream
+
+mz
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12936.
+https://www.npmjs.com/package/mz
+
+nan
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2735.
+https://www.npmjs.com/package/nan
+
+nanoid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12947.
+https://www.npmjs.com/package/nanoid
+
+nanomatch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9315.
+https://www.npmjs.com/package/nanomatch
+
+natural-compare
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4519.
+https://www.npmjs.com/package/natural-compare
+
+nearley
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9505.
+https://www.npmjs.com/package/nearley
+
+needle
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1586.
+https://www.npmjs.com/package/needle
+
+negotiator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2741.
+https://www.npmjs.com/package/negotiator
+
+neo-async
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:9523.
+https://www.npmjs.com/package/neo-async
+
+nested-property
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9529.
+https://www.npmjs.com/package/nested-property
 
 network
 Copyright (c) 2002-2010, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/network.
+https://hackage.haskell.org/package/network
 
 network-uri
 Copyright (c) 2002-2010, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/network-uri.
+https://hackage.haskell.org/package/network-uri
+
+next
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:12972.
+https://www.npmjs.com/package/next
+
+next-themes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13024.
+https://www.npmjs.com/package/next-themes
+
+next-tick
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:2749.
+https://www.npmjs.com/package/next-tick
 
 nibblestring
 Copyright (c) 2014, Jamshid
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/nibblestring.
+https://hackage.haskell.org/package/nibblestring
+
+no-case
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2539.
+https://www.npmjs.com/package/no-case
+
+node-addon-api
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13071.
+https://www.npmjs.com/package/node-addon-api
+
+node-cron
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See mercata/services/oracle/package-lock.json:2224.
+https://www.npmjs.com/package/node-cron
+
+node-fetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3193.
+https://www.npmjs.com/package/node-fetch
+
+node-fetch-native
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13097.
+https://www.npmjs.com/package/node-fetch-native
+
+node-gyp-build
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:3213.
+https://www.npmjs.com/package/node-gyp-build
+
+node-int64
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2427.
+https://www.npmjs.com/package/node-int64
+
+node-libs-browser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9564.
+https://www.npmjs.com/package/node-libs-browser
+
+node-mock-http
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13114.
+https://www.npmjs.com/package/node-mock-http
+
+node-notifier
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7739.
+https://www.npmjs.com/package/node-notifier
+
+node-pre-gyp
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:1603.
+https://www.npmjs.com/package/node-pre-gyp
+
+nodemailer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT-0 License (per npm registry metadata).
+See apex/api/package-lock.json:2754.
+https://www.npmjs.com/package/nodemailer
+
+nomnom
+Upstream author (npm metadata): Heather Arthur <fayearthur@gmail.com>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See smd-ui/package-lock.json:9511.
+https://www.npmjs.com/package/nomnom
+
+nopt
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1624.
+https://www.npmjs.com/package/nopt
 
 normaldistribution
 Copyright (c) 2011, Bjorn Buckwalter.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/normaldistribution.
+https://hackage.haskell.org/package/normaldistribution
+
+normalize-package-data
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:2762.
+https://www.npmjs.com/package/normalize-package-data
+
+normalize-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13127.
+https://www.npmjs.com/package/normalize-path
+
+normalize-range
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:956.
+https://www.npmjs.com/package/normalize-range
+
+normalize-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9652.
+https://www.npmjs.com/package/normalize-url
+
+normalize.css
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:30.
+https://www.npmjs.com/package/normalize.css
+
+npm-bundled
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1637.
+https://www.npmjs.com/package/npm-bundled
+
+npm-packlist
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1643.
+https://www.npmjs.com/package/npm-packlist
+
+npm-run-all
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2773.
+https://www.npmjs.com/package/npm-run-all
+
+npm-run-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2843.
+https://www.npmjs.com/package/npm-run-path
+
+npmlog
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1653.
+https://www.npmjs.com/package/npmlog
+
+nth-check
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3384.
+https://www.npmjs.com/package/nth-check
+
+num2fraction
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:957.
+https://www.npmjs.com/package/num2fraction
+
+number-is-nan
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1665.
+https://www.npmjs.com/package/number-is-nan
+
+nwmatcher
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8798.
+https://www.npmjs.com/package/nwmatcher
+
+oauth-sign
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See apex/api/package-lock.json:2862.
+https://www.npmjs.com/package/oauth-sign
+
+obj-multiplex
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:13136.
+https://www.npmjs.com/package/obj-multiplex
+
+object-assign
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1674.
+https://www.npmjs.com/package/object-assign
+
+object-component
+Upstream author (npm metadata): tjholowaychuk <tj@vision-media.ca>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See apex/api/package-lock.json:2878.
+https://www.npmjs.com/package/object-component
+
+object-copy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9788.
+https://www.npmjs.com/package/object-copy
+
+object-hash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13192.
+https://www.npmjs.com/package/object-hash
+
+object-inspect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1652.
+https://www.npmjs.com/package/object-inspect
+
+object-is
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4269.
+https://www.npmjs.com/package/object-is
+
+object-keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2883.
+https://www.npmjs.com/package/object-keys
+
+object-visit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2917.
+https://www.npmjs.com/package/object-visit
+
+object.assign
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:688.
+https://www.npmjs.com/package/object.assign
+
+object.entries
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4271.
+https://www.npmjs.com/package/object.entries
+
+object.omit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6830.
+https://www.npmjs.com/package/object.omit
+
+object.pick
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9316.
+https://www.npmjs.com/package/object.pick
+
+object.values
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4272.
+https://www.npmjs.com/package/object.values
+
+obuf
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6563.
+https://www.npmjs.com/package/obuf
+
+ofetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13201.
+https://www.npmjs.com/package/ofetch
+
+on-exit-leak-free
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13212.
+https://www.npmjs.com/package/on-exit-leak-free
+
+on-finished
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2891.
+https://www.npmjs.com/package/on-finished
+
+on-headers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2902.
+https://www.npmjs.com/package/on-headers
+
+once
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1683.
+https://www.npmjs.com/package/once
+
+one-time
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1685.
+https://www.npmjs.com/package/one-time
+
+onetime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9933.
+https://www.npmjs.com/package/onetime
 
 opaleye
 Copyright (c) 2014-2018 Purely Agile Limited
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/opaleye.
+https://hackage.haskell.org/package/opaleye
+
+openapi-fetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13227.
+https://www.npmjs.com/package/openapi-fetch
+
+openapi-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1694.
+https://www.npmjs.com/package/openapi-types
+
+openapi-typescript-helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13236.
+https://www.npmjs.com/package/openapi-typescript-helpers
+
+opn
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9939.
+https://www.npmjs.com/package/opn
+
+optimist
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT/X11 License (per npm registry metadata).
+See smd-ui/package-lock.json:6302.
+https://www.npmjs.com/package/optimist
+
+optional
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2918.
+https://www.npmjs.com/package/optional
+
+optionator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4459.
+https://www.npmjs.com/package/optionator
 
 optparse-applicative
 Copyright (c) 2012, Paolo Capriotti
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/optparse-applicative.
+https://hackage.haskell.org/package/optparse-applicative
 
 ordered-containers
 Copyright (c) 2016, Daniel Wagner
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/ordered-containers.
+https://hackage.haskell.org/package/ordered-containers
+
+original
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4827.
+https://www.npmjs.com/package/original
+
+os-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9579.
+https://www.npmjs.com/package/os-browserify
+
+os-homedir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1692.
+https://www.npmjs.com/package/os-homedir
+
+os-locale
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4507.
+https://www.npmjs.com/package/os-locale
+
+os-tmpdir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1701.
+https://www.npmjs.com/package/os-tmpdir
+
+osenv
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1710.
+https://www.npmjs.com/package/osenv
+
+ox
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:5995.
+https://www.npmjs.com/package/ox
+
+p-cancelable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8052.
+https://www.npmjs.com/package/p-cancelable
+
+p-finally
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2923.
+https://www.npmjs.com/package/p-finally
+
+p-limit
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2931.
+https://www.npmjs.com/package/p-limit
+
+p-locate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2942.
+https://www.npmjs.com/package/p-locate
+
+p-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:10048.
+https://www.npmjs.com/package/p-map
+
+p-queue
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2266.
+https://www.npmjs.com/package/p-queue
+
+p-retry
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2288.
+https://www.npmjs.com/package/p-retry
+
+p-timeout
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2301.
+https://www.npmjs.com/package/p-timeout
+
+p-try
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2953.
+https://www.npmjs.com/package/p-try
+
+package-json
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8928.
+https://www.npmjs.com/package/package-json
+
+packet-reader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2961.
+https://www.npmjs.com/package/packet-reader
+
+pako
+Copyright information is provided by the upstream package authors.
+Licensed under the (MIT AND Zlib) License (per npm registry metadata).
+See smd-ui/package-lock.json:2408.
+https://www.npmjs.com/package/pako
+
+param-case
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6599.
+https://www.npmjs.com/package/param-case
+
+parse-asn1
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:2372.
+https://www.npmjs.com/package/parse-asn1
+
+parse-glob
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6831.
+https://www.npmjs.com/package/parse-glob
+
+parse-json
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2966.
+https://www.npmjs.com/package/parse-json
+
+parse-passwd
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6547.
+https://www.npmjs.com/package/parse-passwd
+
+parse5
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2666.
+https://www.npmjs.com/package/parse5
 
 parsec
 Copyright 1999-2000, Daan Leijen; 2007, Paolo Martini. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/parsec.
+https://hackage.haskell.org/package/parsec
 
 parsec3-numbers
 Copyright information in referenced file
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/parsec3-numbers.
+https://hackage.haskell.org/package/parsec3-numbers
+
+parseqs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2977.
+https://www.npmjs.com/package/parseqs
+
+parseuri
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2985.
+https://www.npmjs.com/package/parseuri
+
+parseurl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2993.
+https://www.npmjs.com/package/parseurl
+
+pascalcase
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2020.
+https://www.npmjs.com/package/pascalcase
 
 path
 Copyright (c) 2014 Hage Yaapa <[http://www.hacksparrow.com](http://www.hacksparrow.com)>
 Licensed under the MIT License.
 See apex/api/licenses/path.
+https://www.npmjs.com/package/path
+
+path-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9580.
+https://www.npmjs.com/package/path-browserify
+
+path-dirname
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10170.
+https://www.npmjs.com/package/path-dirname
+
+path-exists
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2419.
+https://www.npmjs.com/package/path-exists
+
+path-is-absolute
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1720.
+https://www.npmjs.com/package/path-is-absolute
+
+path-is-inside
+Copyright information is provided by the upstream package authors.
+Licensed under the (WTFPL OR MIT) License (per npm registry metadata).
+See smd-ui/package-lock.json:4521.
+https://www.npmjs.com/package/path-is-inside
+
+path-key
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3018.
+https://www.npmjs.com/package/path-key
+
+path-parse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3026.
+https://www.npmjs.com/package/path-parse
 
 path-pieces
 Copyright 2009, Michael Snoyman. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/path-pieces.
+https://hackage.haskell.org/package/path-pieces
+
+path-to-regexp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3031.
+https://www.npmjs.com/package/path-to-regexp
+
+path-type
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2811.
+https://www.npmjs.com/package/path-type
+
+pathval
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3036.
+https://www.npmjs.com/package/pathval
+
+pause-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT OR Apache2 License (per npm registry metadata).
+See apex/api/package-lock.json:3044.
+https://www.npmjs.com/package/pause-stream
 
 pbkdf
 Copyright 2001-2005, Chris Dornan
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/pbkdf.
+https://hackage.haskell.org/package/pbkdf
+
+pbkdf2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3307.
+https://www.npmjs.com/package/pbkdf2
+
+performance-now
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3052.
+https://www.npmjs.com/package/performance-now
 
 persistent
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/persistent.
+https://hackage.haskell.org/package/persistent
 
 persistent-postgresql
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/persistent-postgresql.
+https://hackage.haskell.org/package/persistent-postgresql
 
 persistent-template
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/persistent-template.
+https://hackage.haskell.org/package/persistent-template
 
 pg
 Copyright (c) 2010 - 2018 Brian Carlson
 Licensed under the MIT License.
 See apex/api/licenses/pg.
+https://www.npmjs.com/package/pg
+
+pg-cloudflare
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3085.
+https://www.npmjs.com/package/pg-cloudflare
+
+pg-connection-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3091.
+https://www.npmjs.com/package/pg-connection-string
 
 pg-hstore
 Copyright (c) 2014 Hage Yaapa <[http://www.hacksparrow.com](http://www.hacksparrow.com)>
 Licensed under the MIT License.
 See apex/api/licenses/pg-hstore.
+https://www.npmjs.com/package/pg-hstore
+
+pg-int8
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3096.
+https://www.npmjs.com/package/pg-int8
+
+pg-pool
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3104.
+https://www.npmjs.com/package/pg-pool
+
+pg-protocol
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3112.
+https://www.npmjs.com/package/pg-protocol
+
+pg-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3117.
+https://www.npmjs.com/package/pg-types
+
+pgpass
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3132.
+https://www.npmjs.com/package/pgpass
 
 pgtools
 Copyright (c) 2010 - 2018 Brian Carlson
 Licensed under the MIT License.
 See apex/api/licenses/pgtools.
+https://www.npmjs.com/package/pgtools
+
+picocolors
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:13408.
+https://www.npmjs.com/package/picocolors
+
+picomatch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13414.
+https://www.npmjs.com/package/picomatch
+
+pify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3289.
+https://www.npmjs.com/package/pify
+
+pinkie
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10266.
+https://www.npmjs.com/package/pinkie
+
+pinkie-promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3929.
+https://www.npmjs.com/package/pinkie-promise
+
+pino
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13435.
+https://www.npmjs.com/package/pino
+
+pino-abstract-transport
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13457.
+https://www.npmjs.com/package/pino-abstract-transport
+
+pino-std-serializers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13467.
+https://www.npmjs.com/package/pino-std-serializers
+
+pirates
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13473.
+https://www.npmjs.com/package/pirates
+
+pkg-dir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4599.
+https://www.npmjs.com/package/pkg-dir
+
+pkg-up
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4652.
+https://www.npmjs.com/package/pkg-up
 
 plottable
 Copyright (c) 2014-2015 Palantir Technologies, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/plottable.
+https://www.npmjs.com/package/plottable
+
+pluralize
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4522.
+https://www.npmjs.com/package/pluralize
+
+pngjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13482.
+https://www.npmjs.com/package/pngjs
+
+pony-cause
+Copyright information is provided by the upstream package authors.
+Licensed under the 0BSD License (per package-lock metadata).
+See mercata/ui/package-lock.json:13491.
+https://www.npmjs.com/package/pony-cause
+
+popper.js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:72.
+https://www.npmjs.com/package/popper.js
+
+portfinder
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10362.
+https://www.npmjs.com/package/portfinder
+
+porto
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8217.
+https://www.npmjs.com/package/porto
+
+posix-character-classes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4879.
+https://www.npmjs.com/package/posix-character-classes
+
+possible-typed-array-names
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13500.
+https://www.npmjs.com/package/possible-typed-array-names
+
+postcss
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13043.
+https://www.npmjs.com/package/postcss
+
+postcss-calc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3421.
+https://www.npmjs.com/package/postcss-calc
+
+postcss-colormin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3422.
+https://www.npmjs.com/package/postcss-colormin
+
+postcss-convert-values
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3423.
+https://www.npmjs.com/package/postcss-convert-values
+
+postcss-discard-comments
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3424.
+https://www.npmjs.com/package/postcss-discard-comments
+
+postcss-discard-duplicates
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3425.
+https://www.npmjs.com/package/postcss-discard-duplicates
+
+postcss-discard-empty
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3426.
+https://www.npmjs.com/package/postcss-discard-empty
+
+postcss-discard-overridden
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3427.
+https://www.npmjs.com/package/postcss-discard-overridden
+
+postcss-discard-unused
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3428.
+https://www.npmjs.com/package/postcss-discard-unused
+
+postcss-filter-plugins
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3429.
+https://www.npmjs.com/package/postcss-filter-plugins
+
+postcss-flexbugs-fixes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10822.
+https://www.npmjs.com/package/postcss-flexbugs-fixes
+
+postcss-import
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13537.
+https://www.npmjs.com/package/postcss-import
+
+postcss-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13554.
+https://www.npmjs.com/package/postcss-js
+
+postcss-load-config
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13579.
+https://www.npmjs.com/package/postcss-load-config
+
+postcss-load-options
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10839.
+https://www.npmjs.com/package/postcss-load-options
+
+postcss-load-plugins
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10840.
+https://www.npmjs.com/package/postcss-load-plugins
+
+postcss-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10863.
+https://www.npmjs.com/package/postcss-loader
+
+postcss-merge-idents
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3430.
+https://www.npmjs.com/package/postcss-merge-idents
+
+postcss-merge-longhand
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3431.
+https://www.npmjs.com/package/postcss-merge-longhand
+
+postcss-merge-rules
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3432.
+https://www.npmjs.com/package/postcss-merge-rules
+
+postcss-message-helpers
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10481.
+https://www.npmjs.com/package/postcss-message-helpers
+
+postcss-minify-font-values
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3433.
+https://www.npmjs.com/package/postcss-minify-font-values
+
+postcss-minify-gradients
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3434.
+https://www.npmjs.com/package/postcss-minify-gradients
+
+postcss-minify-params
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3435.
+https://www.npmjs.com/package/postcss-minify-params
+
+postcss-minify-selectors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3436.
+https://www.npmjs.com/package/postcss-minify-selectors
+
+postcss-modules-extract-imports
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3338.
+https://www.npmjs.com/package/postcss-modules-extract-imports
+
+postcss-modules-local-by-default
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3339.
+https://www.npmjs.com/package/postcss-modules-local-by-default
+
+postcss-modules-scope
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3340.
+https://www.npmjs.com/package/postcss-modules-scope
+
+postcss-modules-values
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:3341.
+https://www.npmjs.com/package/postcss-modules-values
+
+postcss-nested
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13621.
+https://www.npmjs.com/package/postcss-nested
+
+postcss-normalize-charset
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3437.
+https://www.npmjs.com/package/postcss-normalize-charset
+
+postcss-normalize-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3438.
+https://www.npmjs.com/package/postcss-normalize-url
+
+postcss-ordered-values
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3439.
+https://www.npmjs.com/package/postcss-ordered-values
+
+postcss-reduce-idents
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3440.
+https://www.npmjs.com/package/postcss-reduce-idents
+
+postcss-reduce-initial
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3441.
+https://www.npmjs.com/package/postcss-reduce-initial
+
+postcss-reduce-transforms
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3442.
+https://www.npmjs.com/package/postcss-reduce-transforms
+
+postcss-selector-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13646.
+https://www.npmjs.com/package/postcss-selector-parser
+
+postcss-svgo
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3443.
+https://www.npmjs.com/package/postcss-svgo
+
+postcss-unique-selectors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3444.
+https://www.npmjs.com/package/postcss-unique-selectors
+
+postcss-value-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13673.
+https://www.npmjs.com/package/postcss-value-parser
+
+postcss-zindex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3446.
+https://www.npmjs.com/package/postcss-zindex
+
+postgres-array
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3297.
+https://www.npmjs.com/package/postgres-array
+
+postgres-bytea
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3305.
+https://www.npmjs.com/package/postgres-bytea
+
+postgres-date
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3313.
+https://www.npmjs.com/package/postgres-date
+
+postgres-interval
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3321.
+https://www.npmjs.com/package/postgres-interval
 
 postgresql-simple
 Copyright (c) 2011, Leon P Smith
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/postgresql-simple.
+https://hackage.haskell.org/package/postgresql-simple
 
 postgrest
 Copyright (c) 2014 Joe Nelson
 Licensed under the MIT License.
 See postgrest-packager/licenses/postgrest.
+https://www.npmjs.com/package/postgrest
+
+preact
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13679.
+https://www.npmjs.com/package/preact
+
+prelude-ls
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:8958.
+https://www.npmjs.com/package/prelude-ls
+
+prepend-http
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9659.
+https://www.npmjs.com/package/prepend-http
+
+preserve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6760.
+https://www.npmjs.com/package/preserve
+
+pretty-bytes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11602.
+https://www.npmjs.com/package/pretty-bytes
+
+pretty-error
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6646.
+https://www.npmjs.com/package/pretty-error
+
+pretty-format
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7830.
+https://www.npmjs.com/package/pretty-format
+
+private
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1016.
+https://www.npmjs.com/package/private
 
 process
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/process.
+https://hackage.haskell.org/package/process
+
+process-nextick-args
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1729.
+https://www.npmjs.com/package/process-nextick-args
+
+process-warning
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13705.
+https://www.npmjs.com/package/process-warning
 
 product-profunctors
 Copyright (c) 2013, Karamaan Group LLC; 2014-2018 Purely Agile Limited
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/product-profunctors.
+https://hackage.haskell.org/package/product-profunctors
 
 profunctors
 Copyright 2011-2015 Edward Kmett
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/profunctors.
+https://hackage.haskell.org/package/profunctors
+
+progress
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4523.
+https://www.npmjs.com/package/progress
+
+prom-client
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See apex/api/package-lock.json:3345.
+https://www.npmjs.com/package/prom-client
 
 prometheus-packager
 Copyright 2012-2015 The Prometheus Authors
 Licensed under the Apache License, Version 2.0.
 See prometheus-packager/NOTICE.
+https://www.npmjs.com/package/prometheus-packager
+
+promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3357.
+https://www.npmjs.com/package/promise
+
+prop-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13711.
+https://www.npmjs.com/package/prop-types
+
+proto-list
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3365.
+https://www.npmjs.com/package/proto-list
+
+proxy-addr
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3370.
+https://www.npmjs.com/package/proxy-addr
+
+proxy-compare
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13728.
+https://www.npmjs.com/package/proxy-compare
+
+proxy-from-env
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1761.
+https://www.npmjs.com/package/proxy-from-env
+
+prr
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4305.
+https://www.npmjs.com/package/prr
+
+ps-tree
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3382.
+https://www.npmjs.com/package/ps-tree
+
+pseudomap
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3393.
+https://www.npmjs.com/package/pseudomap
+
+public-encrypt
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3308.
+https://www.npmjs.com/package/public-encrypt
+
+pump
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13740.
+https://www.npmjs.com/package/pump
+
+punycode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:67.
+https://www.npmjs.com/package/punycode
+
+pure-render-decorator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:31.
+https://www.npmjs.com/package/pure-render-decorator
+
+pvtsutils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6079.
+https://www.npmjs.com/package/pvtsutils
+
+pvutils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6089.
+https://www.npmjs.com/package/pvutils
+
+q
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2901.
+https://www.npmjs.com/package/q
+
+qr
+Copyright information is provided by the upstream package authors.
+Licensed under the (MIT OR Apache-2.0) License (per package-lock metadata).
+See mercata/ui/package-lock.json:13760.
+https://www.npmjs.com/package/qr
+
+qrcode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13769.
+https://www.npmjs.com/package/qrcode
+
+qs
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See apex/api/package-lock.json:3403.
+https://www.npmjs.com/package/qs
 
 query-string
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Licensed under the MIT License.
 See smd-ui/licenses/query-string.
+https://www.npmjs.com/package/query-string
+
+querystring
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3411.
+https://www.npmjs.com/package/querystring
+
+querystring-es3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9583.
+https://www.npmjs.com/package/querystring-es3
+
+querystringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11785.
+https://www.npmjs.com/package/querystringify
+
+queue-microtask
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13805.
+https://www.npmjs.com/package/queue-microtask
+
+quick-format-unescaped
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13825.
+https://www.npmjs.com/package/quick-format-unescaped
 
 QuickCheck
 Copyright (c) 2000-2017, Koen Claessen
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/QuickCheck.
+https://hackage.haskell.org/package/QuickCheck
 
 quickcheck-instances
 Copyright (c)2012, Antoine Latter
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/quickcheck-instances.
+https://hackage.haskell.org/package/quickcheck-instances
+
+radix3
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13831.
+https://www.npmjs.com/package/radix3
+
+raf
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4273.
+https://www.npmjs.com/package/raf
+
+rafl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11800.
+https://www.npmjs.com/package/rafl
+
+railroad-diagrams
+Copyright information is provided by the upstream package authors.
+Licensed under the CC0-1.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:9512.
+https://www.npmjs.com/package/railroad-diagrams
+
+randexp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9513.
+https://www.npmjs.com/package/randexp
 
 random
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/random.
+https://hackage.haskell.org/package/random
+
+randomatic
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4931.
+https://www.npmjs.com/package/randomatic
+
+randombytes
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2357.
+https://www.npmjs.com/package/randombytes
+
+randomfill
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3310.
+https://www.npmjs.com/package/randomfill
+
+range-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3420.
+https://www.npmjs.com/package/range-parser
 
 rapidsnark
 Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
 Licensed under the GNU Lesser General Public License.
 See strato/libs/groth16-rapidsnark/vendor/rapidsnark/COPYING.
+https://github.com/iden3/rapidsnark
+
+raw-body
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3428.
+https://www.npmjs.com/package/raw-body
 
 raw-strings-qq
 Copyright (c) 2013, Mikhail Glushenkov
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/raw-strings-qq.
+https://hackage.haskell.org/package/raw-strings-qq
+
+rc
+Copyright information is provided by the upstream package authors.
+Licensed under the (BSD-2-Clause OR MIT OR Apache-2.0) License (per package-lock metadata).
+See apex/api/package-lock.json:1735.
+https://www.npmjs.com/package/rc
+
+rc-cascader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13837.
+https://www.npmjs.com/package/rc-cascader
+
+rc-checkbox
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13854.
+https://www.npmjs.com/package/rc-checkbox
+
+rc-collapse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13869.
+https://www.npmjs.com/package/rc-collapse
+
+rc-dialog
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13885.
+https://www.npmjs.com/package/rc-dialog
+
+rc-drawer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13902.
+https://www.npmjs.com/package/rc-drawer
+
+rc-dropdown
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13919.
+https://www.npmjs.com/package/rc-dropdown
+
+rc-field-form
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13935.
+https://www.npmjs.com/package/rc-field-form
+
+rc-image
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13953.
+https://www.npmjs.com/package/rc-image
+
+rc-input
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13971.
+https://www.npmjs.com/package/rc-input
+
+rc-input-number
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13986.
+https://www.npmjs.com/package/rc-input-number
+
+rc-mentions
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14003.
+https://www.npmjs.com/package/rc-mentions
+
+rc-menu
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14022.
+https://www.npmjs.com/package/rc-menu
+
+rc-motion
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14040.
+https://www.npmjs.com/package/rc-motion
+
+rc-notification
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14055.
+https://www.npmjs.com/package/rc-notification
+
+rc-overflow
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14074.
+https://www.npmjs.com/package/rc-overflow
+
+rc-pagination
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14090.
+https://www.npmjs.com/package/rc-pagination
+
+rc-picker
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14105.
+https://www.npmjs.com/package/rc-picker
+
+rc-progress
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14144.
+https://www.npmjs.com/package/rc-progress
+
+rc-rate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14159.
+https://www.npmjs.com/package/rc-rate
+
+rc-resize-observer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14177.
+https://www.npmjs.com/package/rc-resize-observer
+
+rc-segmented
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14193.
+https://www.npmjs.com/package/rc-segmented
+
+rc-select
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14209.
+https://www.npmjs.com/package/rc-select
+
+rc-slider
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14231.
+https://www.npmjs.com/package/rc-slider
+
+rc-steps
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14249.
+https://www.npmjs.com/package/rc-steps
+
+rc-switch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14267.
+https://www.npmjs.com/package/rc-switch
+
+rc-table
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14282.
+https://www.npmjs.com/package/rc-table
+
+rc-tabs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14303.
+https://www.npmjs.com/package/rc-tabs
+
+rc-textarea
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14325.
+https://www.npmjs.com/package/rc-textarea
+
+rc-tooltip
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14342.
+https://www.npmjs.com/package/rc-tooltip
+
+rc-tree
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14358.
+https://www.npmjs.com/package/rc-tree
+
+rc-tree-select
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14378.
+https://www.npmjs.com/package/rc-tree-select
+
+rc-upload
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14395.
+https://www.npmjs.com/package/rc-upload
+
+rc-util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14410.
+https://www.npmjs.com/package/rc-util
+
+rc-virtual-list
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14424.
+https://www.npmjs.com/package/rc-virtual-list
 
 react
 Copyright (c) 2013-present, Facebook, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/react.
+https://www.npmjs.com/package/react
 
 react-addons-css-transition-group
 Copyright (c) 2013-present, Facebook, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/react-addons-css-transition-group.
+https://www.npmjs.com/package/react-addons-css-transition-group
 
 react-copy-to-clipboard
 Copyright (c) 2016 Nik Butenko
 Licensed under the MIT License.
 See smd-ui/licenses/react-copy-to-clipboard.
+https://www.npmjs.com/package/react-copy-to-clipboard
+
+react-day-picker
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14455.
+https://www.npmjs.com/package/react-day-picker
+
+react-dev-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11962.
+https://www.npmjs.com/package/react-dev-utils
 
 react-dom
 Copyright (c) 2013-present, Facebook, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/react-dom.
+https://www.npmjs.com/package/react-dom
 
 react-dropzone
 Copyright (c) 2014 Param Aggarwal
 Licensed under the MIT License.
 See smd-ui/licenses/react-dropzone.
+https://www.npmjs.com/package/react-dropzone
+
+react-error-overlay
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12106.
+https://www.npmjs.com/package/react-error-overlay
+
+react-ga4
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12363.
+https://www.npmjs.com/package/react-ga4
+
+react-hook-form
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14482.
+https://www.npmjs.com/package/react-hook-form
+
+react-is
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:13722.
+https://www.npmjs.com/package/react-is
 
 react-joyride
 Copyright (c) 2015, Gil Barbara
 Licensed under the MIT License.
 See smd-ui/licenses/react-joyride.
+https://www.npmjs.com/package/react-joyride
+
+react-lifecycles-compat
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:73.
+https://www.npmjs.com/package/react-lifecycles-compat
 
 react-loading
 Copyright information in referenced file
 Licensed under terms in the referenced file.
 See smd-ui/licenses/react-loading.
+https://www.npmjs.com/package/react-loading
+
+react-lottie-player
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14504.
+https://www.npmjs.com/package/react-lottie-player
 
 react-monaco-editor
 Copyright (c) 2016-present Leon Shi
 Licensed under the MIT License.
 See smd-ui/licenses/react-monaco-editor.
+https://www.npmjs.com/package/react-monaco-editor
+
+react-number-format
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14521.
+https://www.npmjs.com/package/react-number-format
+
+react-popper
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:74.
+https://www.npmjs.com/package/react-popper
 
 react-redux
 Copyright (c) 2015-present Dan Abramov
 Licensed under the MIT License.
 See smd-ui/licenses/react-redux.
+https://www.npmjs.com/package/react-redux
+
+react-redux-loading-bar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12452.
+https://www.npmjs.com/package/react-redux-loading-bar
+
+react-remove-scroll
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4257.
+https://www.npmjs.com/package/react-remove-scroll
+
+react-remove-scroll-bar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14556.
+https://www.npmjs.com/package/react-remove-scroll-bar
+
+react-resizable-panels
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14578.
+https://www.npmjs.com/package/react-resizable-panels
+
+react-router
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14588.
+https://www.npmjs.com/package/react-router
 
 react-router-dom
 Copyright (c) React Training 2016-2018
 Licensed under the MIT License.
 See smd-ui/licenses/react-router-dom.
+https://www.npmjs.com/package/react-router-dom
 
 react-router-redux
 Copyright (c) 2015-present James Long
 Licensed under the MIT License.
 See smd-ui/licenses/react-router-redux.
+https://www.npmjs.com/package/react-router-redux
+
+react-scripts
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12505.
+https://www.npmjs.com/package/react-scripts
+
+react-smooth
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14620.
+https://www.npmjs.com/package/react-smooth
+
+react-style-singleton
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14635.
+https://www.npmjs.com/package/react-style-singleton
+
+react-test-renderer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14180.
+https://www.npmjs.com/package/react-test-renderer
+
+react-transition-group
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:14657.
+https://www.npmjs.com/package/react-transition-group
+
+read-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14673.
+https://www.npmjs.com/package/read-cache
+
+read-pkg
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:2822.
+https://www.npmjs.com/package/read-pkg
+
+read-pkg-up
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4544.
+https://www.npmjs.com/package/read-pkg-up
+
+readable-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1756.
+https://www.npmjs.com/package/readable-stream
+
+readdirp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4837.
+https://www.npmjs.com/package/readdirp
+
+readline2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6979.
+https://www.npmjs.com/package/readline2
+
+real-require
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14708.
+https://www.npmjs.com/package/real-require
+
+recharts
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14717.
+https://www.npmjs.com/package/recharts
+
+recharts-scale
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14740.
+https://www.npmjs.com/package/recharts-scale
+
+rechoir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14306.
+https://www.npmjs.com/package/rechoir
+
+recursive-readdir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:11980.
+https://www.npmjs.com/package/recursive-readdir
+
+redent
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9271.
+https://www.npmjs.com/package/redent
+
+reduce-css-calc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10482.
+https://www.npmjs.com/package/reduce-css-calc
+
+reduce-function-call
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14353.
+https://www.npmjs.com/package/reduce-function-call
 
 redux
 Copyright (c) 2015-present Dan Abramov
 Licensed under the MIT License.
 See smd-ui/licenses/redux.
+https://www.npmjs.com/package/redux
 
 redux-form
 Copyright (c) 2015 Erik Rasmussen
 Licensed under the MIT License.
 See smd-ui/licenses/redux-form.
+https://www.npmjs.com/package/redux-form
+
+redux-mock-store
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14399.
+https://www.npmjs.com/package/redux-mock-store
 
 redux-saga
 Copyright (c) 2015 Yassine Elouafi
 Licensed under the MIT License.
 See smd-ui/licenses/redux-saga.
+https://www.npmjs.com/package/redux-saga
 
 redux-saga-test-plan
 Copyright (c) 2016 Jeremy Fairbank
 Licensed under the MIT License.
 See smd-ui/licenses/redux-saga-test-plan.
+https://www.npmjs.com/package/redux-saga-test-plan
 
 redux-saga-testing
 Copyright (c) 2016 Antoine Jaussoin
 Licensed under the MIT License.
 See smd-ui/licenses/redux-saga-testing.
+https://www.npmjs.com/package/redux-saga-testing
+
+regenerate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14433.
+https://www.npmjs.com/package/regenerate
+
+regenerator-runtime
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3456.
+https://www.npmjs.com/package/regenerator-runtime
+
+regenerator-transform
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1726.
+https://www.npmjs.com/package/regenerator-transform
+
+regex-cache
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6832.
+https://www.npmjs.com/package/regex-cache
+
+regex-not
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4880.
+https://www.npmjs.com/package/regex-not
+
+regexp.prototype.flags
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12420.
+https://www.npmjs.com/package/regexp.prototype.flags
+
+regexpu-core
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1637.
+https://www.npmjs.com/package/regexpu-core
+
+registry-auth-token
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10067.
+https://www.npmjs.com/package/registry-auth-token
+
+registry-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10068.
+https://www.npmjs.com/package/registry-url
+
+regjsgen
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14506.
+https://www.npmjs.com/package/regjsgen
+
+regjsparser
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:14507.
+https://www.npmjs.com/package/regjsparser
 
 relapse
 Copyright (c) 2016 Ilya Ostrovskiy
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/relapse.
+https://hackage.haskell.org/package/relapse
+
+relateurl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6600.
+https://www.npmjs.com/package/relateurl
+
+remove-trailing-separator
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:9643.
+https://www.npmjs.com/package/remove-trailing-separator
+
+renderkid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11615.
+https://www.npmjs.com/package/renderkid
+
+repeat-element
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2280.
+https://www.npmjs.com/package/repeat-element
+
+repeat-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:504.
+https://www.npmjs.com/package/repeat-string
+
+repeating
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3967.
+https://www.npmjs.com/package/repeating
 
 request
 "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
 Licensed under terms in the referenced file.
 See apex/api/licenses/request.
+https://www.npmjs.com/package/request
 
 request-promise
 Copyright (c) 2017, Nicolai Kamenzky, Ty Abonil, and contributors
 Licensed under the ISC License.
 See apex/api/licenses/request-promise.
+https://www.npmjs.com/package/request-promise
+
+request-promise-core
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3512.
+https://www.npmjs.com/package/request-promise-core
+
+require-directory
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3526.
+https://www.npmjs.com/package/require-directory
+
+require-from-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3188.
+https://www.npmjs.com/package/require-from-string
+
+require-main-filename
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:3534.
+https://www.npmjs.com/package/require-main-filename
+
+require-uncached
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4524.
+https://www.npmjs.com/package/require-uncached
+
+requires-port
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6723.
+https://www.npmjs.com/package/requires-port
 
 reselect
 Copyright (c) 2015-2018 Reselect Contributors
 Licensed under the MIT License.
 See smd-ui/licenses/reselect.
+https://www.npmjs.com/package/reselect
+
+resize-observer-polyfill
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14764.
+https://www.npmjs.com/package/resize-observer-polyfill
+
+resolve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3539.
+https://www.npmjs.com/package/resolve
+
+resolve-dir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6208.
+https://www.npmjs.com/package/resolve-dir
+
+resolve-from
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:14731.
+https://www.npmjs.com/package/resolve-from
+
+resolve-pathname
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6503.
+https://www.npmjs.com/package/resolve-pathname
+
+resolve-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14777.
+https://www.npmjs.com/package/resolve-url
 
 resource-pool
 Copyright (c) 2011, MailRank, Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/resource-pool.
+https://hackage.haskell.org/package/resource-pool
 
 resourcet
 Copyright (c)2011, Michael Snoyman
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/resourcet.
+https://hackage.haskell.org/package/resourcet
+
+restore-cursor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2855.
+https://www.npmjs.com/package/restore-cursor
+
+ret
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11821.
+https://www.npmjs.com/package/ret
+
+retry
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2379.
+https://www.npmjs.com/package/retry
+
+retry-as-promised
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3547.
+https://www.npmjs.com/package/retry-as-promised
+
+reusify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14800.
+https://www.npmjs.com/package/reusify
+
+rfdc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14810.
+https://www.npmjs.com/package/rfdc
+
+right-align
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2871.
+https://www.npmjs.com/package/right-align
+
+rimraf
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1771.
+https://www.npmjs.com/package/rimraf
+
+ripemd160
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:3235.
+https://www.npmjs.com/package/ripemd160
 
 route-parser
 Copyright (c) 2014 Ryan Sorensen
 Licensed under the MIT License.
 See apex/api/licenses/route-parser.
+https://www.npmjs.com/package/route-parser
+
+router
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1868.
+https://www.npmjs.com/package/router
+
+rpc-websockets
+Copyright information is provided by the upstream package authors.
+Licensed under the LGPL-3.0-only License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6151.
+https://www.npmjs.com/package/rpc-websockets
+
+rst-selector-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:4274.
+https://www.npmjs.com/package/rst-selector-parser
+
+run-async
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6980.
+https://www.npmjs.com/package/run-async
+
+run-parallel
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14899.
+https://www.npmjs.com/package/run-parallel
+
+rw
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:3645.
+https://www.npmjs.com/package/rw
+
+rx
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:12047.
+https://www.npmjs.com/package/rx
+
+rx-lite
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache License, Version 2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:6981.
+https://www.npmjs.com/package/rx-lite
+
+rx-lite-aggregates
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache License, Version 2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:12239.
+https://www.npmjs.com/package/rx-lite-aggregates
+
+safe-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1783.
+https://www.npmjs.com/package/safe-buffer
+
+safe-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14472.
+https://www.npmjs.com/package/safe-regex
+
+safe-regex-test
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14942.
+https://www.npmjs.com/package/safe-regex-test
+
+safe-stable-stringify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1904.
+https://www.npmjs.com/package/safe-stable-stringify
+
+safer-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1789.
+https://www.npmjs.com/package/safer-buffer
 
 SafeSemaphore
 Copyright (c)2011, Chris Kuklewicz
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/SafeSemaphore.
+https://hackage.haskell.org/package/SafeSemaphore
 
 saltine
 Copyright (c) 2013 Joseph Abrahamson
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/saltine.
+https://hackage.haskell.org/package/saltine
+
+sane
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7959.
+https://www.npmjs.com/package/sane
+
+sass
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14915.
+https://www.npmjs.com/package/sass
+
+sax
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1795.
+https://www.npmjs.com/package/sax
+
+scheduler
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14968.
+https://www.npmjs.com/package/scheduler
+
+schema-utils
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10872.
+https://www.npmjs.com/package/schema-utils
 
 scientific
 Copyright (c) 2013, Bas van Dijk
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/scientific.
+https://hackage.haskell.org/package/scientific
+
+scroll
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12379.
+https://www.npmjs.com/package/scroll
+
+scroll-into-view-if-needed
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:14977.
+https://www.npmjs.com/package/scroll-into-view-if-needed
+
+scrypt-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6200.
+https://www.npmjs.com/package/scrypt-js
 
 secp256k1
 In jurisdictions that recognize copyright laws, the author or authors
 Licensed under terms in the referenced file.
 See strato/extraFiles/strato/licenses/secp256k1.
+https://hackage.haskell.org/package/secp256k1
+
+select-hose
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14982.
+https://www.npmjs.com/package/select-hose
+
+semver
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1801.
+https://www.npmjs.com/package/semver
+
+semver-diff
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14994.
+https://www.npmjs.com/package/semver-diff
+
+send
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3568.
+https://www.npmjs.com/package/send
 
 sequelize
 Copyright (c) 2014-present Sequelize contributors
 Licensed under the MIT License.
 See apex/api/licenses/sequelize.
+https://www.npmjs.com/package/sequelize
 
 sequelize-cli
 Copyright (c) 2017 sequelize
 Licensed under the MIT License.
 See apex/api/licenses/sequelize-cli.
+https://www.npmjs.com/package/sequelize-cli
+
+sequelize-pool
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3662.
+https://www.npmjs.com/package/sequelize-pool
 
 servant
 Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant.
+https://hackage.haskell.org/package/servant
 
 servant-client
 Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant-client.
+https://hackage.haskell.org/package/servant-client
 
 servant-docs
 Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant-docs.
+https://hackage.haskell.org/package/servant-docs
 
 servant-mock
 Copyright (c) 2015-2016, Servant Contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant-mock.
+https://hackage.haskell.org/package/servant-mock
 
 servant-options
 Copyright 2017 Lyndon Maydwell
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/servant-options.
+https://hackage.haskell.org/package/servant-options
 
 servant-server
 Copyright (c) 2014-2016, Zalora South East Asia Pte Ltd, Servant Contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant-server.
+https://hackage.haskell.org/package/servant-server
 
 servant-swagger
 Copyright (c) 2015-2016, Servant contributors
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/servant-swagger.
+https://hackage.haskell.org/package/servant-swagger
 
 servant-swagger-ui
 Copyright (c) 2016, Oleg Grenrus
 Licensed under the Apache License, Version 2.0.
 See strato/extraFiles/strato/licenses/servant-swagger-ui.
+https://hackage.haskell.org/package/servant-swagger-ui
 
 serve
 Copyright (c) 2018 ZEIT, Inc.
 Licensed under the MIT License.
 See smd-ui/licenses/serve.
+https://www.npmjs.com/package/serve
 
 serve-favicon
 Copyright (c) 2010 Sencha Inc.
 Licensed under the MIT License.
 See apex/api/licenses/serve-favicon.
+https://www.npmjs.com/package/serve-favicon
+
+serve-index
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15055.
+https://www.npmjs.com/package/serve-index
+
+serve-static
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3707.
+https://www.npmjs.com/package/serve-static
+
+serviceworker-cache-polyfill
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15111.
+https://www.npmjs.com/package/serviceworker-cache-polyfill
+
+set-blocking
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1810.
+https://www.npmjs.com/package/set-blocking
+
+set-function-length
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15004.
+https://www.npmjs.com/package/set-function-length
+
+set-value
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2490.
+https://www.npmjs.com/package/set-value
+
+setimmediate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:5268.
+https://www.npmjs.com/package/setimmediate
+
+setprototypeof
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1108.
+https://www.npmjs.com/package/setprototypeof
+
+settle-promise
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12116.
+https://www.npmjs.com/package/settle-promise
+
+sha.js
+Copyright information is provided by the upstream package authors.
+Licensed under the (MIT AND BSD-3-Clause) License (per package-lock metadata).
+See mercata/ui/package-lock.json:15021.
+https://www.npmjs.com/package/sha.js
 
 shakespeare
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/shakespeare.
+https://hackage.haskell.org/package/shakespeare
+
+sharp
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:15041.
+https://www.npmjs.com/package/sharp
+
+shebang-command
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3731.
+https://www.npmjs.com/package/shebang-command
+
+shebang-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3742.
+https://www.npmjs.com/package/shebang-regex
+
+shell-quote
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3750.
+https://www.npmjs.com/package/shell-quote
+
+shelljs
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4525.
+https://www.npmjs.com/package/shelljs
+
+shellwords
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9611.
+https://www.npmjs.com/package/shellwords
+
+shimmer
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:3761.
+https://www.npmjs.com/package/shimmer
+
+side-channel
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1962.
+https://www.npmjs.com/package/side-channel
+
+side-channel-list
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1981.
+https://www.npmjs.com/package/side-channel-list
+
+side-channel-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:1997.
+https://www.npmjs.com/package/side-channel-map
+
+side-channel-weakmap
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2015.
+https://www.npmjs.com/package/side-channel-weakmap
+
+sigmund
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3766.
+https://www.npmjs.com/package/sigmund
+
+signal-exit
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1816.
+https://www.npmjs.com/package/signal-exit
+
+simple-oauth2
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6350.
+https://www.npmjs.com/package/simple-oauth2
+
+simple-swizzle
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2034.
+https://www.npmjs.com/package/simple-swizzle
+
+slash
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:1017.
+https://www.npmjs.com/package/slash
+
+slice-ansi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:15229.
+https://www.npmjs.com/package/slice-ansi
+
+snapdragon
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2281.
+https://www.npmjs.com/package/snapdragon
+
+snapdragon-node
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2282.
+https://www.npmjs.com/package/snapdragon-node
+
+snapdragon-util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15288.
+https://www.npmjs.com/package/snapdragon-util
+
+sntp
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:3776.
+https://www.npmjs.com/package/sntp
 
 socket.io
 Copyright (c) 2014-2018 Automattic <dev@cloudup.com>
 Licensed under the MIT License.
 See apex/api/licenses/socket.io.
+https://www.npmjs.com/package/socket.io
+
+socket.io-adapter
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3800.
+https://www.npmjs.com/package/socket.io-adapter
 
 socket.io-client
 Copyright (c) 2014 Guillermo Rauch
 Licensed under the MIT License.
 See smd-ui/licenses/socket.io-client.
+https://www.npmjs.com/package/socket.io-client
+
+socket.io-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3833.
+https://www.npmjs.com/package/socket.io-parser
+
+sockjs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15398.
+https://www.npmjs.com/package/sockjs
+
+sockjs-client
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11982.
+https://www.npmjs.com/package/sockjs-client
 
 solidity
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 Licensed under the GNU Lesser General Public License.
 See strato/extraFiles/strato/licenses/solidity.
+https://hackage.haskell.org/package/solidity
+
+sonic-boom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15137.
+https://www.npmjs.com/package/sonic-boom
+
+sonner
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15146.
+https://www.npmjs.com/package/sonner
+
+sort-keys
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9661.
+https://www.npmjs.com/package/sort-keys
+
+source-list-map
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3343.
+https://www.npmjs.com/package/source-list-map
+
+source-map
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:1018.
+https://www.npmjs.com/package/source-map
+
+source-map-js
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/ui/package-lock.json:15156.
+https://www.npmjs.com/package/source-map-js
+
+source-map-resolve
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15247.
+https://www.npmjs.com/package/source-map-resolve
+
+source-map-support
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:1909.
+https://www.npmjs.com/package/source-map-support
+
+source-map-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15492.
+https://www.npmjs.com/package/source-map-url
+
+spdx-correct
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See apex/api/package-lock.json:3865.
+https://www.npmjs.com/package/spdx-correct
+
+spdx-exceptions
+Copyright information is provided by the upstream package authors.
+Licensed under the CC-BY-3.0 License (per package-lock metadata).
+See smd-ui/package-lock.json:15521.
+https://www.npmjs.com/package/spdx-exceptions
+
+spdx-expression-parse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3873.
+https://www.npmjs.com/package/spdx-expression-parse
+
+spdx-license-ids
+Copyright information is provided by the upstream package authors.
+Licensed under the CC0-1.0 License (per package-lock metadata).
+See apex/api/package-lock.json:3878.
+https://www.npmjs.com/package/spdx-license-ids
+
+spdy
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15543.
+https://www.npmjs.com/package/spdy
+
+spdy-transport
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15554.
+https://www.npmjs.com/package/spdy-transport
+
+split
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:1032.
+https://www.npmjs.com/package/split
+
+split-on-first
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15165.
+https://www.npmjs.com/package/split-on-first
+
+split-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2283.
+https://www.npmjs.com/package/split-string
+
+split2
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:15174.
+https://www.npmjs.com/package/split2
+
+sprintf-js
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:594.
+https://www.npmjs.com/package/sprintf-js
+
+sshpk
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3894.
+https://www.npmjs.com/package/sshpk
+
+stack-trace
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3919.
+https://www.npmjs.com/package/stack-trace
+
+static-extend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2807.
+https://www.npmjs.com/package/static-extend
+
+statuses
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1113.
+https://www.npmjs.com/package/statuses
+
+stealthy-require
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:3935.
+https://www.npmjs.com/package/stealthy-require
 
 stm
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/stm.
+https://hackage.haskell.org/package/stm
 
 stm-conduit
 Copyright (c)2012, Clark Gaebel
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/stm-conduit.
+https://hackage.haskell.org/package/stm-conduit
+
+stream-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9585.
+https://www.npmjs.com/package/stream-browserify
+
+stream-chain
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6407.
+https://www.npmjs.com/package/stream-chain
+
+stream-combiner
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3943.
+https://www.npmjs.com/package/stream-combiner
+
+stream-http
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9586.
+https://www.npmjs.com/package/stream-http
+
+stream-json
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6413.
+https://www.npmjs.com/package/stream-json
+
+stream-shift
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15198.
+https://www.npmjs.com/package/stream-shift
 
 streaming-commons
 Copyright (c) 2014 FP Complete
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/streaming-commons.
+https://hackage.haskell.org/package/streaming-commons
+
+strict-uri-encode
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15204.
+https://www.npmjs.com/package/strict-uri-encode
+
+string-convert
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15222.
+https://www.npmjs.com/package/string-convert
+
+string-length
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7742.
+https://www.npmjs.com/package/string-length
+
+string-width
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1831.
+https://www.npmjs.com/package/string-width
+
+string.prototype.padend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3972.
+https://www.npmjs.com/package/string.prototype.padend
+
+string.prototype.trimend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:689.
+https://www.npmjs.com/package/string.prototype.trimend
+
+string.prototype.trimstart
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:690.
+https://www.npmjs.com/package/string.prototype.trimstart
+
+string_decoder
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1822.
+https://www.npmjs.com/package/string_decoder
+
+stringstream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:3985.
+https://www.npmjs.com/package/stringstream
+
+strip-ansi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1845.
+https://www.npmjs.com/package/strip-ansi
+
+strip-bom
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:2835.
+https://www.npmjs.com/package/strip-bom
+
+strip-eof
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4001.
+https://www.npmjs.com/package/strip-eof
+
+strip-indent
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14342.
+https://www.npmjs.com/package/strip-indent
+
+strip-json-comments
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1857.
+https://www.npmjs.com/package/strip-json-comments
+
+strnum
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/oracle/package-lock.json:2543.
+https://www.npmjs.com/package/strnum
+
+sturdy-websocket
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6422.
+https://www.npmjs.com/package/sturdy-websocket
+
+style-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12541.
+https://www.npmjs.com/package/style-loader
+
+styled-jsx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15267.
+https://www.npmjs.com/package/styled-jsx
+
+stylis
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15290.
+https://www.npmjs.com/package/stylis
+
+sucrase
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15296.
+https://www.npmjs.com/package/sucrase
+
+superagent
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4009.
+https://www.npmjs.com/package/superagent
+
+superstruct
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6428.
+https://www.npmjs.com/package/superstruct
+
+supports-color
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:463.
+https://www.npmjs.com/package/supports-color
+
+supports-preserve-symlinks-flag
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15340.
+https://www.npmjs.com/package/supports-preserve-symlinks-flag
+
+svgo
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11466.
+https://www.npmjs.com/package/svgo
+
+sw-precache
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:15932.
+https://www.npmjs.com/package/sw-precache
+
+sw-precache-webpack-plugin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12542.
+https://www.npmjs.com/package/sw-precache-webpack-plugin
+
+sw-toolbox
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:15946.
+https://www.npmjs.com/package/sw-toolbox
+
+swagger-jsdoc
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2124.
+https://www.npmjs.com/package/swagger-jsdoc
+
+swagger-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2165.
+https://www.npmjs.com/package/swagger-parser
+
+swagger-ui-dist
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/backend/package-lock.json:2177.
+https://www.npmjs.com/package/swagger-ui-dist
+
+swagger-ui-express
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2186.
+https://www.npmjs.com/package/swagger-ui-express
 
 swagger2
 Copyright (c) 2015-2017, GetShopTV
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/swagger2.
+https://hackage.haskell.org/package/swagger2
+
+symbol-observable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:14381.
+https://www.npmjs.com/package/symbol-observable
+
+symbol-tree
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:8802.
+https://www.npmjs.com/package/symbol-tree
 
 sync-request
 Copyright (c) 2014 Forbes Lindesay
 Licensed under the MIT License.
 See apex/api/licenses/sync-request.
+https://www.npmjs.com/package/sync-request
+
+systeminformation
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4063.
+https://www.npmjs.com/package/systeminformation
+
+table
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:4528.
+https://www.npmjs.com/package/table
+
+tailwind-merge
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15352.
+https://www.npmjs.com/package/tailwind-merge
+
+tailwindcss
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15362.
+https://www.npmjs.com/package/tailwindcss
+
+tailwindcss-animate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15399.
+https://www.npmjs.com/package/tailwindcss-animate
+
+tapable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4244.
+https://www.npmjs.com/package/tapable
+
+tar
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1866.
+https://www.npmjs.com/package/tar
+
+tar-pack
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:13343.
+https://www.npmjs.com/package/tar-pack
+
+tdigest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4088.
+https://www.npmjs.com/package/tdigest
 
 template-haskell
 Copyright 2002-2007, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/template-haskell.
+https://hackage.haskell.org/package/template-haskell
 
 temporary
 Copyright
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/temporary.
+https://hackage.haskell.org/package/temporary
+
+term-size
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2218.
+https://www.npmjs.com/package/term-size
+
+test-exclude
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:1290.
+https://www.npmjs.com/package/test-exclude
+
+tether
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:32.
+https://www.npmjs.com/package/tether
 
 text
 Copyright (c) 2008-2009, Tom Harper
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/text.
+https://hackage.haskell.org/package/text
+
+text-encoding-utf-8
+Upstream authors (npm metadata): Erik Arvidsson <erik.arvidsson@gmail.com>, Rick Eyre <rick.eyre@outlook.com>, Joshua Bell <inexorabletash@gmail.com>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See mercata/services/bridge/package-lock.json:6450.
+https://www.npmjs.com/package/text-encoding-utf-8
+
+text-hex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2201.
+https://www.npmjs.com/package/text-hex
+
+text-table
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:4529.
+https://www.npmjs.com/package/text-table
+
+then-request
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4097.
+https://www.npmjs.com/package/then-request
+
+thenify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15426.
+https://www.npmjs.com/package/thenify
+
+thenify-all
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15435.
+https://www.npmjs.com/package/thenify-all
+
+thread-stream
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15447.
+https://www.npmjs.com/package/thread-stream
+
+throat
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7811.
+https://www.npmjs.com/package/throat
+
+throttle-debounce
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15456.
+https://www.npmjs.com/package/throttle-debounce
+
+through
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4115.
+https://www.npmjs.com/package/through
 
 time
 TimeLib is Copyright (c) Ashley Yakeley, 2004-2014. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/time.
+https://hackage.haskell.org/package/time
+
+time-stamp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16059.
+https://www.npmjs.com/package/time-stamp
+
+timed-out
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6258.
+https://www.npmjs.com/package/timed-out
+
+timers-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9588.
+https://www.npmjs.com/package/timers-browserify
+
+timers-ext
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See apex/api/package-lock.json:4120.
+https://www.npmjs.com/package/timers-ext
+
+tiny-invariant
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15465.
+https://www.npmjs.com/package/tiny-invariant
+
+tiny-warning
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6505.
+https://www.npmjs.com/package/tiny-warning
+
+tinyglobby
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15471.
+https://www.npmjs.com/package/tinyglobby
+
+tmp
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:5118.
+https://www.npmjs.com/package/tmp
+
+tmpl
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:9185.
+https://www.npmjs.com/package/tmpl
+
+to-array
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4129.
+https://www.npmjs.com/package/to-array
+
+to-arraybuffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15689.
+https://www.npmjs.com/package/to-arraybuffer
+
+to-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15516.
+https://www.npmjs.com/package/to-buffer
+
+to-fast-properties
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1988.
+https://www.npmjs.com/package/to-fast-properties
+
+to-object-path
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2491.
+https://www.npmjs.com/package/to-object-path
+
+to-regex
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2284.
+https://www.npmjs.com/package/to-regex
+
+to-regex-range
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15530.
+https://www.npmjs.com/package/to-regex-range
+
+toggle-selection
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15542.
+https://www.npmjs.com/package/toggle-selection
+
+toidentifier
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2220.
+https://www.npmjs.com/package/toidentifier
+
+toposort
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6647.
+https://www.npmjs.com/package/toposort
+
+toposort-class
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4134.
+https://www.npmjs.com/package/toposort-class
+
+tough-cookie
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-3-Clause License (per npm registry metadata).
+See apex/api/package-lock.json:4139.
+https://www.npmjs.com/package/tough-cookie
+
+tr46
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6487.
+https://www.npmjs.com/package/tr46
 
 transformers
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/transformers.
+https://hackage.haskell.org/package/transformers
 
 transformers-base
 Copyright (c) 2011, Mikhail Vorozhtsov, Bas van Dijk
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/transformers-base.
+https://hackage.haskell.org/package/transformers-base
 
 transformers-lift
 Copyright (c) 2015, Vladislav Zavialov
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/transformers-lift.
+https://hackage.haskell.org/package/transformers-lift
+
+trim-newlines
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9272.
+https://www.npmjs.com/package/trim-newlines
+
+trim-right
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:1057.
+https://www.npmjs.com/package/trim-right
+
+triple-beam
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2239.
+https://www.npmjs.com/package/triple-beam
+
+ts-interface-checker
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:15567.
+https://www.npmjs.com/package/ts-interface-checker
+
+tslib
+Copyright information is provided by the upstream package authors.
+Licensed under the 0BSD License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:2272.
+https://www.npmjs.com/package/tslib
+
+tty-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9589.
+https://www.npmjs.com/package/tty-browserify
+
+tunnel-agent
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See apex/api/package-lock.json:4150.
+https://www.npmjs.com/package/tunnel-agent
+
+tweetnacl
+Copyright information is provided by the upstream package authors.
+Licensed under the Unlicense License (per npm registry metadata).
+See apex/api/package-lock.json:4161.
+https://www.npmjs.com/package/tweetnacl
+
+type
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6543.
+https://www.npmjs.com/package/type
+
+type-check
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:8959.
+https://www.npmjs.com/package/type-check
+
+type-detect
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4167.
+https://www.npmjs.com/package/type-detect
+
+type-is
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4175.
+https://www.npmjs.com/package/type-is
+
+typed-array-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15592.
+https://www.npmjs.com/package/typed-array-buffer
+
+typed-styles
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12406.
+https://www.npmjs.com/package/typed-styles
+
+typedarray
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4187.
+https://www.npmjs.com/package/typedarray
+
+typedarray-to-buffer
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6562.
+https://www.npmjs.com/package/typedarray-to-buffer
+
+typescript
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6571.
+https://www.npmjs.com/package/typescript
+
+typesettable
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10348.
+https://www.npmjs.com/package/typesettable
+
+ua-parser-js
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15643.
+https://www.npmjs.com/package/ua-parser-js
+
+ufo
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15669.
+https://www.npmjs.com/package/ufo
+
+uglify-js
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:6304.
+https://www.npmjs.com/package/uglify-js
+
+uglify-to-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16305.
+https://www.npmjs.com/package/uglify-to-browserify
+
+uid-number
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per npm registry metadata).
+See smd-ui/package-lock.json:13625.
+https://www.npmjs.com/package/uid-number
+
+uint8arrays
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15675.
+https://www.npmjs.com/package/uint8arrays
+
+ultron
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4192.
+https://www.npmjs.com/package/ultron
+
+umzug
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4197.
+https://www.npmjs.com/package/umzug
+
+unbox-primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:691.
+https://www.npmjs.com/package/unbox-primitive
+
+uncrypto
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15684.
+https://www.npmjs.com/package/uncrypto
 
 underscore
 Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
 Licensed under the MIT License.
 See apex/api/licenses/underscore.
+https://www.npmjs.com/package/underscore
+
+undici-types
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6591.
+https://www.npmjs.com/package/undici-types
+
+union-value
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2492.
+https://www.npmjs.com/package/union-value
+
+uniq
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:11454.
+https://www.npmjs.com/package/uniq
+
+uniqs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10752.
+https://www.npmjs.com/package/uniqs
+
+unique-string
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3083.
+https://www.npmjs.com/package/unique-string
+
+universalify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4216.
+https://www.npmjs.com/package/universalify
 
 unix
 Copyright 2004, The University Court of the University of Glasgow.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/unix.
+https://hackage.haskell.org/package/unix
 
 unordered-containers
 Copyright (c) 2010, Johan Tibell
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/unordered-containers.
+https://hackage.haskell.org/package/unordered-containers
+
+unpipe
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4221.
+https://www.npmjs.com/package/unpipe
+
+unset-value
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2493.
+https://www.npmjs.com/package/unset-value
+
+unstorage
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:4850.
+https://www.npmjs.com/package/unstorage
+
+unzip-response
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6259.
+https://www.npmjs.com/package/unzip-response
+
+upath
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16481.
+https://www.npmjs.com/package/upath
+
+update-notifier
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per npm registry metadata).
+See smd-ui/package-lock.json:15947.
+https://www.npmjs.com/package/update-notifier
+
+upper-case
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:2540.
+https://www.npmjs.com/package/upper-case
+
+uri-js
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See smd-ui/package-lock.json:14951.
+https://www.npmjs.com/package/uri-js
+
+urijs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4057.
+https://www.npmjs.com/package/urijs
+
+urix
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15493.
+https://www.npmjs.com/package/urix
+
+url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:72.
+https://www.npmjs.com/package/url
+
+url-loader
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12543.
+https://www.npmjs.com/package/url-loader
+
+url-parse
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9986.
+https://www.npmjs.com/package/url-parse
+
+url-parse-lax
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6260.
+https://www.npmjs.com/package/url-parse-lax
+
+url-value-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT-0 License (per npm registry metadata).
+See apex/api/package-lock.json:4229.
+https://www.npmjs.com/package/url-value-parser
+
+use
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15248.
+https://www.npmjs.com/package/use
+
+use-callback-ref
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15737.
+https://www.npmjs.com/package/use-callback-ref
+
+use-sidecar
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15758.
+https://www.npmjs.com/package/use-sidecar
+
+use-sync-external-store
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15780.
+https://www.npmjs.com/package/use-sync-external-store
+
+user-home
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4530.
+https://www.npmjs.com/package/user-home
+
+utf-8-validate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6606.
+https://www.npmjs.com/package/utf-8-validate
 
 utf8-string
 * Copyright (c) 2007, Galois Inc.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/utf8-string.
+https://hackage.haskell.org/package/utf8-string
+
+util
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4237.
+https://www.npmjs.com/package/util
+
+util-deprecate
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:1884.
+https://www.npmjs.com/package/util-deprecate
+
+util-inspect
+Upstream author (npm metadata): rauchg <rauchg@gmail.com>.
+License not declared in package-lock metadata; consult upstream package LICENSE/NOTICE.
+See smd-ui/package-lock.json:14423.
+https://www.npmjs.com/package/util-inspect
+
+utila
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:4022.
+https://www.npmjs.com/package/utila
+
+utils-merge
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4255.
+https://www.npmjs.com/package/utils-merge
+
+uuid
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3699.
+https://www.npmjs.com/package/uuid
+
+uws
+Copyright information is provided by the upstream package authors.
+Licensed under the Zlib License (per npm registry metadata).
+See apex/api/package-lock.json:4272.
+https://www.npmjs.com/package/uws
+
+validate-npm-package-license
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See apex/api/package-lock.json:4283.
+https://www.npmjs.com/package/validate-npm-package-license
+
+validator
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4292.
+https://www.npmjs.com/package/validator
+
+valtio
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15830.
+https://www.npmjs.com/package/valtio
+
+value-equal
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6506.
+https://www.npmjs.com/package/value-equal
+
+vary
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4300.
+https://www.npmjs.com/package/vary
+
+vaul
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:15865.
+https://www.npmjs.com/package/vaul
 
 vector
 Copyright (c) 2008-2012, Roman Leshchinskiy
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/vector.
+https://hackage.haskell.org/package/vector
+
+vendors
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:10963.
+https://www.npmjs.com/package/vendors
+
+verror
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4308.
+https://www.npmjs.com/package/verror
+
+victory-vendor
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT AND ISC License (per package-lock metadata).
+See mercata/ui/package-lock.json:15878.
+https://www.npmjs.com/package/victory-vendor
+
+viem
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6653.
+https://www.npmjs.com/package/viem
+
+vm-browserify
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:9592.
+https://www.npmjs.com/package/vm-browserify
 
 vscode
 Copyright (c) 2015 - present Microsoft Corporation
 Licensed under the MIT License.
 See smd-ui/licenses/vscode.
+https://www.npmjs.com/package/vscode
+
+wagmi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:16468.
+https://www.npmjs.com/package/wagmi
 
 wai
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/wai.
+https://hackage.haskell.org/package/wai
 
 wai-cors
 Copyright (c) 2015 Lars Kuhtz <lakuhtz@gmail.com>
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/wai-cors.
+https://hackage.haskell.org/package/wai-cors
 
 wai-extra
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/wai-extra.
+https://hackage.haskell.org/package/wai-extra
+
+walker
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:14082.
+https://www.npmjs.com/package/walker
+
+warning
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:120.
+https://www.npmjs.com/package/warning
 
 warp
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/warp.
+https://hackage.haskell.org/package/warp
 
 warp-tls
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/warp-tls.
+https://hackage.haskell.org/package/warp-tls
 
 wasm3
 Copyright (c) 2019 Steven Massey, Volodymyr Shymanskyy
 Licensed under the MIT License.
 See strato/libs/groth16-rapidsnark/vendor/wasm3/LICENSE.
+https://github.com/wasm3/wasm3
+
+watch
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:14083.
+https://www.npmjs.com/package/watch
+
+watchpack
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16775.
+https://www.npmjs.com/package/watchpack
+
+watchpack-chokidar2
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16784.
+https://www.npmjs.com/package/watchpack-chokidar2
+
+wbuf
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6565.
+https://www.npmjs.com/package/wbuf
+
+webextension-polyfill
+Copyright information is provided by the upstream package authors.
+Licensed under the MPL-2.0 License (per package-lock metadata).
+See mercata/ui/package-lock.json:16502.
+https://www.npmjs.com/package/webextension-polyfill
+
+webidl-conversions
+Copyright information is provided by the upstream package authors.
+Licensed under the BSD-2-Clause License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6683.
+https://www.npmjs.com/package/webidl-conversions
+
+webpack
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12544.
+https://www.npmjs.com/package/webpack
+
+webpack-dev-middleware
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:17104.
+https://www.npmjs.com/package/webpack-dev-middleware
+
+webpack-dev-server
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12545.
+https://www.npmjs.com/package/webpack-dev-server
+
+webpack-manifest-plugin
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:12546.
+https://www.npmjs.com/package/webpack-manifest-plugin
+
+webpack-sources
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5195.
+https://www.npmjs.com/package/webpack-sources
+
+websocket
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6689.
+https://www.npmjs.com/package/websocket
+
+websocket-driver
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:5246.
+https://www.npmjs.com/package/websocket-driver
+
+websocket-extensions
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:17709.
+https://www.npmjs.com/package/websocket-extensions
+
+whatwg-encoding
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:6580.
+https://www.npmjs.com/package/whatwg-encoding
+
+whatwg-fetch
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7508.
+https://www.npmjs.com/package/whatwg-fetch
+
+whatwg-url
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6706.
+https://www.npmjs.com/package/whatwg-url
+
+whet.extend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:15905.
+https://www.npmjs.com/package/whet.extend
+
+which
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:4321.
+https://www.npmjs.com/package/which
+
+which-boxed-primitive
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16344.
+https://www.npmjs.com/package/which-boxed-primitive
+
+which-module
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:4587.
+https://www.npmjs.com/package/which-module
+
+which-typed-array
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:16546.
+https://www.npmjs.com/package/which-typed-array
+
+wide-align
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1890.
+https://www.npmjs.com/package/wide-align
+
+widest-line
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2219.
+https://www.npmjs.com/package/widest-line
+
+window-size
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:16318.
+https://www.npmjs.com/package/window-size
+
+winston
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4332.
+https://www.npmjs.com/package/winston
 
 winston-color
 Copyright (c) 2016 Arturo Arevalo
 Licensed under the MIT License.
 See apex/api/licenses/winston-color.
+https://www.npmjs.com/package/winston-color
+
+winston-transport
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2437.
+https://www.npmjs.com/package/winston-transport
+
+wkx
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4361.
+https://www.npmjs.com/package/wkx
 
 wl-pprint-text
 Copyright (c)2010, Ivan Lazar Miljenovic
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/wl-pprint-text.
+https://hackage.haskell.org/package/wl-pprint-text
+
+wordwrap
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See smd-ui/package-lock.json:2872.
+https://www.npmjs.com/package/wordwrap
+
+worker-farm
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:7745.
+https://www.npmjs.com/package/worker-farm
+
+wrap-ansi
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3240.
+https://www.npmjs.com/package/wrap-ansi
+
+wrappy
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1899.
+https://www.npmjs.com/package/wrappy
+
+write
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:5408.
+https://www.npmjs.com/package/write
+
+write-file-atomic
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See smd-ui/package-lock.json:3084.
+https://www.npmjs.com/package/write-file-atomic
+
+ws
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4386.
+https://www.npmjs.com/package/ws
+
+xdg-basedir
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3085.
+https://www.npmjs.com/package/xdg-basedir
+
+xml-name-validator
+Copyright information is provided by the upstream package authors.
+Licensed under the Apache-2.0 License (per npm registry metadata).
+See smd-ui/package-lock.json:8807.
+https://www.npmjs.com/package/xml-name-validator
+
+xmlhttprequest
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See smd-ui/package-lock.json:3723.
+https://www.npmjs.com/package/xmlhttprequest
+
+xmlhttprequest-ssl
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4396.
+https://www.npmjs.com/package/xmlhttprequest-ssl
+
+xtend
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:4404.
+https://www.npmjs.com/package/xtend
+
+y18n
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:3256.
+https://www.npmjs.com/package/y18n
+
+yaeti
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/services/bridge/package-lock.json:6737.
+https://www.npmjs.com/package/yaeti
+
+yallist
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:1905.
+https://www.npmjs.com/package/yallist
 
 yaml
 Copyright 2008, Michael Snoyman. All rights reserved.
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/yaml.
+https://hackage.haskell.org/package/yaml
+
+yargs
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See apex/api/package-lock.json:3264.
+https://www.npmjs.com/package/yargs
+
+yargs-parser
+Copyright information is provided by the upstream package authors.
+Licensed under the ISC License (per package-lock metadata).
+See apex/api/package-lock.json:3281.
+https://www.npmjs.com/package/yargs-parser
+
+yeast
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per npm registry metadata).
+See apex/api/package-lock.json:4592.
+https://www.npmjs.com/package/yeast
 
 yesod
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/yesod.
+https://hackage.haskell.org/package/yesod
 
 yesod-core
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/yesod-core.
+https://hackage.haskell.org/package/yesod-core
 
 yesod-raml
 Copyright (c) 2015 Junji Hashimoto
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/yesod-raml.
+https://hackage.haskell.org/package/yesod-raml
 
 yesod-static
 Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
 Licensed under the MIT License.
 See strato/extraFiles/strato/licenses/yesod-static.
+https://hackage.haskell.org/package/yesod-static
+
+z-schema
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/backend/package-lock.json:2486.
+https://www.npmjs.com/package/z-schema
 
 zlib
 Copyright (c) 2006-2016, Duncan Coutts
 Licensed under the BSD License.
 See strato/extraFiles/strato/licenses/zlib.
+https://hackage.haskell.org/package/zlib
+
+zod
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:5500.
+https://www.npmjs.com/package/zod
+
+zustand
+Copyright information is provided by the upstream package authors.
+Licensed under the MIT License (per package-lock metadata).
+See mercata/ui/package-lock.json:8314.
+https://www.npmjs.com/package/zustand
 
 -------------------------------------------------------------------------------
 WORK IN PROGRESS:


### PR DESCRIPTION
## Summary
- refresh and significantly expand NOTICE third-party entries
- include vendored/bundled components and runtime dependency coverage from repo packaging metadata
- normalize entry format and sort ordering for consistent reviewability

## What was added
- source references with file + line anchors (for lockfile/cabal/stack-backed entries)
- canonical package URLs (npm/Hackage/upstream where known)
- license provenance notes indicating whether data came from:
  - package-lock metadata
  - npm registry (npm view)
  - npm package page metadata
  - upstream package contents (LICENSE/README/package.json from npm tarballs)

## Additional coverage in this PR
- backfilled unresolved npm entries where possible
- added missing Haskell dependency entries discovered from .cabal and stack.yaml
- flagged custom/non-standard upstream license terms explicitly where detected

## Current state
- Third-Party Notices section is structurally normalized and alphabetized
- no remaining unresolved license placeholders in the current generated set