### PR TITLE
Fix railgun unshield change note recovery

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -23,7 +23,8 @@ RUN apt -y update && apt install -y \
   && apt autoremove \
   && rm -rf /var/lib/apt/lists/* \
   && apt clean \
-  && ln -s /lib/x86_64-linux-gnu/libleveldb.so.1.23.0 /lib/x86_64-linux-gnu/libleveldb.so.1 \
+  && LEVELDB_REAL="$(ls -1 /lib/*/libleveldb.so.* /usr/lib/*/libleveldb.so.* 2>/dev/null | head -n 1)" \
+  && if [ -n "$LEVELDB_REAL" ]; then ln -sf "$LEVELDB_REAL" "$(dirname "$LEVELDB_REAL")/libleveldb.so.1"; fi \
   && locale-gen en_US.UTF-8 \
   && ldconfig
 

--- a/strato/tools/airlock/exec_src/Main.hs
+++ b/strato/tools/airlock/exec_src/Main.hs
@@ -38,13 +38,11 @@ import Railgun.Types (RailgunAddress(..), RailgunKeys(..), TokenType(..))
 import Railgun.Balance (scanShieldedBalance, TokenBalance(..))
 import qualified Railgun.Balance as Bal
 import Railgun.Merkle (fetchMerkleTreeData, computeMerkleProof, MerkleTreeData(..))
-import Railgun.Crypto (poseidonHash, computeNullifier)
-import qualified Railgun.Crypto
+import Railgun.Crypto (poseidonHash, computeNullifier, randomBytes)
 import Railgun.Witness (SpendableNote(..), buildUnshieldWitness, buildTransferWitness)
 import Railgun.Transfer (parseRecipientAddress, createTransferRequest, TransferNote(..), encryptNoteForRecipient, createCommitmentCiphertext)
 import qualified Railgun.Transfer
 import qualified Railgun.Unshield
-import Railgun.Unshield (CommitmentCiphertext(..))
 import Railgun.Prover (generateProof, getProverConfig)
 import Railgun.Signing (deriveSigningKey, signTransactionData, computeSignatureMessage, RailgunSignature(..))
 
@@ -831,17 +829,18 @@ runUnshield uopts = do
           tokenId = hexToInteger (Bal.snTokenAddress noteToSpend)
           recipientInt = hexToInteger (T.pack $ uoRecipient uopts)
           
-      -- Get bound params hash from contract (SolidVM has different ABI encoding)
-      -- For unshield with 2 commitments (change + unshield), we need 1 ciphertext entry
-      -- Using dummy ciphertext for unshield (change note - recipient gets unshielded tokens)
-      let dummyCiphertext = CommitmentCiphertext
-            { ccCiphertext = [BS.replicate 32 0, BS.replicate 32 0, BS.replicate 32 0, BS.replicate 32 0]
-            , ccBlindedSenderViewingKey = BS.replicate 32 0
-            , ccBlindedReceiverViewingKey = BS.replicate 32 0
-            , ccAnnotationData = BS.empty
-            , ccMemo = BS.empty
-            }
-      boundParamsHashResult <- getBoundParamsHash (fromIntegral treeNum) chainId [dummyCiphertext] True -- True = unshield
+      -- Create real encrypted ciphertext for the change note so the wallet can recover it
+      let changeValue = Bal.snValue noteToSpend - actualAmount
+          changeRandom = Bal.snRandom noteToSpend
+      changeCiphertext <- createCommitmentCiphertext
+                            (viewingPrivateKey keys)
+                            (viewingPublicKey keys)
+                            npkInt
+                            (T.pack $ uoTokenAddress uopts)
+                            changeValue
+                            changeRandom
+
+      boundParamsHashResult <- getBoundParamsHash (fromIntegral treeNum) chainId [changeCiphertext] True -- True = unshield
       boundParamsHash <- case boundParamsHashResult of
         Left err -> do
           TIO.hPutStrLn stderr $ "Failed to get boundParamsHash: " <> err
@@ -852,8 +851,6 @@ runUnshield uopts = do
           
       let -- Compute output commitments
           unshieldCommitment = poseidonHash [recipientInt, tokenId, actualAmount]
-          changeValue = Bal.snValue noteToSpend - actualAmount
-          -- Always use our NPK for change commitment (even if value is 0)
           changeCommitment = poseidonHash [npkInt, tokenId, changeValue]
           
           -- Compute the message to sign
@@ -920,6 +917,7 @@ runUnshield uopts = do
                           (T.pack $ uoRecipient uopts)
                           chainId
                           (fromIntegral treeNum)
+                          [changeCiphertext]
       
       TIO.putStrLn "\nSending unshield transaction..."
       unshieldResult <- callTransact unshieldReq
@@ -1130,7 +1128,7 @@ runTransfer topts = do
       let recipientMasterPublicKey = bytesToIntegerBE recipientMasterPk
       
       -- Generate random for recipient's note
-      recipientRandom <- Railgun.Crypto.randomBytes 16
+      recipientRandom <- randomBytes 16
       let recipientRandomInt = bytesToIntegerBE recipientRandom
           -- Compute recipient's NPK using same formula as Shield
           recipientNpk = poseidonHash [recipientMasterPublicKey, recipientRandomInt]

--- a/strato/tools/airlock/src/Railgun/Unshield.hs
+++ b/strato/tools/airlock/src/Railgun/Unshield.hs
@@ -61,16 +61,6 @@ data CommitmentCiphertext = CommitmentCiphertext
   , ccMemo :: ByteString  -- bytes (empty for us)
   } deriving (Show, Eq)
 
--- | Create a dummy commitment ciphertext (all zeros)
-dummyCommitmentCiphertext :: CommitmentCiphertext
-dummyCommitmentCiphertext = CommitmentCiphertext
-  { ccCiphertext = [BS.replicate 32 0, BS.replicate 32 0, BS.replicate 32 0, BS.replicate 32 0]
-  , ccBlindedSenderViewingKey = BS.replicate 32 0
-  , ccBlindedReceiverViewingKey = BS.replicate 32 0
-  , ccAnnotationData = BS.empty
-  , ccMemo = BS.empty
-  }
-
 -- | Bound parameters for transaction
 data BoundParams = BoundParams
   { bpTreeNumber :: Int
@@ -159,8 +149,9 @@ createUnshieldRequest
   -> Text           -- ^ Recipient address
   -> Integer        -- ^ Chain ID
   -> Int            -- ^ Tree number
+  -> [CommitmentCiphertext]  -- ^ Ciphertexts for non-unshield outputs (change notes)
   -> UnshieldRequest
-createUnshieldRequest proof merkleRoot nullifier commitments tokenAddr amount recipient chainId treeNum =
+createUnshieldRequest proof merkleRoot nullifier commitments tokenAddr amount recipient chainId treeNum changeCiphertexts =
   let
     -- Convert nullifier to bytes32
     nullifierBytes = integerToBytes32 nullifier
@@ -185,12 +176,9 @@ createUnshieldRequest proof merkleRoot nullifier commitments tokenAddr amount re
       , cpValue = amount
       }
     
-    -- Bound params
-    -- For unshield with 2 commitments (unshield + change), we need 1 ciphertext entry
-    -- The ciphertext length must equal commitments.length - 1
-    ciphertextForChange = if length commitments > 1
-                          then [dummyCommitmentCiphertext]  -- Dummy ciphertext for change note
-                          else []
+    -- Ciphertext length must equal commitments.length - 1
+    -- (the last commitment is the unshield itself, which has no ciphertext)
+    ciphertextForChange = changeCiphertexts
     
     boundParams = BoundParams
       { bpTreeNumber = treeNum


### PR DESCRIPTION
## Summary
- Fix partial unshields to encrypt change note ciphertext so the wallet scanner can recover the change balance (previously used all-zero dummy ciphertext, effectively burning change)
- Use original note's random for change note so `npk == poseidon(masterPubKey, random)` verification passes in the scanner
- Fix Dockerfile.multi libleveldb symlink for ARM64 builds (was hardcoded to x86_64 path)

## Test plan
Tested end-to-end on helium testnet (local node):
- [x] Shield 50 USDST -> 49.875 shielded (0.25% fee)
- [x] Unshield 25 USDST -> 24.875 change note recovered by balance scanner
- [x] Full-amount shield/unshield round-trip (no change) still works
- [x] Balance scanner correctly decrypts change note from Transact event ciphertext


Made with [Cursor](https://cursor.com)