### PR TITLE
6310 net balance calls

### DIFF
--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -193,32 +193,6 @@ const Dashboard = () => {
     borrowedCacheRef.current = borrowedHistoryCache;
   }, [netBalanceHistoryCache, rewardsHistoryCache, borrowedHistoryCache]);
 
-  const prefetchOtherRanges = useCallback((primaryRange: TimeRange, tab: TabType) => {
-    const rangesToPrefetch = TIME_RANGES.filter(range => range !== primaryRange);
-    
-    rangesToPrefetch.forEach(range => {
-      (async () => {
-        try {
-          if (tab === 'netBalance') {
-            if (netBalanceCacheRef.current[range]) return;
-            const data = await getBalanceHistory(range, '');
-            setNetBalanceHistoryCache(range, data);
-          } else if (tab === 'rewards') {
-            if (rewardsCacheRef.current[range]) return;
-            const data = await getCataBalanceHistory(range, '');
-            setRewardsHistoryCache(range, data);
-          } else if (tab === 'borrowed') {
-            if (borrowedCacheRef.current[range]) return;
-            const data = await getBorrowingHistory(range, '');
-            setBorrowedHistoryCache(range, data);
-          }
-        } catch (err) {
-          // ignore background errors
-        }
-      })();
-    });
-  }, [getBalanceHistory, getCataBalanceHistory, getBorrowingHistory, setNetBalanceHistoryCache, setRewardsHistoryCache, setBorrowedHistoryCache]);
-
   const tabConfig = useMemo(() => ({
     netBalance: {
       fetchFn: getBalanceHistory,
@@ -254,18 +228,6 @@ const Dashboard = () => {
       
       if (cached && cached.length > 0) {
         setLoadingBalanceHistory(false);
-        prefetchOtherRanges(selectedTimeRange, activeTab);
-        
-        (async () => {
-          try {
-            const data = await config.fetchFn(selectedTimeRange, '');
-            if (isMounted) {
-              config.setCache(selectedTimeRange, data);
-            }
-          } catch (err) {
-            // ignore background errors
-          }
-        })();
         return;
       }
 
@@ -278,7 +240,6 @@ const Dashboard = () => {
       } finally {
         if (isMounted) {
           setLoadingBalanceHistory(false);
-          prefetchOtherRanges(selectedTimeRange, activeTab);
         }
       }
     };
@@ -288,7 +249,7 @@ const Dashboard = () => {
     return () => {
       isMounted = false;
     };
-  }, [selectedTimeRange, activeTab, tabConfig, prefetchOtherRanges, setLoadingBalanceHistory, isLoggedIn]);
+  }, [selectedTimeRange, activeTab, tabConfig, setLoadingBalanceHistory, isLoggedIn]);
 
   const onTimeRangeChange = useCallback((duration: string) => {
     setSelectedTimeRange(duration as TimeRange);

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -186,6 +186,7 @@ const Dashboard = () => {
   const netBalanceCacheRef = useRef(netBalanceHistoryCache);
   const rewardsCacheRef = useRef(rewardsHistoryCache);
   const borrowedCacheRef = useRef(borrowedHistoryCache);
+  const cacheTimestampsRef = useRef<Record<string, number>>({});
 
   useEffect(() => {
     netBalanceCacheRef.current = netBalanceHistoryCache;
@@ -219,14 +220,17 @@ const Dashboard = () => {
 
     const loadRange = async () => {
       const config = tabConfig[activeTab];
-      const cache = activeTab === 'netBalance' 
-        ? netBalanceCacheRef.current 
-        : activeTab === 'rewards' 
-        ? rewardsCacheRef.current 
+      const cache = activeTab === 'netBalance'
+        ? netBalanceCacheRef.current
+        : activeTab === 'rewards'
+        ? rewardsCacheRef.current
         : borrowedCacheRef.current;
+      const cacheKey = `${activeTab}:${selectedTimeRange}`;
       const cached = cache[selectedTimeRange];
-      
-      if (cached && cached.length > 0) {
+      const cachedAt = cacheTimestampsRef.current[cacheKey] || 0;
+      const isFresh = Date.now() - cachedAt < 10_000;
+
+      if (cached && cached.length > 0 && isFresh) {
         setLoadingBalanceHistory(false);
         return;
       }
@@ -236,6 +240,7 @@ const Dashboard = () => {
         const data = await config.fetchFn(selectedTimeRange, '');
         if (!isMounted) return;
         config.setCache(selectedTimeRange, data);
+        cacheTimestampsRef.current[cacheKey] = Date.now();
       } catch (err) {
       } finally {
         if (isMounted) {


### PR DESCRIPTION
Only one net-balance call is made on page load for the period selected.
When switching the periods, a separate call is made.
The data is cached and a period switch does not trigger new requests until the cache is expired.
Cache TTL is 15 seconds.