### PR TITLE
Unignore cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ strato/tools/x509-generator/subject.json
 strato/tools/genesis-builder/certs.json
 strato/haddock
 strato/hpc
-*.cabal
-!strato/simulator/strato-obelisk/**/*.cabal
 *~
 bridge_image_tag*
 

--- a/strato/VM/EVM/ethereum-vm/.gitignore
+++ b/strato/VM/EVM/ethereum-vm/.gitignore
@@ -2,4 +2,3 @@
 *~
 dist
 .DS_Store
-ethereum-vm.cabal

--- a/strato/VM/EVM/evm-solidity/.gitignore
+++ b/strato/VM/EVM/evm-solidity/.gitignore
@@ -1,1 +1,0 @@
-blockapps-solidity.cabal

--- a/strato/VM/EVM/evm-solidity/evm-solidity.cabal
+++ b/strato/VM/EVM/evm-solidity/evm-solidity.cabal
@@ -1,0 +1,84 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           evm-solidity
+version:        0.1.0.0
+synopsis:       Solidity datatypes
+description:    Solidity datatypes
+category:       Web
+author:         Eitan Chatav
+maintainer:     eitan@blockapps.net
+copyright:      2016 BlockApps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Solidity.ArgValue
+      BlockApps.Solidity.Contract
+      BlockApps.Solidity.Parse.Declarations
+      BlockApps.Solidity.Parse.Expression
+      BlockApps.Solidity.Parse.File
+      BlockApps.Solidity.Parse.Imports
+      BlockApps.Solidity.Parse.Lexer
+      BlockApps.Solidity.Parse.Parser
+      BlockApps.Solidity.Parse.ParserTypes
+      BlockApps.Solidity.Parse.Pragmas
+      BlockApps.Solidity.Parse.Selector
+      BlockApps.Solidity.Parse.Types
+      BlockApps.Solidity.Parse.UnParser
+      BlockApps.Solidity.SolidityValue
+      BlockApps.Solidity.Storage
+      BlockApps.Solidity.Struct
+      BlockApps.Solidity.Type
+      BlockApps.Solidity.TypeDefs
+      BlockApps.Solidity.Value
+      BlockApps.Solidity.Xabi
+      BlockApps.Solidity.Xabi.Def
+      BlockApps.Solidity.Xabi.Type
+      BlockApps.Solidity.XabiContract
+      BlockApps.SolidityVarReader
+      BlockApps.SolidVMStorageDecoder
+      BlockApps.Storage
+      BlockApps.XAbiConverter
+  other-modules:
+      Paths_evm_solidity
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      Decimal
+    , QuickCheck
+    , aeson
+    , aeson-casing
+    , base
+    , base16-bytestring
+    , bimap
+    , binary
+    , bytestring
+    , containers
+    , cryptonite
+    , deepseq
+    , extra
+    , generic-random
+    , hashable
+    , lens
+    , memory
+    , monad-alter
+    , mtl
+    , openapi3
+    , ordered-containers
+    , parsec
+    , quickcheck-instances
+    , scientific
+    , semver-range
+    , solid-vm-model
+    , strato-model
+    , text
+    , transformers
+    , unordered-containers
+    , vector
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/debugger/debugger.cabal
+++ b/strato/VM/SolidVM/debugger/debugger.cabal
@@ -1,0 +1,71 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           debugger
+version:        0.0.1
+synopsis:       A debugging API that can be hooked in to any Haskell project
+description:    A debugging API that can be hooked in to any Haskell project
+category:       Debuggers
+author:         Dustin Norwood
+maintainer:     dustin@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Debugger
+      Debugger.Options
+  other-modules:
+      Debugger.Init
+      Debugger.Rest
+      Debugger.Rest.Api
+      Debugger.Rest.Server
+      Debugger.Server
+      Debugger.Types
+      Debugger.Util
+      Debugger.WebSocket
+      Debugger.WebSocket.Api
+      Debugger.WebSocket.Server
+      Paths_debugger
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      QuickCheck
+    , aeson
+    , async
+    , base
+    , containers
+    , deepseq
+    , hflags
+    , monad-alter
+    , parsec
+    , quickcheck-instances
+    , servant-server
+    , source-tools
+    , text
+    , unliftio
+    , warp
+    , websockets
+  default-language: Haskell2010
+
+test-suite debugger-spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      DebuggerSpec
+      Spec
+      Paths_debugger
+  hs-source-dirs:
+      tests/
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , debugger
+    , hflags
+    , hspec
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm-compiler/solid-vm-compiler.cabal
+++ b/strato/VM/SolidVM/solid-vm-compiler/solid-vm-compiler.cabal
@@ -1,0 +1,43 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm-compiler
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.SolidVM.CodeCollectionDB
+      Blockchain.SolidVM.Metrics
+      SolidVM.CodeCollectionTools
+  other-modules:
+      Blockchain.SolidVM.ImportResolver
+      Paths_solid_vm_compiler
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      aeson
+    , base
+    , blockapps-mpdbs
+    , bytestring
+    , containers
+    , data-default
+    , deepseq
+    , lens
+    , lrucache
+    , monad-alter
+    , parsec
+    , prometheus-client
+    , solid-vm-model
+    , solid-vm-parser
+    , solid-vm-static-analysis
+    , source-tools
+    , strato-model
+    , text
+    , transformers
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm-fuzzer/solid-vm-fuzzer.cabal
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/solid-vm-fuzzer.cabal
@@ -1,0 +1,93 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm-fuzzer
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      SolidVM.Solidity.Fuzzer
+      SolidVM.Solidity.Fuzzer.Types
+      SolidVM.Solidity.SourceTools
+  other-modules:
+      Paths_solid_vm_fuzzer
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , blockapps-data
+    , bytestring
+    , common-log
+    , containers
+    , debugger
+    , exceptions
+    , lens
+    , monad-alter
+    , servant-server
+    , solid-vm
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-static-analysis
+    , source-tools
+    , strato-model
+    , text
+    , transformers
+    , unliftio
+    , vm-tools
+  default-language: Haskell2010
+
+executable solid-vm-cli
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , containers
+    , data-default
+    , debugger
+    , exceptions
+    , hflags
+    , lens
+    , monad-alter
+    , solid-vm-compiler
+    , solid-vm-fuzzer
+    , solid-vm-model
+    , solid-vm-static-analysis
+    , source-tools
+    , strato-model
+    , text
+    , unliftio
+    , vm-tools
+  default-language: Haskell2010
+
+test-suite solid-vm-spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      FuzzerSpec
+      Spec
+      Paths_solid_vm_fuzzer
+  hs-source-dirs:
+      tests/
+  ghc-options: -Wall -O2 -dynamic
+  build-depends:
+      base
+    , hflags
+    , hspec
+    , raw-strings-qq
+    , solid-vm-fuzzer
+    , source-tools
+    , text
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm-model/solid-vm-model.cabal
+++ b/strato/VM/SolidVM/solid-vm-model/solid-vm-model.cabal
@@ -1,0 +1,114 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm-model
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Ethereum2
+      Blockchain.SolidVM.Exception
+      Blockchain.VM.SolidException
+      SolidVM.Model.CodeCollection
+      SolidVM.Model.CodeCollection.ConstantDecl
+      SolidVM.Model.CodeCollection.Contract
+      SolidVM.Model.CodeCollection.Def
+      SolidVM.Model.CodeCollection.Event
+      SolidVM.Model.CodeCollection.Function
+      SolidVM.Model.CodeCollection.Import
+      SolidVM.Model.CodeCollection.Statement
+      SolidVM.Model.CodeCollection.VarDef
+      SolidVM.Model.CodeCollection.VariableDecl
+      SolidVM.Model.CodeCollection.Visibility
+      SolidVM.Model.SolidString
+      SolidVM.Model.Storable
+      SolidVM.Model.Type
+      SolidVM.Model.Value
+  other-modules:
+      Paths_solid_vm_model
+  hs-source-dirs:
+      src/
+  default-extensions:
+      BangPatterns
+      OverloadedStrings
+  build-depends:
+      Decimal
+    , QuickCheck
+    , aeson >=2.1.1.0 && <2.3
+    , aeson-casing
+    , attoparsec
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , containers
+    , cryptonite
+    , data-default
+    , deepseq
+    , esqueleto
+    , ethereum-rlp
+    , format
+    , generic-random
+    , hashable
+    , labeled-error
+    , lens
+    , openapi3
+    , persistent
+    , quickcheck-instances
+    , regex-tdfa
+    , scientific
+    , servant-server
+    , source-tools
+    , strato-model
+    , text
+    , utf8-string
+    , vector
+  default-language: Haskell2010
+
+test-suite storage-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      BasicValueStringTest
+      StorageTest
+  hs-source-dirs:
+      test/
+  default-extensions:
+      BangPatterns
+      OverloadedStrings
+  ghc-options: -dynamic
+  build-depends:
+      base
+    , bytestring
+    , ethereum-rlp
+    , format
+    , hspec
+    , persistent
+    , solid-vm-model
+    , unliftio
+  default-language: Haskell2010
+
+benchmark storage-bench
+  type: exitcode-stdio-1.0
+  main-is: StorageBench.hs
+  hs-source-dirs:
+      bench/
+  default-extensions:
+      BangPatterns
+      OverloadedStrings
+  ghc-options: -dynamic
+  build-depends:
+      base
+    , binary
+    , bytestring
+    , cereal
+    , criterion
+    , ethereum-rlp
+    , solid-vm-model
+    , strato-model
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm-parser/solid-vm-parser.cabal
+++ b/strato/VM/SolidVM/solid-vm-parser/solid-vm-parser.cabal
@@ -1,0 +1,87 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm-parser
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      SolidVM.Solidity.Parse.File
+      SolidVM.Solidity.Parse.Lexer
+      SolidVM.Solidity.Parse.Statement
+      SolidVM.Solidity.Parse.Pragmas
+      SolidVM.Solidity.Parse.ParserTypes
+      SolidVM.Solidity.Parse.UnParser
+      SolidVM.Solidity.Parse.Declarations
+      SolidVM.Solidity.Xabi
+  other-modules:
+      SolidVM.Solidity.Parse.Alias
+      SolidVM.Solidity.Parse.Expression
+      SolidVM.Solidity.Parse.Imports
+      SolidVM.Solidity.Parse.Parser
+      SolidVM.Solidity.Parse.Types
+      Paths_solid_vm_parser
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      Decimal
+    , QuickCheck
+    , aeson
+    , aeson-casing
+    , base
+    , bytestring
+    , containers
+    , deepseq
+    , extra
+    , lens
+    , openapi3
+    , parsec
+    , quickcheck-instances
+    , semver-range
+    , solid-vm-model
+    , source-tools
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+executable parse-solidvm
+  main-is: Parse.hs
+  hs-source-dirs:
+      exec_src
+  ghc-options: -Wall -O2 -threaded -rtsopts
+  build-depends:
+      base
+    , containers
+    , parsec
+    , solid-vm-parser
+  default-language: Haskell2010
+
+test-suite solid-vm-spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      ParserSpec
+      PragmaSpec
+      Spec
+      Paths_solid_vm_parser
+  hs-source-dirs:
+      tests/
+  ghc-options: -dynamic
+  build-depends:
+      HUnit
+    , base
+    , hflags
+    , hspec
+    , parsec
+    , raw-strings-qq
+    , solid-vm-model
+    , solid-vm-parser
+    , source-tools
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm-static-analysis/solid-vm-static-analysis.cabal
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/solid-vm-static-analysis.cabal
@@ -1,0 +1,45 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm-static-analysis
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      SolidVM.Solidity.StaticAnalysis
+      SolidVM.Solidity.StaticAnalysis.Contracts.ParentConstructors
+      SolidVM.Solidity.StaticAnalysis.Expressions.BooleanLiterals
+      SolidVM.Solidity.StaticAnalysis.Expressions.DivideBeforeMultiply
+      SolidVM.Solidity.StaticAnalysis.Pragmas.IncorrectSolidityVersion
+      SolidVM.Solidity.StaticAnalysis.Functions.ConstantFunctions
+      SolidVM.Solidity.StaticAnalysis.Optimizer
+      SolidVM.Solidity.StaticAnalysis.Statements.MultipleDeclarations
+      SolidVM.Solidity.StaticAnalysis.Statements.StateVariableShadowing
+      SolidVM.Solidity.StaticAnalysis.Statements.UninitializedLocalVariables
+      SolidVM.Solidity.StaticAnalysis.Statements.WriteAfterWrite
+      SolidVM.Solidity.StaticAnalysis.Typechecker
+      SolidVM.Solidity.StaticAnalysis.Types
+      SolidVM.Solidity.StaticAnalysis.Variables.StateVariables
+  other-modules:
+      SolidVM.Solidity.StaticAnalysis.Trivial
+      Paths_solid_vm_static_analysis
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      Decimal
+    , base
+    , containers
+    , lens
+    , mtl
+    , solid-vm-model
+    , solid-vm-parser
+    , source-tools
+    , text
+    , transformers
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/solid-vm/solid-vm.cabal
+++ b/strato/VM/SolidVM/solid-vm/solid-vm.cabal
@@ -1,0 +1,176 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           solid-vm
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.SolidVM
+      Blockchain.SolidVM.Simple
+      Blockchain.SolidVM.SM
+  other-modules:
+      Blockchain.SolidVM.Builtins
+      Blockchain.SolidVM.Environment
+      Blockchain.SolidVM.GasInfo
+      Blockchain.SolidVM.SetGet
+      Blockchain.SolidVM.TraceTools
+      Paths_solid_vm
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      Decimal
+    , base
+    , base16-bytestring
+    , base64-bytestring
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-haskoin
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , containers
+    , cryptohash
+    , crypton
+    , data-default
+    , debugger
+    , deepseq
+    , elliptic-curve
+    , ethereum-rlp
+    , exceptions
+    , extra
+    , format
+    , galois-field
+    , labeled-error
+    , lens
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , ordered-containers
+    , pairing
+    , parsec
+    , poseidon-hash
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-parser
+    , solid-vm-static-analysis
+    , source-tools
+    , strato-conf
+    , strato-model
+    , text
+    , time
+    , transformers
+    , unliftio
+    , utf8-string
+    , vector
+    , vm-tools
+  default-language: Haskell2010
+
+executable exprs-needed
+  main-is: ExprsNeeded.hs
+  hs-source-dirs:
+      exec_src
+  build-depends:
+      base
+    , containers
+    , parsec
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-parser
+    , solid-vm-static-analysis
+    , text
+  default-language: Haskell2010
+
+test-suite solid-vm-spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      OptimizerSpec
+      SolidVMSpec
+      Spec
+      StaticAnalysisSpec
+      TypecheckerSpec
+      Paths_solid_vm
+  hs-source-dirs:
+      tests/
+  ghc-options: -dynamic
+  build-depends:
+      QuickCheck
+    , aeson
+    , async
+    , base
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , composable-monads-base
+    , containers
+    , crypto-api
+    , ethereum-rlp
+    , extra
+    , hflags
+    , hspec
+    , hspec-expectations-lifted
+    , labeled-error
+    , lens
+    , merkle-patricia-db
+    , monad-alter
+    , ordered-containers
+    , raw-strings-qq
+    , seqevents
+    , solid-vm
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-parser
+    , solid-vm-static-analysis
+    , source-tools
+    , strato-genesis
+    , strato-init
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , transformers
+    , unliftio
+    , utf8-string
+    , vm-tools
+  default-language: Haskell2010
+
+benchmark codebench
+  type: exitcode-stdio-1.0
+  main-is: CodeBench.hs
+  other-modules:
+      Paths_solid_vm
+  hs-source-dirs:
+      bench/
+  ghc-options: -dynamic
+  build-depends:
+      base
+    , binary
+    , bytestring
+    , common-log
+    , containers
+    , criterion
+    , deepseq
+    , file-embed
+    , hflags
+    , lens
+    , memory
+    , parsec
+    , solid-vm
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-parser
+    , solid-vm-static-analysis
+    , strato-model
+    , text
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/VM/SolidVM/source-tools/source-tools.cabal
+++ b/strato/VM/SolidVM/source-tools/source-tools.cabal
@@ -1,0 +1,56 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           source-tools
+version:        0.0.1.0
+author:         dustin@blockapps.net
+maintainer:     dustin@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Data.Source
+      Data.Source.Annotation
+      Data.Source.Diagnostic
+      Data.Source.Map
+      Data.Source.Position
+      Data.Source.Severity
+  other-modules:
+      Paths_source_tools
+  hs-source-dirs:
+      src
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , binary
+    , bytestring
+    , containers
+    , data-default
+    , deepseq
+    , ethereum-rlp
+    , hashable
+    , lens
+    , openapi3
+    , parsec
+    , quickcheck-instances
+    , text
+  default-language: Haskell2010
+
+test-suite source-tools-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test/
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , hspec
+    , source-tools
+    , text
+  default-language: Haskell2010

--- a/strato/VM/vrun/vrun.cabal
+++ b/strato/VM/vrun/vrun.cabal
@@ -1,0 +1,46 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           vrun
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/vrun#readme>
+homepage:       https://github.com/githubuser/vrun#readme
+bug-reports:    https://github.com/githubuser/vrun/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/vrun
+
+executable vrun
+  main-is: Main.hs
+  other-modules:
+      Paths_vrun
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , hflags
+    , merkle-patricia-db
+    , prometheus-client
+    , strato-model
+    , text
+    , time
+    , transformers
+    , vm-runner
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/api/bloc/bloc2/bloc2.cabal
+++ b/strato/api/bloc/bloc2/bloc2.cabal
@@ -1,0 +1,97 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           bloc2
+version:        0.1.0.0
+synopsis:       Bloc microservice
+description:    Bloc microservice
+category:       Web
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Bloc.Database.Queries
+      Bloc.Monad
+      Bloc.Server
+      Bloc.Server.Contracts
+      Bloc.Server.Transaction
+      Bloc.Server.TransactionResult
+      Bloc.Server.Utils
+      Bloc.XabiHelper
+  other-modules:
+      Paths_bloc2
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -Werror -fsimpl-tick-factor=15000
+  build-depends:
+      base
+    , base16-bytestring
+    , bimap
+    , bloc2api
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , blockapps-secp256k1-haskell
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , cache
+    , clock
+    , common-log
+    , containers
+    , core-api2
+    , deepseq
+    , esqueleto
+    , ethereum-rlp
+    , evm-solidity
+    , extra
+    , format
+    , hashable
+    , insert-ordered-containers
+    , labeled-error
+    , lens
+    , monad-alter
+    , monad-logger
+    , mtl
+    , openapi3
+    , ordered-containers
+    , parsec
+    , seqevents
+    , servant-client
+    , servant-openapi3
+    , servant-server
+    , solid-vm-compiler
+    , solid-vm-model
+    , solid-vm-parser
+    , source-tools
+    , sql-monad
+    , strato-auth
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , transformers
+    , unliftio
+    , vault-monad
+    , vector
+  default-language: Haskell2010
+
+test-suite blockapps-bloc22-server-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      UtilsSpec
+      Paths_bloc2
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror
+  build-depends:
+      base
+    , bloc2
+    , hspec
+  default-language: Haskell2010

--- a/strato/api/bloc/bloc2api/bloc2api.cabal
+++ b/strato/api/bloc/bloc2api/bloc2api.cabal
@@ -1,0 +1,74 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           bloc2api
+version:        0.1.0.0
+synopsis:       Bloc microservice
+description:    Bloc microservice
+category:       Web
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Bloc.API
+      Bloc.API.AbiBin
+      Bloc.API.Contracts
+      Bloc.API.DeprecatedPostTransaction
+      Bloc.API.Git
+      Bloc.API.SwaggerSchema
+      Bloc.API.Transaction
+      Bloc.API.TypeWrappers
+      Bloc.API.Users
+      Bloc.API.Utils
+  other-modules:
+      Paths_bloc2api
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      QuickCheck
+    , aeson
+    , aeson-casing
+    , base
+    , binary
+    , blockDB
+    , blockapps-data
+    , bytestring
+    , containers
+    , evm-solidity
+    , generic-random
+    , gitrev
+    , http-api-data
+    , lens
+    , openapi3
+    , quickcheck-instances
+    , servant
+    , servant-docs
+    , servant-server
+    , solid-vm-model
+    , source-tools
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+test-suite blockapps-strato-api-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Strato.TypesSpec
+      Paths_bloc2api
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror -dynamic
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , bloc2api
+    , hspec
+    , quickcheck-instances
+  default-language: Haskell2010

--- a/strato/api/bloc/bloc2client/bloc2client.cabal
+++ b/strato/api/bloc/bloc2client/bloc2client.cabal
@@ -1,0 +1,40 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           bloc2client
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/bloc2client#readme>
+homepage:       https://github.com/githubuser/bloc2client#readme
+bug-reports:    https://github.com/githubuser/bloc2client/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2023 Author name here
+license:        BSD3
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/bloc2client
+
+library
+  exposed-modules:
+      Bloc.Client
+  other-modules:
+      Paths_bloc2client
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  build-depends:
+      base
+    , bloc2api
+    , servant-client
+    , solid-vm-model
+    , strato-model
+    , text
+  default-language: Haskell2010

--- a/strato/api/core/core-api2.cabal
+++ b/strato/api/core/core-api2.cabal
@@ -1,0 +1,87 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           core-api2
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Core.API
+      FaucetKey
+      Handlers.AccountInfo
+      Handlers.BlkLast
+      Handlers.Block
+      Handlers.Metadata
+      Handlers.Peers
+      Handlers.QueuedTransactions
+      Handlers.Stats
+      Handlers.Storage
+      Handlers.Transaction
+      Handlers.TransactionResult
+      Handlers.TxLast
+      Settings
+      SortDirection
+      SQLM
+      Versioning
+  other-modules:
+      Paths_core_api2
+  hs-source-dirs:
+      src
+  build-depends:
+      QuickCheck
+    , aeson
+    , aeson-casing
+    , base
+    , base64-bytestring
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , clock
+    , common-log
+    , conduit
+    , containers
+    , deepseq
+    , directory
+    , esqueleto
+    , ethereum-discovery
+    , evm-solidity
+    , extra
+    , filepath
+    , format
+    , hflags
+    , http-types
+    , labeled-error
+    , lens
+    , monad-alter
+    , mtl
+    , openapi3
+    , persistent-postgresql
+    , process
+    , seqevents
+    , servant-client
+    , servant-multipart
+    , servant-multipart-client
+    , servant-server
+    , solid-vm-model
+    , source-tools
+    , sql-monad
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , template-haskell
+    , text
+    , time
+    , transformers
+    , unliftio
+    , unordered-containers
+    , vault-monad
+  default-language: Haskell2010

--- a/strato/api/ethereum-jsonrpc/.gitignore
+++ b/strato/api/ethereum-jsonrpc/.gitignore
@@ -3,4 +3,3 @@
 dist
 .DS_Store
 .stack-work
-ethereum-jsonrpc.cabal

--- a/strato/api/strato-api/strato-api.cabal
+++ b/strato/api/strato-api/strato-api.cabal
@@ -1,0 +1,68 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-api
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+executable strato-api
+  main-is: Main.hs
+  other-modules:
+      Paths_strato_api
+  hs-source-dirs:
+      exec_src
+  ghc-options: -threaded
+  build-depends:
+      aeson
+    , base
+    , bloc2
+    , bloc2api
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-init
+    , blockapps-mpdbs
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , cache
+    , clock
+    , common-log
+    , containers
+    , core-api2
+    , ethereum-discovery
+    , format
+    , hflags
+    , http-types
+    , insert-ordered-containers
+    , lens
+    , monad-alter
+    , openapi3
+    , process-monitor
+    , regex-compat
+    , servant-client-core
+    , servant-multipart
+    , servant-openapi3
+    , servant-server
+    , servant-swagger-ui
+    , solid-vm-model
+    , source-tools
+    , sql-monad
+    , strato-auth
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , transformers
+    , unliftio
+    , vault-monad
+    , wai
+    , wai-cors
+    , wai-extra
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010

--- a/strato/core/blockDB/blockDB.cabal
+++ b/strato/core/blockDB/blockDB.cabal
@@ -1,0 +1,90 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockDB
+version:        0.0.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.BlockDB
+      Blockchain.DB.Witnessable
+      Blockchain.Model.JsonBlock
+      Blockchain.Model.SyncState
+      Blockchain.Model.SyncTask
+      Blockchain.Model.WrappedBlock
+      Blockchain.SyncDB
+  other-modules:
+      Paths_blockDB
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fconstraint-solver-iterations=8
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , binary
+    , blockapps-data
+    , blockapps-datadefs
+    , bytestring
+    , common-log
+    , containers
+    , data-default
+    , deepseq
+    , esqueleto
+    , ethereum-rlp
+    , format
+    , generic-arbitrary
+    , hedis
+    , labeled-error
+    , lens
+    , mtl
+    , openapi3
+    , persistent
+    , random
+    , raw-strings-qq
+    , sql-monad
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+  default-language: Haskell2010
+
+test-suite blockdb-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      BlockDBSpec
+      BlockSpec
+      Spec
+      Paths_blockDB
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -O0 -Wall -rtsopts -fno-warn-unused-do-bind -dynamic
+  build-depends:
+      HUnit
+    , QuickCheck
+    , aeson
+    , aeson-diff
+    , base >=4.7 && <5
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-secp256k1-haskell
+    , bytestring
+    , containers
+    , ethereum-rlp
+    , format
+    , hedis
+    , hspec
+    , http-api-data
+    , labeled-error
+    , lens-family
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , vector
+  default-language: Haskell2010

--- a/strato/core/blockapps-data/.gitignore
+++ b/strato/core/blockapps-data/.gitignore
@@ -3,4 +3,3 @@ genesis.json
 dist
 .DS_Store
 #*#
-blockapps-data.cabal

--- a/strato/core/blockapps-data/blockapps-data.cabal
+++ b/strato/core/blockapps-data/blockapps-data.cabal
@@ -1,0 +1,87 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-data
+version:        0.0.1
+synopsis:       A Haskell version of an Ethereum client
+description:    The client described in the Ethereum Yellowpaper
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Constants
+      Blockchain.Data.AddressStateRef
+      Blockchain.Data.Block
+      Blockchain.Data.BlockDB
+      Blockchain.Data.BlockHeader
+      Blockchain.Data.ChainInfo
+      Blockchain.Data.Enode
+      Blockchain.Data.EventDB
+      Blockchain.Data.Extra
+      Blockchain.Data.Log
+      Blockchain.Data.LogDB
+      Blockchain.Data.RawTransaction
+      Blockchain.Data.Transaction
+      Blockchain.Data.TransactionDef
+      Blockchain.Data.TransactionResult
+      Blockchain.DB.DetailsDB
+      Blockchain.DB.SQLDB
+      Blockchain.DBM
+      Blockchain.Verification
+  other-modules:
+      Paths_blockapps_data
+  hs-source-dirs:
+      src/
+  default-extensions:
+      TemplateHaskell
+  ghc-options: -Wall -O2
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , base-unicode-symbols
+    , base16-bytestring
+    , binary
+    , blockapps-datadefs
+    , blockapps-secp256k1-haskell
+    , bytestring
+    , bytestring-arbitrary
+    , clock
+    , common-log
+    , composable-monads-base
+    , containers
+    , data-default
+    , deepseq
+    , esqueleto
+    , ethereum-rlp
+    , filepath
+    , format
+    , generic-arbitrary
+    , generic-random
+    , labeled-error
+    , lens
+    , merkle-patricia-db
+    , monad-logger
+    , network
+    , openapi3
+    , persistent
+    , persistent-postgresql
+    , quickcheck-instances
+    , regex-compat
+    , resourcet
+    , servant-docs
+    , strato-conf
+    , strato-model
+    , text
+    , time
+    , transformers
+    , unliftio
+    , unliftio-core
+  default-language: Haskell2010

--- a/strato/core/blockapps-datadefs/blockapps-datadefs.cabal
+++ b/strato/core/blockapps-datadefs/blockapps-datadefs.cabal
@@ -1,0 +1,47 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-datadefs
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Data.DataDefs
+      Blockchain.Data.PersistTypes
+      Blockchain.Data.TransactionResultStatus
+      Blockchain.Data.TXOrigin
+  other-modules:
+      Paths_blockapps_datadefs
+  hs-source-dirs:
+      src/
+  default-extensions:
+      TemplateHaskell
+  ghc-options: -Wall -O2 -fconstraint-solver-iterations=20
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , crypto-pubkey-types
+    , deepseq
+    , ethereum-encryption
+    , evm-solidity
+    , format
+    , generic-arbitrary
+    , generic-random
+    , labeled-error
+    , openapi3
+    , persistent
+    , solid-vm-model
+    , strato-model
+    , text
+    , time
+    , transformers
+  default-language: Haskell2010

--- a/strato/core/blockapps-mpdbs/blockapps-mpdbs.cabal
+++ b/strato/core/blockapps-mpdbs/blockapps-mpdbs.cabal
@@ -1,0 +1,91 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-mpdbs
+version:        0.0.1
+synopsis:       A Haskell version of an Ethereum client
+description:    The client described in the Ethereum Yellowpaper
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Data.AddressStateDB
+      Blockchain.DB.AddressStateDB
+      Blockchain.DB.ChainDB
+      Blockchain.DB.CodeDB
+      Blockchain.DB.HashDB
+      Blockchain.DB.MemAddressStateDB
+      Blockchain.DB.RawStorageDB
+      Blockchain.DB.SolidStorageDB
+      Blockchain.DB.StateDB
+      Blockchain.DB.StorageDB
+  other-modules:
+      Paths_blockapps_mpdbs
+  hs-source-dirs:
+      src/
+  default-extensions:
+      TemplateHaskell
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , common-log
+    , containers
+    , data-default
+    , deepseq
+    , ethereum-rlp
+    , fastMP
+    , format
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , monad-logger
+    , monad-loops
+    , nibblestring
+    , solid-vm-model
+    , strato-model
+    , text
+    , transformers
+    , unliftio-core
+  default-language: Haskell2010
+
+test-suite blockapps-mpdbs-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      StorageSpec
+      Paths_blockapps_mpdbs
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -O2 -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -dynamic
+  build-depends:
+      base
+    , blockapps-data
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , containers
+    , directory
+    , hspec
+    , hspec-expectations-lifted
+    , lens
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , resourcet
+    , solid-vm-model
+    , strato-model
+    , transformers
+    , unix
+    , unliftio
+  default-language: Haskell2010

--- a/strato/core/blockstanbul/.gitignore
+++ b/strato/core/blockstanbul/.gitignore
@@ -1,2 +1,1 @@
 -- experimental hpack trial
-blockstanbul.cabal

--- a/strato/core/blockstanbul/blockstanbul.cabal
+++ b/strato/core/blockstanbul/blockstanbul.cabal
@@ -1,0 +1,87 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockstanbul
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Blockstanbul
+      Blockchain.Blockstanbul.Authentication
+      Blockchain.Blockstanbul.BenchmarkLib
+      Blockchain.Blockstanbul.EventLoop
+      Blockchain.Blockstanbul.Messages
+      Blockchain.Blockstanbul.Metrics
+      Blockchain.Blockstanbul.Options
+      Blockchain.Blockstanbul.StateMachine
+  other-modules:
+      Paths_blockstanbul
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , binary
+    , blockDB
+    , blockapps-data
+    , bytestring
+    , common-log
+    , conduit
+    , containers
+    , cross-monitoring
+    , cryptonite
+    , data-default
+    , deepseq
+    , ethereum-rlp
+    , extra
+    , format
+    , generic-arbitrary
+    , hflags
+    , lens
+    , monad-alter
+    , mtl
+    , prometheus-client
+    , strato-model
+    , text
+    , transformers
+  default-language: Haskell2010
+
+test-suite blockstanbul-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      AuthenticationSpec
+      MessageSpec
+      Spec
+      StateMachineSpec
+      Paths_blockstanbul
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror -dynamic
+  build-depends:
+      base
+    , common-log
+    , hflags
+    , hspec
+  default-language: Haskell2010
+
+benchmark one-node
+  type: exitcode-stdio-1.0
+  main-is: OneNode.hs
+  other-modules:
+      Paths_blockstanbul
+  hs-source-dirs:
+      bench/
+  ghc-options: -Wall -Werror -dynamic
+  build-depends:
+      base
+    , blockstanbul
+    , transformers
+  default-language: Haskell2010

--- a/strato/core/certificateDB/certificateDB.cabal
+++ b/strato/core/certificateDB/certificateDB.cabal
@@ -1,0 +1,29 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           certificateDB
+version:        0.0.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.CertificateDB
+  other-modules:
+      Paths_certificateDB
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -O2
+  build-depends:
+      base
+    , bytestring
+    , hedis
+    , monad-alter
+    , mtl
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+  default-language: Haskell2010

--- a/strato/core/ethereum-discovery/.gitignore
+++ b/strato/core/ethereum-discovery/.gitignore
@@ -10,9 +10,6 @@ cabal-dev
 .virtualenv
 .hpc
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
 *.prof
 *.aux
 *.hp
-ethereum-discovery.cabal

--- a/strato/core/ethereum-discovery/ethereum-discovery.cabal
+++ b/strato/core/ethereum-discovery/ethereum-discovery.cabal
@@ -1,0 +1,144 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           ethereum-discovery
+version:        0.1.0.0
+author:         jamshid
+maintainer:     jim
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Strato.Discovery.Data.MemPeerDB
+      Blockchain.Strato.Discovery.Data.Peer
+      Blockchain.Strato.Discovery.Data.PeerIOWiring
+      Blockchain.Strato.Discovery.ContextLite
+      Blockchain.Strato.Discovery.UDP
+      Blockchain.Strato.Discovery.UDPServer
+      Blockchain.Strato.Discovery.P2PUtil
+      Executable.EthereumDiscovery
+      Executable.EthDiscoverySetup
+      Executable.Options
+  other-modules:
+      Blockchain.Strato.Discovery.Data.PeerDefinition
+      Blockchain.Strato.Discovery.Metrics
+      Paths_ethereum_discovery
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , base16-bytestring
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , bytestring
+    , common-log
+    , composable-monads-base
+    , containers
+    , cpu
+    , crypto-pubkey-types
+    , data-default
+    , either
+    , entropy
+    , errors
+    , esqueleto
+    , ethereum-encryption
+    , ethereum-rlp
+    , exceptions
+    , format
+    , hedis
+    , hflags
+    , http-client
+    , iproute
+    , labeled-error
+    , lens
+    , monad-alter
+    , mtl
+    , network
+    , network-uri
+    , persistent
+    , persistent-postgresql
+    , prometheus-client
+    , random
+    , split
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , unliftio
+    , unliftio-core
+    , vault-monad
+  default-language: Haskell2010
+
+executable ethereum-discover
+  main-is: Main.hs
+  other-modules:
+      Paths_ethereum_discovery
+  hs-source-dirs:
+      exec_src/ethereumDiscovery/
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , blockapps-init
+    , common-log
+    , ethereum-discovery
+    , format
+    , hflags
+    , monad-logger
+    , mtl
+    , network
+    , process-monitor
+    , resourcet
+    , strato-conf
+    , strato-networks
+    , text
+    , unliftio
+    , vault-monad
+  default-language: Haskell2010
+
+executable strato-network-monitor
+  main-is: Main.hs
+  other-modules:
+      NetworkInterface
+      NetworkInterfaceEvent
+      Paths_ethereum_discovery
+  hs-source-dirs:
+      exec_src/networkMonitor/
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , common-log
+    , containers
+    , ethereum-discovery
+    , format
+    , hflags
+    , network
+    , network-info
+    , text
+  default-language: Haskell2010
+
+test-suite ethereum-discover-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Blockchain.Strato.Discovery.UDPSpec
+      Paths_ethereum_discovery
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -O2 -Wall -Werror -dynamic
+  build-depends:
+      base
+    , ethereum-discovery
+    , ethereum-rlp
+    , format
+    , hspec
+    , network
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/ethereum-encryption/.gitignore
+++ b/strato/core/ethereum-encryption/.gitignore
@@ -1,4 +1,3 @@
 
 dist
 *~
-ethereum-encryption.cabal

--- a/strato/core/ethereum-encryption/ethereum-encryption.cabal
+++ b/strato/core/ethereum-encryption/ethereum-encryption.cabal
@@ -1,0 +1,52 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           ethereum-encryption
+version:        0.1.0.0
+author:         jamshid
+maintainer:     jim
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.AESCTR
+      Blockchain.Data.PubKey
+      Blockchain.ECIES
+      Blockchain.Error
+      Blockchain.EthEncryptionException
+      Blockchain.Frame
+      Blockchain.Handshake
+      Blockchain.RLPx
+  other-modules:
+      Paths_ethereum_encryption
+  hs-source-dirs:
+      src
+  other-extensions:
+      OverloadedStrings
+  ghc-options: -Wall -O2
+  build-depends:
+      Crypto
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cipher-aes
+    , common-log
+    , conduit
+    , conduit-extra
+    , crypto-pubkey-types
+    , cryptohash
+    , cryptonite
+    , entropy
+    , ethereum-rlp
+    , format
+    , lifted-base
+    , memory
+    , strato-model
+    , text
+    , unix
+  default-language: Haskell2010

--- a/strato/core/fast-keccak256/fast-keccak256.cabal
+++ b/strato/core/fast-keccak256/fast-keccak256.cabal
@@ -1,0 +1,62 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           fast-keccak256
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      FastKeccak256
+  other-modules:
+      Paths_fast_keccak256
+  hs-source-dirs:
+      src/
+  other-extensions:
+      ForeignFunctionInterface
+  ghc-options: -Wall -Werror
+  cc-options: -std=c11
+  include-dirs:
+      c-src/
+  c-sources:
+      c-src/keccak-tiny.c
+  build-depends:
+      base
+    , bytestring
+    , cryptonite
+    , memory
+  default-language: Haskell2010
+
+test-suite keccak256-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_fast_keccak256
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror
+  build-depends:
+      base
+    , bytestring
+    , fast-keccak256
+    , hspec
+  default-language: Haskell2010
+
+benchmark hash-bench
+  type: exitcode-stdio-1.0
+  main-is: HashBench.hs
+  other-modules:
+      Paths_fast_keccak256
+  hs-source-dirs:
+      bench/
+  ghc-options: -Wall -Werror
+  build-depends:
+      base
+    , bytestring
+    , criterion
+    , fast-keccak256
+  default-language: Haskell2010

--- a/strato/core/fastMP/fastMP.cabal
+++ b/strato/core/fastMP/fastMP.cabal
@@ -1,0 +1,115 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           fastMP
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BatchMerge
+      FastMP
+      KV
+      LevelDBTools
+      ReverseOrderedKVs
+  other-modules:
+      Paths_fastMP
+  hs-source-dirs:
+      src
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , common-log
+    , conduit
+    , ethereum-rlp
+    , format
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , monad-loops
+    , nibblestring
+    , resourcet
+    , strato-model
+    , text
+    , transformers
+  default-language: Haskell2010
+
+executable fastMP-exe
+  main-is: Main.hs
+  other-modules:
+      Paths_fastMP
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , ethereum-rlp
+    , fastMP
+    , format
+    , leveldb-haskell
+    , merkle-patricia-db
+    , nibblestring
+    , resourcet
+  default-language: Haskell2010
+
+executable insertLDB
+  main-is: insertLDB.hs
+  other-modules:
+      Main
+      Paths_fastMP
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , bytestring
+    , conduit
+    , fastMP
+    , labeled-error
+    , leveldb-haskell
+  default-language: Haskell2010
+
+executable insertMP
+  main-is: insertMP.hs
+  other-modules:
+      Main
+      Paths_fastMP
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , bytestring
+    , ethereum-rlp
+    , fastMP
+    , format
+    , labeled-error
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , transformers
+  default-language: Haskell2010
+
+executable makeSampleKVs
+  main-is: makeSampleKVs.hs
+  other-modules:
+      Main
+      Paths_fastMP
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/merkle-patricia-db/.gitignore
+++ b/strato/core/merkle-patricia-db/.gitignore
@@ -7,7 +7,3 @@ cabal-dev
 *.chs.h
 .virtualenv
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
-cabal.config
-merkle-patricia-db.cabal

--- a/strato/core/merkle-patricia-db/merkle-patricia-db.cabal
+++ b/strato/core/merkle-patricia-db/merkle-patricia-db.cabal
@@ -1,0 +1,103 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           merkle-patricia-db
+version:        0.0.1
+synopsis:       A modified Merkle Patricia DB
+description:    The modified Merkle Patricia DB described in the Ethereum Yellowpaper
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Database.MerklePatricia
+      Blockchain.Database.MerklePatricia.Diff
+      Blockchain.Database.MerklePatricia.ForEach
+      Blockchain.Database.MerklePatricia.Internal
+      Blockchain.Database.MerklePatricia.Map
+      Blockchain.Database.MerklePatricia.MPDB
+      Blockchain.Database.MerklePatricia.NodeData
+      Blockchain.Database.MerklePatricia.StateRoot
+  other-modules:
+      Paths_merkle_patricia_db
+  hs-source-dirs:
+      src
+  build-depends:
+      QuickCheck
+    , Ranged-sets
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , conduit
+    , containers
+    , data-default
+    , data-fix
+    , deepseq
+    , ethereum-rlp
+    , format
+    , leveldb-haskell
+    , monad-alter
+    , mtl
+    , nibblestring
+    , resourcet
+    , strato-model
+    , transformers
+  default-language: Haskell2010
+
+test-suite test-merkle-patricia-db
+  type: exitcode-stdio-1.0
+  main-is: MerklePatriciaSpec.hs
+  other-modules:
+      Main
+      Paths_merkle_patricia_db
+  hs-source-dirs:
+      test
+  ghc-options: -dynamic
+  build-depends:
+      HUnit
+    , base
+    , bytestring
+    , ethereum-rlp
+    , hspec
+    , hspec-contrib
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , resourcet
+    , strato-model
+    , transformers
+  default-language: Haskell2010
+
+benchmark mpbench
+  type: exitcode-stdio-1.0
+  main-is: MPBench.hs
+  other-modules:
+      Paths_merkle_patricia_db
+  hs-source-dirs:
+      bench/
+  ghc-options: -dynamic
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , criterion
+    , deepseq
+    , directory
+    , ethereum-rlp
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , resourcet
+    , strato-model
+    , transformers
+    , unix
+  default-language: Haskell2010

--- a/strato/core/miner-ethash/.gitignore
+++ b/strato/core/miner-ethash/.gitignore
@@ -2,4 +2,3 @@
 *~
 dist
 .DS_Store
-miner-ethash.cabal

--- a/strato/core/miner-ethash/miner-ethash.cabal
+++ b/strato/core/miner-ethash/miner-ethash.cabal
@@ -1,0 +1,65 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           miner-ethash
+version:        0.1.0.0
+category:       System
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Strato.Mining.Ethash.Cache
+      Blockchain.Strato.Mining.Ethash.Constants
+      Blockchain.Strato.Mining.Ethash.Dataset
+      Blockchain.Strato.Mining.Ethash.Hashimoto
+      Blockchain.Strato.Mining.Ethash.TimeIt
+  other-modules:
+      Blockchain.Strato.Mining.Ethash.Util
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      arithmoi
+    , array
+    , base
+    , binary
+    , bytestring
+    , strato-model
+    , time
+  default-language: Haskell2010
+
+executable miner-ethash
+  main-is: Main.hs
+  other-modules:
+      Paths_miner_ethash
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -O2
+  build-depends:
+      array
+    , base
+    , binary
+    , bytestring
+    , miner-ethash
+    , mmap
+  default-language: Haskell2010
+
+executable mkDataset
+  main-is: mkDataset.hs
+  other-modules:
+      Main
+      Paths_miner_ethash
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -O2
+  build-depends:
+      array
+    , base
+    , binary
+    , bytestring
+    , miner-ethash
+  default-language: Haskell2010

--- a/strato/core/seqevents/seqevents.cabal
+++ b/strato/core/seqevents/seqevents.cabal
@@ -1,0 +1,58 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           seqevents
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Sequencer.Constants
+      Blockchain.Sequencer.Event
+      Blockchain.Sequencer.Kafka
+      Blockchain.Sequencer.Kafka.Metrics
+  other-modules:
+      Paths_seqevents
+  hs-source-dirs:
+      src/
+  ghc-options: -fconstraint-solver-iterations=8
+  build-depends:
+      base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockstanbul
+    , bytestring
+    , format
+    , kafka-monad
+    , merkle-patricia-db
+    , monad-alter
+    , prometheus-client
+    , strato-conf
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+test-suite seqevents-spec
+  type: exitcode-stdio-1.0
+  main-is: EventSpec.hs
+  other-modules:
+      Paths_seqevents
+  hs-source-dirs:
+      test/
+  ghc-options: -dynamic
+  build-depends:
+      QuickCheck
+    , base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , hspec
+    , seqevents
+  default-language: Haskell2010

--- a/strato/core/strato-conf/.gitignore
+++ b/strato/core/strato-conf/.gitignore
@@ -10,9 +10,6 @@ cabal-dev
 .virtualenv
 .hpc
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
 *.prof
 *.aux
 *.hp
-strato-conf.cabal

--- a/strato/core/strato-conf/strato-conf.cabal
+++ b/strato/core/strato-conf/strato-conf.cabal
@@ -1,0 +1,37 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-conf
+version:        0.1.0.0
+category:       Web
+author:         Jamshid
+maintainer:     Jamshid
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.EthConf
+      Blockchain.EthConf.Model
+      Blockchain.KafkaTopics
+  other-modules:
+      Paths_strato_conf
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , containers
+    , data-default
+    , hedis
+    , kafka-monad
+    , postgresql-simple
+    , servant-client
+    , strato-model
+    , text
+    , yaml
+  default-language: Haskell2010

--- a/strato/core/strato-genesis/.gitignore
+++ b/strato/core/strato-genesis/.gitignore
@@ -1,1 +1,0 @@
-strato-genesis.cabal

--- a/strato/core/strato-genesis/strato-genesis.cabal
+++ b/strato/core/strato-genesis/strato-genesis.cabal
@@ -1,0 +1,101 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-genesis
+version:        0.0.1
+synopsis:       A tool to setup the DBs for a Strato instance
+description:    A tool to setup the DBs for a Strato instance
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Data.AddressInfo
+      Blockchain.Data.CodeInfo
+      Blockchain.Data.CodeInfoOld
+      Blockchain.Data.GenesisBlock
+      Blockchain.Data.GenesisInfo
+      Blockchain.Generation
+      Blockchain.GenesisBlocks.Builder
+      Blockchain.GenesisBlocks.Contracts.Decide
+      Blockchain.GenesisBlocks.Contracts.GovernanceV2
+      Blockchain.GenesisBlocks.Contracts.Mercata
+      Blockchain.GenesisBlocks.Contracts.TH
+      Blockchain.GenesisBlocks.Contracts.UserRegistry
+      Blockchain.GenesisBlocks.HeliumGenesisBlock
+      Blockchain.GenesisBlocks.Instances.GenesisAssets
+      Blockchain.GenesisBlocks.Instances.GenesisEscrows
+      Blockchain.GenesisBlocks.Instances.GenesisReserves
+  other-modules:
+      Paths_strato_genesis
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      aeson
+    , aeson-casing
+    , base
+    , base16-bytestring
+    , binary
+    , blockapps-data
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , containers
+    , crypto-api
+    , data-default
+    , directory
+    , ethereum-rlp
+    , file-embed
+    , filepath
+    , format
+    , json-stream
+    , labeled-error
+    , lens
+    , merkle-patricia-db
+    , monad-alter
+    , scientific
+    , solid-vm-compiler
+    , solid-vm-model
+    , split
+    , strato-model
+    , template-haskell
+    , text
+    , time
+    , vector
+    , vm-tools
+  default-language: Haskell2010
+
+test-suite strato-genesis-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      GenerationSpec
+      JsonSpec
+      Spec
+      Paths_strato_genesis
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -dynamic
+  build-depends:
+      aeson
+    , base
+    , blockapps-data
+    , bytestring
+    , containers
+    , hspec
+    , json-stream
+    , labeled-error
+    , merkle-patricia-db
+    , strato-genesis
+    , strato-model
+    , text
+    , time
+    , vector
+  default-language: Haskell2010

--- a/strato/core/strato-init/.gitignore
+++ b/strato/core/strato-init/.gitignore
@@ -3,5 +3,4 @@ genesis.json
 dist
 .DS_Store
 #*#
-strato-init.cabal
 build/

--- a/strato/core/strato-init/strato-init.cabal
+++ b/strato/core/strato-init/strato-init.cabal
@@ -1,0 +1,113 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-init
+version:        0.0.1
+synopsis:       A tool to setup the DBs for a Strato instance
+description:    A tool to setup the DBs for a Strato instance
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.GenesisBlock
+      Blockchain.Init.EthConf
+      Blockchain.Init.Generator
+      Blockchain.Init.Monad
+      Blockchain.Init.Options
+  other-modules:
+      Paths_strato_init
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2 -threaded
+  build-depends:
+      aeson
+    , base
+    , base16-bytestring
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , common-log
+    , conduit
+    , containers
+    , data-default
+    , directory
+    , ethereum-rlp
+    , evm-solidity
+    , exceptions
+    , file-embed
+    , filepath
+    , format
+    , hflags
+    , http-client
+    , http-types
+    , kafka-monad
+    , lens
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , ordered-containers
+    , persistent-postgresql
+    , raw-strings-qq
+    , redis-monad
+    , resourcet
+    , servant-client
+    , solid-vm
+    , solid-vm-compiler
+    , solid-vm-model
+    , sql-monad
+    , strato-auth
+    , strato-conf
+    , strato-genesis
+    , strato-index
+    , strato-model
+    , strato-sequencer
+    , strato-statediff
+    , text
+    , transformers
+    , turtle
+    , unliftio
+    , vm-tools
+    , yaml
+  default-language: Haskell2010
+
+executable genesis-builder
+  main-is: GenesisBuilder.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -O2 -threaded
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , data-default
+    , strato-genesis
+    , strato-init
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+executable strato-setup
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -O2 -threaded
+  build-depends:
+      base
+    , common-log
+    , hflags
+    , kafka-monad
+    , strato-init
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/strato-model/.gitignore
+++ b/strato/core/strato-model/.gitignore
@@ -1,1 +1,0 @@
-strato-model.cabal

--- a/strato/core/strato-model/strato-model.cabal
+++ b/strato/core/strato-model/strato-model.cabal
@@ -1,0 +1,149 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-model
+version:        0.1.0.0
+author:         BlockApps
+maintainer:     blockapps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Blockstanbul.Model.Authentication
+      Blockchain.MiscArbitrary
+      Blockchain.MiscJSON
+      Blockchain.Strato.Model.Address
+      Blockchain.Strato.Model.BlockchainClass
+      Blockchain.Strato.Model.Class
+      Blockchain.Strato.Model.Code
+      Blockchain.Strato.Model.CodePtr
+      Blockchain.Strato.Model.Delta
+      Blockchain.Strato.Model.Event
+      Blockchain.Strato.Model.ExtendedWord
+      Blockchain.Strato.Model.Gas
+      Blockchain.Strato.Model.Host
+      Blockchain.Strato.Model.Keccak256
+      Blockchain.Strato.Model.Keccak512
+      Blockchain.Strato.Model.MicroTime
+      Blockchain.Strato.Model.Nonce
+      Blockchain.Strato.Model.Options
+      Blockchain.Strato.Model.PositiveInteger
+      Blockchain.Strato.Model.Query
+      Blockchain.Strato.Model.Secp256k1
+      Blockchain.Strato.Model.StateRoot
+      Blockchain.Strato.Model.Util
+      Blockchain.Strato.Model.Validator
+      Blockchain.Strato.Model.Wei
+  other-modules:
+      Paths_strato_model
+  hs-source-dirs:
+      src
+  default-extensions:
+      MultiParamTypeClasses
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      GADTs
+      RecordWildCards
+      FunctionalDependencies
+  ghc-options: -Wall -Werror -fno-warn-warnings-deprecations
+  build-depends:
+      QuickCheck
+    , Ranged-sets
+    , aeson
+    , aeson-casing
+    , asn1-encoding
+    , asn1-types
+    , base
+    , base16-bytestring
+    , binary
+    , blockapps-haskoin
+    , blockapps-secp256k1-haskell
+    , bytestring
+    , bytestring-arbitrary
+    , conduit
+    , containers
+    , cpu
+    , crypton
+    , crypton-x509
+    , crypton-x509-validation
+    , data-default
+    , deepseq
+    , ethereum-rlp
+    , extra
+    , fast-keccak256
+    , format
+    , generic-arbitrary
+    , generic-random
+    , hashable
+    , hflags
+    , hourglass
+    , http-api-data
+    , integer-gmp
+    , iproute
+    , labeled-error
+    , lens
+    , memory
+    , monad-alter
+    , mtl
+    , nibblestring
+    , openapi3
+    , path-pieces
+    , pem
+    , persistent
+    , persistent-postgresql
+    , primitive
+    , quickcheck-instances
+    , servant
+    , servant-docs
+    , servant-server
+    , text
+    , time
+    , transformers
+    , vector
+  default-language: Haskell2010
+
+test-suite strato-model-tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_strato_model
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror -fno-warn-warnings-deprecations -dynamic
+  build-depends:
+      QuickCheck
+    , Ranged-sets
+    , aeson
+    , aeson-qq
+    , base
+    , binary
+    , blockapps-haskoin
+    , bytestring
+    , ethereum-rlp
+    , hspec
+    , labeled-error
+    , persistent
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+benchmark word256
+  type: exitcode-stdio-1.0
+  main-is: Word256Bench.hs
+  other-modules:
+      Paths_strato_model
+  hs-source-dirs:
+      bench/
+  ghc-options: -Wall -Werror -fno-warn-warnings-deprecations -dynamic
+  build-depends:
+      base
+    , blockapps-haskoin
+    , bytestring
+    , criterion
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/strato-networks/strato-networks.cabal
+++ b/strato/core/strato-networks/strato-networks.cabal
@@ -1,0 +1,22 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-networks
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Network
+  other-modules:
+      Paths_strato_networks
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/strato-p2p/.gitignore
+++ b/strato/core/strato-p2p/.gitignore
@@ -1,4 +1,3 @@
-strato-p2p.cabal
 *~
 dist
 .DS_Store

--- a/strato/core/strato-p2p/strato-p2p.cabal
+++ b/strato/core/strato-p2p/strato-p2p.cabal
@@ -1,0 +1,121 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-p2p
+version:        0.0.0
+synopsis:       a microservice that handles peer to peer connections for strato
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.CommunicationConduit
+      Blockchain.Context
+      Blockchain.Data.Control
+      Blockchain.Data.Wire
+      Blockchain.Display
+      Blockchain.Event
+      Blockchain.EventException
+      Blockchain.EventModel
+      Blockchain.ExtMergeSources
+      Blockchain.HeaderCache
+      Blockchain.Metrics
+      Blockchain.Options
+      Blockchain.P2PUtil
+      Blockchain.Participation
+      Blockchain.SeqEventNotify
+      Blockchain.Threads
+      Blockchain.TimerSource
+      Executable.StratoP2P
+      Executable.StratoP2PClient
+      Executable.StratoP2PLoopback
+      Executable.StratoP2PServer
+  other-modules:
+      Paths_strato_p2p
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -threaded -Wall -O2
+  build-depends:
+      aeson
+    , base
+    , base16-bytestring
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockstanbul
+    , bytestring
+    , common-log
+    , composable-monads-base
+    , conduit
+    , conduit-extra
+    , containers
+    , cross-monitoring
+    , crypto-pubkey-types
+    , dns
+    , either
+    , ethereum-discovery
+    , ethereum-encryption
+    , ethereum-rlp
+    , format
+    , hedis
+    , hflags
+    , http-client
+    , iproute
+    , kafka-monad
+    , lens
+    , lifted-async
+    , lifted-base
+    , merkle-patricia-db
+    , monad-alter
+    , mtl
+    , network
+    , ordered-containers
+    , persistent
+    , prometheus-client
+    , resourcet
+    , seqevents
+    , servant-client
+    , servant-server
+    , split
+    , sql-monad
+    , stm-conduit
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , unliftio
+    , unliftio-core
+    , vault-monad
+    , warp
+  default-language: Haskell2010
+
+executable strato-p2p
+  main-is: StratoP2PMain.hs
+  other-modules:
+      Paths_strato_p2p
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -threaded
+  build-depends:
+      base
+    , blockapps-init
+    , common-log
+    , ethereum-discovery
+    , hflags
+    , lifted-async
+    , ordered-containers
+    , process-monitor
+    , strato-conf
+    , strato-model
+    , strato-p2p
+    , vault-monad
+    , vm-tools
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010

--- a/strato/core/strato-redis-blockdb/.gitignore
+++ b/strato/core/strato-redis-blockdb/.gitignore
@@ -1,1 +1,0 @@
-strato-redis-blockdb.cabal

--- a/strato/core/strato-redis-blockdb/strato-redis-blockdb.cabal
+++ b/strato/core/strato-redis-blockdb/strato-redis-blockdb.cabal
@@ -1,0 +1,40 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-redis-blockdb
+version:        0.1.0.0
+description:    Functions to operate against the Redis-backed BlockDB
+author:         BlockApps
+maintainer:     blockapps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Strato.RedisBlockDB
+      Blockchain.Strato.RedisBlockDB.Models
+      Blockchain.Strato.RedisBlockDB.Test.Chain
+  other-modules:
+      Paths_strato_redis_blockdb
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -O2
+  build-depends:
+      QuickCheck
+    , base
+    , base16-bytestring
+    , binary
+    , blockapps-data
+    , bytestring
+    , containers
+    , ethereum-rlp
+    , format
+    , hedis
+    , monad-alter
+    , mtl
+    , strato-conf
+    , strato-model
+  default-language: Haskell2010

--- a/strato/core/strato-sequencer/.gitignore
+++ b/strato/core/strato-sequencer/.gitignore
@@ -1,2 +1,1 @@
 .stack-work/
-strato-sequencer.cabal

--- a/strato/core/strato-sequencer/strato-sequencer.cabal
+++ b/strato/core/strato-sequencer/strato-sequencer.cabal
@@ -1,0 +1,137 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-sequencer
+version:        0.1.0.0
+category:       Blockchain
+author:         Ilya Ostrovskiy
+maintainer:     ilya@blockapps.net
+copyright:      2016 BlockApps Inc
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Sequencer
+      Blockchain.Sequencer.Bootstrap
+      Blockchain.Sequencer.CablePackage
+      Blockchain.Sequencer.DB.DependentBlockDB
+      Blockchain.Sequencer.DB.Metrics
+      Blockchain.Sequencer.DB.SeenTransactionDB
+      Blockchain.Sequencer.Metrics
+      Blockchain.Sequencer.Monad
+      Flags
+  other-modules:
+      Paths_strato_sequencer
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto
+  build-depends:
+      alarmclock
+    , base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-init
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , blockstanbul
+    , bytestring
+    , classy-prelude
+    , clock
+    , common-log
+    , conduit
+    , containers
+    , directory
+    , format
+    , hflags
+    , http-client
+    , kafka-monad
+    , labeled-error
+    , lens
+    , leveldb-haskell
+    , monad-alter
+    , mtl
+    , prometheus-client
+    , resourcet
+    , seqevents
+    , stm-chans
+    , stm-conduit
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , transformers
+    , vault-monad
+  default-language: Haskell2010
+
+executable forced-config-change
+  main-is: ForcedConfigChange.hs
+  hs-source-dirs:
+      exec-src
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto
+  build-depends:
+      base
+    , blockstanbul
+    , hflags
+    , kafka-monad
+    , seqevents
+    , strato-conf
+  default-language: Haskell2010
+
+executable strato-sequencer
+  main-is: Main.hs
+  hs-source-dirs:
+      exec-src
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto
+  build-depends:
+      async
+    , base
+    , blockDB
+    , blockapps-data
+    , blockapps-init
+    , blockstanbul
+    , common-log
+    , format
+    , hedis
+    , hflags
+    , process-monitor
+    , prometheus-client
+    , seqevents
+    , stm
+    , stm-chans
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , strato-sequencer
+    , text
+    , vault-monad
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010
+
+benchmark send-to-blockstanbul
+  type: exitcode-stdio-1.0
+  main-is: BlockstanbulSend.hs
+  other-modules:
+      Paths_strato_sequencer
+  hs-source-dirs:
+      bench/
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto -dynamic
+  build-depends:
+      base
+    , blockapps-data
+    , blockstanbul
+    , classy-prelude
+    , containers
+    , mtl
+    , resourcet
+    , stm-chans
+    , strato-sequencer
+    , unliftio
+  default-language: Haskell2010

--- a/strato/core/strato-statediff/.gitignore
+++ b/strato/core/strato-statediff/.gitignore
@@ -1,1 +1,0 @@
-strato-statediff.cabal

--- a/strato/core/strato-statediff/strato-statediff.cabal
+++ b/strato/core/strato-statediff/strato-statediff.cabal
@@ -1,0 +1,60 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-statediff
+version:        0.1.0.0
+author:         BlockApps
+maintainer:     blockapps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Strato.StateDiff
+      Blockchain.Strato.StateDiff.Database
+      Blockchain.Strato.StateDiff.Kafka
+  other-modules:
+      Paths_strato_statediff
+  hs-source-dirs:
+      src/
+  default-extensions:
+      MultiParamTypeClasses
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      GADTs
+      RecordWildCards
+      FunctionalDependencies
+      DataKinds
+      ExplicitForAll
+      NamedFieldPuns
+      OverloadedStrings
+      TypeFamilies
+      ViewPatterns
+  ghc-options: -Wall -Werror -fno-warn-orphans -fno-warn-unused-imports
+  build-depends:
+      base
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , bytestring
+    , common-log
+    , conduit
+    , containers
+    , ethereum-rlp
+    , format
+    , kafka-monad
+    , merkle-patricia-db
+    , monad-alter
+    , nibblestring
+    , persistent
+    , persistent-postgresql
+    , solid-vm-model
+    , strato-conf
+    , strato-model
+    , text
+    , unliftio
+  default-language: Haskell2010

--- a/strato/core/vm-runner/vm-runner.cabal
+++ b/strato/core/vm-runner/vm-runner.cabal
@@ -1,0 +1,149 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           vm-runner
+version:        0.0.4
+synopsis:       The executable that runs VMs for transactions
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.BlockChain
+      Blockchain.Event
+      Executable.EthereumVM
+      Executable.EthereumVM2
+  other-modules:
+      Blockchain.JsonRpcCommand
+      Blockchain.TheDAOFork
+      Blockchain.Verifier
+      Blockchain.VMConstants
+      Executable.EVMCheckpoint
+      Paths_vm_runner
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , blockstanbul
+    , bytestring
+    , common-log
+    , composable-monads-base
+    , conduit
+    , containers
+    , cross-monitoring
+    , debugger
+    , dlist
+    , ethereum-rlp
+    , exceptions
+    , extra
+    , format
+    , kafka-monad
+    , lens
+    , merkle-patricia-db
+    , monad-alter
+    , ordered-containers
+    , prometheus-client
+    , seqevents
+    , solid-vm
+    , solid-vm-model
+    , sql-monad
+    , strato-conf
+    , strato-index
+    , strato-model
+    , strato-redis-blockdb
+    , strato-statediff
+    , text
+    , time
+    , transformers
+    , unliftio
+    , vm-tools
+  default-language: Haskell2010
+
+executable vm-runner
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src
+  ghc-options: -Wall -O2 -threaded -rtsopts -fprof-auto
+  build-depends:
+      async
+    , base
+    , blockapps-init
+    , common-log
+    , debugger
+    , hflags
+    , process-monitor
+    , solid-vm-fuzzer
+    , strato-model
+    , vm-runner
+    , vm-tools
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010
+
+test-suite ethereum-vm-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_vm_runner
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -dynamic
+  build-depends:
+      base
+    , base16-bytestring
+    , blockapps-data
+    , blockapps-mpdbs
+    , blockstanbul
+    , bytestring
+    , common-log
+    , containers
+    , hflags
+    , hspec
+    , hspec-expectations-lifted
+    , labeled-error
+    , merkle-patricia-db
+    , monad-alter
+    , strato-model
+    , vm-runner
+    , vm-tools
+  default-language: Haskell2010
+
+benchmark extractbench
+  type: exitcode-stdio-1.0
+  main-is: ExtractBench.hs
+  hs-source-dirs:
+      bench/
+  ghc-options: -dynamic
+  build-depends:
+      base
+    , bytestring
+    , criterion
+  default-language: Haskell2010
+
+benchmark microbench
+  type: exitcode-stdio-1.0
+  main-is: Microbench.hs
+  hs-source-dirs:
+      bench/
+  ghc-options: -dynamic
+  build-depends:
+      base
+    , bytestring
+    , containers
+    , criterion
+    , deepseq
+    , strato-model
+    , vector
+  default-language: Haskell2010

--- a/strato/core/vm-tools/vm-tools.cabal
+++ b/strato/core/vm-tools/vm-tools.cabal
@@ -1,0 +1,112 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           vm-tools
+version:        0.0.4
+synopsis:       types and tools needed to write a VM for Strato
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Bagger
+      Blockchain.Bagger.BaggerState
+      Blockchain.Bagger.Transactions
+      Blockchain.Data.BlockSummary
+      Blockchain.Data.ExecResults
+      Blockchain.DB.BlockSummaryDB
+      Blockchain.DB.ModifyStateDB
+      Blockchain.StateRootMismatch
+      Blockchain.Stream.Action
+      Blockchain.Stream.VMEvent
+      Blockchain.Timing
+      Blockchain.TxRunResultCache
+      Blockchain.MemVMContext
+      Blockchain.VMContext
+      Blockchain.VMOptions
+      Blockchain.VM.VMException
+      Blockchain.VMMetrics
+      Blockchain.Wiring
+      Executable.EVMFlags
+  other-modules:
+      Blockchain.Bagger.TransactionList
+      Paths_vm_tools
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , binary
+    , binary-instances
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-init
+    , blockapps-mpdbs
+    , blockstanbul
+    , bytestring
+    , common-log
+    , composable-monads-base
+    , conduit
+    , containers
+    , cross-monitoring
+    , data-default
+    , debugger
+    , deepseq
+    , directory
+    , dlist
+    , ethereum-rlp
+    , exceptions
+    , extra
+    , format
+    , generic-arbitrary
+    , hedis
+    , hflags
+    , kafka-monad
+    , lens
+    , leveldb-haskell
+    , lrucache
+    , merkle-patricia-db
+    , monad-alter
+    , mtl
+    , nibblestring
+    , ordered-containers
+    , persistent-sqlite
+    , prometheus-client
+    , quickcheck-instances
+    , resourcet
+    , seqevents
+    , solid-vm-model
+    , sql-monad
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , strato-statediff
+    , text
+    , time
+    , transformers
+    , unliftio
+  default-language: Haskell2010
+
+test-suite contextm-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_vm_tools
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -O2 -dynamic
+  build-depends:
+      base
+    , hflags
+    , hspec
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/highway/api/blockapps-highway-api.cabal
+++ b/strato/highway/api/blockapps-highway-api.cabal
@@ -1,0 +1,42 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-highway-api
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/API#readme>
+homepage:       https://github.com/githubuser/API#readme
+bug-reports:    https://github.com/githubuser/API/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/API
+
+library
+  exposed-modules:
+      API
+      Strato.API
+  other-modules:
+      Paths_blockapps_highway_api
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , bytestring
+    , http-media
+    , http-types
+    , servant
+    , servant-multipart
+    , servant-server
+    , text
+  default-language: Haskell2010

--- a/strato/highway/client/blockapps-highway-client.cabal
+++ b/strato/highway/client/blockapps-highway-client.cabal
@@ -1,0 +1,41 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-highway-client
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/client#readme>
+homepage:       https://github.com/githubuser/client#readme
+bug-reports:    https://github.com/githubuser/client/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/client
+
+library
+  exposed-modules:
+      Strato.Client
+  other-modules:
+      Paths_blockapps_highway_client
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , blockapps-highway-api
+    , bytestring
+    , http-types
+    , servant-client
+    , servant-multipart
+    , servant-multipart-client
+    , text
+  default-language: Haskell2010

--- a/strato/highway/server/blockapps-highway-server.cabal
+++ b/strato/highway/server/blockapps-highway-server.cabal
@@ -1,0 +1,134 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-highway-server
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/server#readme>
+homepage:       https://github.com/githubuser/blockapps-highway-server#readme
+bug-reports:    https://github.com/githubuser/blockapps-highway-server/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/blockapps-highway-server
+
+library
+  exposed-modules:
+      Strato.Monad
+      Strato.Server
+      Strato.Server.GetS3File
+      Strato.Server.Ping
+      Strato.Server.PutS3File
+  other-modules:
+      Paths_blockapps_highway_server
+  hs-source-dirs:
+      src
+  build-depends:
+      aws
+    , base
+    , blockapps-highway-api
+    , bytestring
+    , common-log
+    , conduit
+    , filepath
+    , http-client
+    , http-conduit
+    , http-types
+    , monad-logger
+    , mtl
+    , resourcet
+    , servant-multipart
+    , servant-server
+    , strato-model
+    , text
+    , transformers
+    , unliftio
+    , unliftio-core
+    , wai-extra
+  default-language: Haskell2010
+
+executable blockapps-highway-server
+  main-is: Main.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  ghc-options: -threaded
+  build-depends:
+      aws
+    , base
+    , blockapps-highway-api
+    , blockapps-highway-server
+    , blockapps-init
+    , bytestring
+    , common-log
+    , hflags
+    , http-client
+    , http-client-tls
+    , http-types
+    , raw-strings-qq
+    , servant-multipart
+    , servant-multipart-client
+    , servant-server
+    , text
+    , unliftio-core
+    , wai
+    , wai-cors
+    , wai-extra
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010
+
+test-suite highway-spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Options
+      Paths_blockapps_highway_server
+  hs-source-dirs:
+      test/
+  build-depends:
+      HUnit
+    , aws
+    , base
+    , blockapps-highway-api
+    , blockapps-highway-client
+    , blockapps-highway-server
+    , bytestring
+    , common-log
+    , hflags
+    , hspec
+    , http-client
+    , http-client-tls
+    , http-types
+    , network
+    , random
+    , regex-compat
+    , resourcet
+    , servant-client
+    , servant-client-core
+    , servant-multipart
+    , servant-multipart-api
+    , servant-multipart-client
+    , servant-server
+    , stm
+    , strato-model
+    , text
+    , transformers
+    , unliftio-core
+    , utf8-string
+    , wai-cors
+    , wai-extra
+    , warp
+    , word8
+  default-language: Haskell2010

--- a/strato/identity-provider/api/blockapps-identity-provider-api.cabal
+++ b/strato/identity-provider/api/blockapps-identity-provider-api.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-identity-provider-api
+version:        0.1.0.0
+homepage:       https://github.com/githubuser/api#readme
+bug-reports:    https://github.com/githubuser/api/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2023 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/api
+
+library
+  exposed-modules:
+      IdentityProvider.API
+      NotificationServer.API
+  other-modules:
+      Paths_blockapps_identity_provider_api
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base
+    , servant
+    , strato-model
+    , text
+  default-language: Haskell2010

--- a/strato/identity-provider/client/blockapps-identity-provider-client.cabal
+++ b/strato/identity-provider/client/blockapps-identity-provider-client.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-identity-provider-client
+version:        0.1.0.0
+homepage:       https://github.com/githubuser/identity-provider-client#readme
+bug-reports:    https://github.com/githubuser/identity-provider-client/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/identity-provider-client
+
+library
+  exposed-modules:
+      IdentityProvider.Client
+      NotificationServer.Client
+  other-modules:
+      Paths_blockapps_identity_provider_client
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , blockapps-identity-provider-api
+    , servant-client
+    , strato-model
+    , text
+  default-language: Haskell2010

--- a/strato/identity-provider/server/blockapps-identity-provider-server.cabal
+++ b/strato/identity-provider/server/blockapps-identity-provider-server.cabal
@@ -1,0 +1,97 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-identity-provider-server
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/identity-provider#readme>
+homepage:       https://github.com/githubuser/blockapps-identity-provider-server#readme
+bug-reports:    https://github.com/githubuser/blockapps-identity-provider-server/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2023 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/blockapps-identity-provider-server
+
+library
+  exposed-modules:
+      IdentityProvider.Email
+      IdentityProvider.OAuth
+      IdentityProvider.Server
+  other-modules:
+      Paths_blockapps_identity_provider_server
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base
+    , base64
+    , bloc2api
+    , bloc2client
+    , blockapps-identity-provider-api
+    , blockapps-identity-provider-client
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , common-log
+    , containers
+    , evm-solidity
+    , http-client
+    , http-client-tls
+    , http-types
+    , lrucache
+    , monad-alter
+    , mtl
+    , notification-monad
+    , servant-client
+    , servant-server
+    , solid-vm-model
+    , split
+    , strato-model
+    , text
+    , time
+    , transformers
+    , unliftio
+    , utf8-string
+    , vault-monad
+  default-language: Haskell2010
+
+executable identity-provider-server
+  main-is: Main.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  ghc-options: -threaded
+  build-depends:
+      base
+    , blockapps-identity-provider-server
+    , bytestring
+    , common-log
+    , containers
+    , hflags
+    , strato-model
+    , warp
+    , yaml
+  default-language: Haskell2010
+
+test-suite identity-provider-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_blockapps_identity_provider_server
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+  default-language: Haskell2010

--- a/strato/indexer/slipstream/.gitignore
+++ b/strato/indexer/slipstream/.gitignore
@@ -1,1 +1,0 @@
-slipstream.cabal

--- a/strato/indexer/slipstream/slipstream.cabal
+++ b/strato/indexer/slipstream/slipstream.cabal
@@ -1,0 +1,158 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           slipstream
+version:        0.1.0.0
+synopsis:       Solidity datatypes
+description:    Solidity datatypes
+category:       Web
+homepage:       https://github.com/blockapps/blockapps-haskell/slipstream
+copyright:      2016 BlockApps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Slipstream.Data.Action
+      Blockchain.Slipstream.Data.CirrusTables
+      Blockchain.Slipstream.Events
+      Blockchain.Slipstream.MessageConsumer
+      Blockchain.Slipstream.Metrics
+      Blockchain.Slipstream.Options
+      Blockchain.Slipstream.OutputData
+      Blockchain.Slipstream.PostgresqlTypedShim
+      Blockchain.Slipstream.Processor
+      Blockchain.Slipstream.QueryFormatHelper
+      Blockchain.Slipstream.SolidityValue
+      Blockchain.Slipstream.SQL
+  other-modules:
+      Paths_slipstream
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -Werror -rtsopts
+  build-depends:
+      aeson
+    , base
+    , base16-bytestring
+    , binary
+    , bloc2
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , bytestring
+    , classy-prelude
+    , common-log
+    , conduit
+    , containers
+    , cross-monitoring
+    , deepseq
+    , esqueleto
+    , evm-solidity
+    , extra
+    , filepath
+    , format
+    , hflags
+    , kafka-monad
+    , lens
+    , monad-alter
+    , network
+    , ordered-containers
+    , persistent
+    , persistent-postgresql
+    , postgresql-simple
+    , prometheus-client
+    , raw-strings-qq
+    , resource-pool
+    , resourcet
+    , scientific
+    , solid-vm-model
+    , source-tools
+    , sql-monad
+    , strato-conf
+    , strato-model
+    , text
+    , time
+    , transformers
+    , unliftio
+    , unliftio-core
+    , vm-tools
+  default-language: Haskell2010
+
+executable slipstream
+  main-is: Main.hs
+  other-modules:
+      Paths_slipstream
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -Werror -rtsopts
+  build-depends:
+      base
+    , bloc2
+    , blockapps-init
+    , bytestring
+    , common-log
+    , containers
+    , evm-solidity
+    , hflags
+    , monad-alter
+    , persistent-postgresql
+    , postgresql-simple
+    , process-monitor
+    , raw-strings-qq
+    , resourcet
+    , slipstream
+    , sql-monad
+    , strato-conf
+    , text
+    , transformers
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010
+
+test-suite slipstream-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      ActionFidelitySpec
+      OutputDataSpec
+      Spec
+      Paths_slipstream
+  hs-source-dirs:
+      tests/
+  ghc-options: -Wall -Werror -rtsopts -dynamic
+  build-depends:
+      QuickCheck
+    , aeson
+    , aeson-qq
+    , base
+    , blockapps-data
+    , blockapps-haskoin
+    , blockapps-mpdbs
+    , bytestring
+    , classy-prelude
+    , common-log
+    , conduit
+    , containers
+    , core-api2
+    , data-default
+    , evm-solidity
+    , hflags
+    , hspec
+    , hspec-expectations-lifted
+    , labeled-error
+    , monad-alter
+    , ordered-containers
+    , persistent-sqlite
+    , raw-strings-qq
+    , resourcet
+    , slipstream
+    , solid-vm-model
+    , strato-model
+    , text
+    , time
+    , unliftio
+    , vm-tools
+  default-language: Haskell2010

--- a/strato/indexer/strato-index/.gitignore
+++ b/strato/indexer/strato-index/.gitignore
@@ -2,4 +2,3 @@
 *~
 dist
 .DS_Store
-strato-index.cabal

--- a/strato/indexer/strato-index/strato-index.cabal
+++ b/strato/indexer/strato-index/strato-index.cabal
@@ -1,0 +1,92 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-index
+version:        0.1.0.0
+description:    Please see README.md
+author:         Jamshid
+maintainer:     Jamshid
+copyright:      2016 Blockapps
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Strato.Indexer.ApiIndexer
+      Blockchain.Strato.Indexer.IContext
+      Blockchain.Strato.Indexer.Kafka
+      Blockchain.Strato.Indexer.Model
+      Blockchain.Strato.Indexer.P2PIndexer
+  other-modules:
+      Paths_strato_index
+  hs-source-dirs:
+      src/
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , common-log
+    , containers
+    , format
+    , kafka-monad
+    , monad-alter
+    , seqevents
+    , strato-conf
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+executable strato-api-indexer
+  main-is: ApiIndexerMain.hs
+  other-modules:
+      Wiring
+  hs-source-dirs:
+      exec_src
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , blockDB
+    , blockapps-data
+    , blockapps-init
+    , common-log
+    , containers
+    , evm-solidity
+    , hflags
+    , monad-alter
+    , process-monitor
+    , redis-monad
+    , sql-monad
+    , strato-conf
+    , strato-index
+    , strato-model
+  default-language: Haskell2010
+
+executable strato-p2p-indexer
+  main-is: P2PIndexerMain.hs
+  other-modules:
+      Wiring
+  hs-source-dirs:
+      exec_src
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , blockDB
+    , blockapps-data
+    , blockapps-init
+    , common-log
+    , containers
+    , evm-solidity
+    , hflags
+    , monad-alter
+    , process-monitor
+    , redis-monad
+    , strato-conf
+    , strato-index
+    , strato-model
+  default-language: Haskell2010

--- a/strato/libs/baby-jubjub/baby-jubjub.cabal
+++ b/strato/libs/baby-jubjub/baby-jubjub.cabal
@@ -1,0 +1,74 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           baby-jubjub
+version:        0.1.0.0
+synopsis:       Baby JubJub elliptic curve and EdDSA signatures for SNARK circuits
+description:    Implementation of the Baby JubJub twisted Edwards curve and EdDSA signature
+                scheme, compatible with circom/snarkjs. Baby JubJub is defined over the
+                BN254 scalar field and is commonly used in zkSNARK applications.
+                .
+                This library is intended for generating valid SNARK witness inputs.
+                It has not been audited for use cases requiring timing-attack resistance.
+category:       Cryptography
+author:         BlockApps
+maintainer:     info@blockapps.net
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+
+library
+  exposed-modules:
+      Crypto.Curve.BabyJubJub
+      Crypto.Curve.BabyJubJub.EdDSA
+  other-modules:
+      Paths_baby_jubjub
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.12 && <5
+    , bytestring >=0.10
+    , cryptonite >=0.25
+    , memory >=0.14
+    , text >=1.2
+  default-language: Haskell2010
+
+executable baby-jubjub-cli
+  main-is: Main.hs
+  other-modules:
+      Paths_baby_jubjub
+  hs-source-dirs:
+      app
+  build-depends:
+      baby-jubjub
+    , base >=4.12 && <5
+    , base16-bytestring >=1.0
+    , bytestring >=0.10
+    , cryptonite >=0.25
+    , memory >=0.14
+    , optparse-applicative >=0.14
+    , text >=1.2
+  default-language: Haskell2010
+
+test-suite baby-jubjub-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_baby_jubjub
+  hs-source-dirs:
+      test
+  build-depends:
+      QuickCheck >=2.13
+    , baby-jubjub
+    , base >=4.12 && <5
+    , bytestring >=0.10
+    , cryptonite >=0.25
+    , hspec >=2.7
+    , memory >=0.14
+    , text >=1.2
+  default-language: Haskell2010

--- a/strato/libs/blockapps-haskoin/.gitignore
+++ b/strato/libs/blockapps-haskoin/.gitignore
@@ -6,8 +6,4 @@
 *.ps
 *.prof
 dist
-.cabal-sandbox
-cabal.sandbox.config
-cabal.config
 .stack-work
-blockapps-haskoin.cabal

--- a/strato/libs/blockapps-haskoin/blockapps-haskoin.cabal
+++ b/strato/libs/blockapps-haskoin/blockapps-haskoin.cabal
@@ -1,0 +1,40 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-haskoin
+version:        1.0.0.1
+synopsis:       Blockapps fork of the "haskoin" library
+description:    A fork from an outdated commit, which our infrastructure happens to depend upon. . This package needs to be maintained until we remove the dependencies from it from our codebase.
+category:       Bitcoin, Finance, Network
+stability:      stable
+author:         Philippe Laprade, Jean-Pierre Rupp
+maintainer:     plaprade+hackage@gmail.com
+license:        PublicDomain
+license-file:   UNLICENSE
+build-type:     Simple
+
+library
+  exposed-modules:
+      Network.Haskoin.Crypto.BigWord
+  other-modules:
+      Network.Haskoin.Crypto.Curve
+      Network.Haskoin.Crypto.NumberTheory
+      Network.Haskoin.Util
+      Paths_blockapps_haskoin
+  hs-source-dirs:
+      ./
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , deepseq
+    , hashable
+    , text
+  default-language: Haskell2010

--- a/strato/libs/clockwork/clockwork.cabal
+++ b/strato/libs/clockwork/clockwork.cabal
@@ -1,0 +1,29 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           clockwork
+version:        0.0.0
+homepage:       https://github.com/githubuser/clockwork#readme
+bug-reports:    https://github.com/githubuser/clockwork/issues
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/clockwork
+
+library
+  exposed-modules:
+      Clockwork
+  other-modules:
+      Paths_clockwork
+  hs-source-dirs:
+      src
+  c-sources:
+      c-source/cclock.c
+  build-depends:
+      base
+  default-language: Haskell2010

--- a/strato/libs/common-log/common-log.cabal
+++ b/strato/libs/common-log/common-log.cabal
@@ -1,0 +1,43 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           common-log
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Logging
+  other-modules:
+      Paths_common_log
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , bytestring
+    , global-lock
+    , hflags
+    , monad-logger
+    , template-haskell
+    , text
+    , time
+  default-language: Haskell2010
+
+test-suite common-log-test
+  type: exitcode-stdio-1.0
+  main-is: LogSpec.hs
+  other-modules:
+      Paths_common_log
+  hs-source-dirs:
+      test/
+  build-depends:
+      base
+    , common-log
+    , hspec
+    , text
+    , time
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/composable-monads-base/composable-monads-base.cabal
+++ b/strato/libs/composable-monads/composable-monads-base/composable-monads-base.cabal
@@ -1,0 +1,24 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           composable-monads-base
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Base
+  other-modules:
+      Paths_composable_monads_base
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , mtl
+    , transformers
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/identity-monad/identity-monad.cabal
+++ b/strato/libs/composable-monads/identity-monad/identity-monad.cabal
@@ -1,0 +1,26 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           identity-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Identity
+  other-modules:
+      Paths_identity_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , http-client
+    , http-client-tls
+    , monad-alter
+    , mtl
+    , servant-client
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/kafka-monad/kafka-monad.cabal
+++ b/strato/libs/composable-monads/kafka-monad/kafka-monad.cabal
@@ -1,0 +1,34 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           kafka-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Kafka
+  other-modules:
+      Paths_kafka_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , base16-bytestring
+    , binary
+    , bytestring
+    , composable-monads-base
+    , conduit
+    , lens
+    , milena
+    , milena-tools
+    , monad-loops
+    , mtl
+    , text
+    , transformers
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/notification-monad/notification-monad.cabal
+++ b/strato/libs/composable-monads/notification-monad/notification-monad.cabal
@@ -1,0 +1,26 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           notification-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Notification
+  other-modules:
+      Paths_notification_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , http-client
+    , http-client-tls
+    , monad-alter
+    , mtl
+    , servant-client
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/redis-monad/redis-monad.cabal
+++ b/strato/libs/composable-monads/redis-monad/redis-monad.cabal
@@ -1,0 +1,24 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           redis-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Redis
+  other-modules:
+      Paths_redis_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , composable-monads-base
+    , hedis
+    , mtl
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/sql-monad/sql-monad.cabal
+++ b/strato/libs/composable-monads/sql-monad/sql-monad.cabal
@@ -1,0 +1,28 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           sql-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.SQL
+  other-modules:
+      Paths_sql_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , blockapps-data
+    , composable-monads-base
+    , monad-logger
+    , mtl
+    , persistent-postgresql
+    , strato-conf
+    , unliftio-core
+  default-language: Haskell2010

--- a/strato/libs/composable-monads/vault-monad/vault-monad.cabal
+++ b/strato/libs/composable-monads/vault-monad/vault-monad.cabal
@@ -1,0 +1,26 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           vault-monad
+version:        0.1.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Control.Monad.Composable.Vault
+  other-modules:
+      Paths_vault_monad
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , mtl
+    , strato-auth
+    , strato-model
+  default-language: Haskell2010

--- a/strato/libs/ethereum-rlp/.gitignore
+++ b/strato/libs/ethereum-rlp/.gitignore
@@ -7,8 +7,4 @@ cabal-dev
 *.chs.h
 .virtualenv
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
-cabal.config
 .stack-work
-ethereum-rlp.cabal

--- a/strato/libs/ethereum-rlp/ethereum-rlp.cabal
+++ b/strato/libs/ethereum-rlp/ethereum-rlp.cabal
@@ -1,0 +1,215 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           ethereum-rlp
+version:        0.1.0
+synopsis:       Ethereum Recursive Length Prefix Encoding
+description:    RLP, as described in the Ethereum Yellowpaper
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Data.RLP
+      Blockchain.Data.Util
+  other-modules:
+      Paths_ethereum_rlp
+  hs-source-dirs:
+      library/
+  default-extensions:
+      Arrows
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveTraversable
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LiberalTypeSynonyms
+      MagicHash
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PatternGuards
+      ParallelListComp
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UnboxedTuples
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , containers
+    , data-fix
+    , deepseq
+    , format
+    , text
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ethereum_rlp
+  hs-source-dirs:
+      test/
+  default-extensions:
+      Arrows
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveTraversable
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LiberalTypeSynonyms
+      MagicHash
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PatternGuards
+      ParallelListComp
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UnboxedTuples
+  build-depends:
+      HUnit
+    , base
+    , bytestring
+    , ethereum-rlp
+    , hspec
+    , test-framework
+    , test-framework-hunit
+  default-language: Haskell2010
+
+benchmark rlpserial
+  type: exitcode-stdio-1.0
+  main-is: RLPShootout.hs
+  hs-source-dirs:
+      bench/
+  default-extensions:
+      Arrows
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveTraversable
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LiberalTypeSynonyms
+      MagicHash
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PatternGuards
+      ParallelListComp
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UnboxedTuples
+  build-depends:
+      base
+    , bytestring
+    , criterion
+    , ethereum-rlp
+    , random-bytestring
+  default-language: Haskell2010
+
+benchmark zipbench
+  type: exitcode-stdio-1.0
+  main-is: ZipBench.hs
+  hs-source-dirs:
+      bench/
+  default-extensions:
+      Arrows
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveTraversable
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LiberalTypeSynonyms
+      MagicHash
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PatternGuards
+      ParallelListComp
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UnboxedTuples
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , criterion
+    , ethereum-rlp
+    , random-bytestring
+    , zlib
+  default-language: Haskell2010

--- a/strato/libs/format/format.cabal
+++ b/strato/libs/format/format.cabal
@@ -1,0 +1,33 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           format
+version:        0.1.0.0
+author:         jamshid
+maintainer:     j
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Text.Colors
+      Text.Format
+      Text.Format.Template
+      Text.ShortDescription
+      Text.Tools
+  other-modules:
+      Paths_format
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , base16-bytestring
+    , bytestring
+    , common-log
+    , template-haskell
+    , text
+    , time
+  default-language: Haskell2010

--- a/strato/libs/groth16-native/groth16-native.cabal
+++ b/strato/libs/groth16-native/groth16-native.cabal
@@ -1,0 +1,55 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           groth16-native
+version:        0.1.0
+synopsis:       Native Haskell Groth16 prover for BN254 curve
+description:    Pure Haskell implementation of Groth16 zero-knowledge proof generation
+                for the BN254 (alt_bn128) curve. Parses snarkjs/circom format files.
+                .
+                EXPERIMENTAL: May produce invalid proofs - use for development/testing only.
+author:         BlockApps
+maintainer:     info@blockapps.net
+license:        AllRightsReserved
+build-type:     Simple
+
+library
+  exposed-modules:
+      Groth16.BN254
+  other-modules:
+      Paths_groth16_native
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -O2
+  build-depends:
+      aeson
+    , base
+    , binary
+    , bytestring
+    , deepseq
+    , elliptic-curve
+    , galois-field
+    , groups
+    , pairing
+    , parallel
+    , random
+    , text
+    , vector
+  default-language: Haskell2010
+
+executable bench-groth16-native
+  main-is: Main.hs
+  other-modules:
+      Paths_groth16_native
+  hs-source-dirs:
+      bench
+  ghc-options: -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N -O2
+  build-depends:
+      base
+    , groth16-native
+    , text
+    , time
+  default-language: Haskell2010

--- a/strato/libs/groth16-rapidsnark/groth16-rapidsnark.cabal
+++ b/strato/libs/groth16-rapidsnark/groth16-rapidsnark.cabal
@@ -1,0 +1,191 @@
+cabal-version: 2.2
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           groth16-rapidsnark
+version:        0.1.0
+synopsis:       Groth16 prover via FFI to rapidsnark
+description:    Native FFI bindings to rapidsnark for fast Groth16 proof generation.
+                .
+                Builds rapidsnark from vendored source (pure C++, generic field arithmetic).
+                No cmake, nasm, or external setup required - just stack build.
+                .
+                Requirements:
+                  - g++ (C++ compiler)  
+                  - libgmp-dev (GNU Multiple Precision library)
+                .
+                Note: This package includes rapidsnark which is licensed under LGPL v3.
+                See NOTICE.md for license details.
+author:         BlockApps
+maintainer:     info@blockapps.net
+license:        NONE
+build-type:     Simple
+extra-source-files:
+    NOTICE.md
+    vendor/ffiasm/c/alt_bn128.cpp
+    vendor/ffiasm/c/curve.cpp
+    vendor/ffiasm/c/f12field.cpp
+    vendor/ffiasm/c/f2field.cpp
+    vendor/ffiasm/c/f6field.cpp
+    vendor/ffiasm/c/fft.cpp
+    vendor/ffiasm/c/misc.cpp
+    vendor/ffiasm/c/msm.cpp
+    vendor/ffiasm/c/multiexp.cpp
+    vendor/ffiasm/c/naf.cpp
+    vendor/ffiasm/c/scalar.cpp
+    vendor/ffiasm/c/splitparstr.cpp
+    vendor/rapidsnark/build/fq.cpp
+    vendor/rapidsnark/build/fq_generic.cpp
+    vendor/rapidsnark/build/fq_raw_generic.cpp
+    vendor/rapidsnark/build/fr.cpp
+    vendor/rapidsnark/build/fr_generic.cpp
+    vendor/rapidsnark/build/fr_raw_generic.cpp
+    vendor/rapidsnark/src/binfile_utils.cpp
+    vendor/rapidsnark/src/fileloader.cpp
+    vendor/rapidsnark/src/groth16.cpp
+    vendor/rapidsnark/src/logger.cpp
+    vendor/rapidsnark/src/prover.cpp
+    vendor/rapidsnark/src/wtns_utils.cpp
+    vendor/rapidsnark/src/zkey_utils.cpp
+    vendor/ffiasm/c/alt_bn128.hpp
+    vendor/ffiasm/c/curve.hpp
+    vendor/ffiasm/c/exp.hpp
+    vendor/ffiasm/c/exp2.hpp
+    vendor/ffiasm/c/f12field.hpp
+    vendor/ffiasm/c/f2field.hpp
+    vendor/ffiasm/c/f6field.hpp
+    vendor/ffiasm/c/fft.hpp
+    vendor/ffiasm/c/misc.hpp
+    vendor/ffiasm/c/msm.hpp
+    vendor/ffiasm/c/multiexp.hpp
+    vendor/ffiasm/c/naf.hpp
+    vendor/ffiasm/c/pointparallelprocessor.hpp
+    vendor/ffiasm/c/polynomial.hpp
+    vendor/ffiasm/c/scalar.hpp
+    vendor/ffiasm/c/splitparstr.hpp
+    vendor/json/single_include/nlohmann/json.hpp
+    vendor/rapidsnark/build/fq.hpp
+    vendor/rapidsnark/build/fq_element.hpp
+    vendor/rapidsnark/build/fr.hpp
+    vendor/rapidsnark/build/fr_element.hpp
+    vendor/rapidsnark/src/binfile_utils.hpp
+    vendor/rapidsnark/src/fileloader.hpp
+    vendor/rapidsnark/src/groth16.hpp
+    vendor/rapidsnark/src/logger.hpp
+    vendor/rapidsnark/src/logging.hpp
+    vendor/rapidsnark/src/random_generator.hpp
+    vendor/rapidsnark/src/wtns_utils.hpp
+    vendor/rapidsnark/src/zkey_utils.hpp
+    vendor/circom_witness.h
+    vendor/rapidsnark/src/prover.h
+    vendor/wasm3/m3_bind.h
+    vendor/wasm3/m3_code.h
+    vendor/wasm3/m3_compile.h
+    vendor/wasm3/m3_config.h
+    vendor/wasm3/m3_config_platforms.h
+    vendor/wasm3/m3_core.h
+    vendor/wasm3/m3_env.h
+    vendor/wasm3/m3_exception.h
+    vendor/wasm3/m3_exec.h
+    vendor/wasm3/m3_exec_defs.h
+    vendor/wasm3/m3_function.h
+    vendor/wasm3/m3_info.h
+    vendor/wasm3/m3_math_utils.h
+    vendor/wasm3/wasm3.h
+    vendor/wasm3/wasm3_defs.h
+    vendor/circom_witness.c
+    vendor/wasm3/m3_bind.c
+    vendor/wasm3/m3_code.c
+    vendor/wasm3/m3_compile.c
+    vendor/wasm3/m3_core.c
+    vendor/wasm3/m3_env.c
+    vendor/wasm3/m3_exec.c
+    vendor/wasm3/m3_function.c
+    vendor/wasm3/m3_info.c
+    vendor/wasm3/m3_module.c
+    vendor/wasm3/m3_parse.c
+    vendor/wasm3/LICENSE
+
+library
+  exposed-modules:
+      Groth16.Prover
+      Groth16.Prover.FFI
+      Groth16.Witness
+      Groth16.Witness.FFI
+  other-modules:
+      Paths_groth16_rapidsnark
+  autogen-modules:
+      Paths_groth16_rapidsnark
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  cc-options: -std=c99 -O2 -fPIC -Wno-unused-parameter -Wno-unused-variable -Dd_m3HasFloat=0
+  cxx-options: -std=c++17 -O2 -fPIC -Wno-address-of-packed-member -Wno-unused-parameter
+  include-dirs:
+      vendor/rapidsnark/src
+      vendor/rapidsnark/build
+      vendor/ffiasm/c
+      vendor/json/single_include
+      vendor/wasm3
+      vendor
+  c-sources:
+      vendor/wasm3/m3_bind.c
+      vendor/wasm3/m3_code.c
+      vendor/wasm3/m3_compile.c
+      vendor/wasm3/m3_core.c
+      vendor/wasm3/m3_env.c
+      vendor/wasm3/m3_exec.c
+      vendor/wasm3/m3_function.c
+      vendor/wasm3/m3_info.c
+      vendor/wasm3/m3_module.c
+      vendor/wasm3/m3_parse.c
+      vendor/circom_witness.c
+  cxx-sources:
+      vendor/rapidsnark/src/prover.cpp
+      vendor/rapidsnark/src/binfile_utils.cpp
+      vendor/rapidsnark/src/zkey_utils.cpp
+      vendor/rapidsnark/src/wtns_utils.cpp
+      vendor/rapidsnark/src/fileloader.cpp
+      vendor/rapidsnark/src/logger.cpp
+      vendor/rapidsnark/build/fr.cpp
+      vendor/rapidsnark/build/fr_generic.cpp
+      vendor/rapidsnark/build/fr_raw_generic.cpp
+      vendor/rapidsnark/build/fq.cpp
+      vendor/rapidsnark/build/fq_generic.cpp
+      vendor/rapidsnark/build/fq_raw_generic.cpp
+      vendor/ffiasm/c/misc.cpp
+      vendor/ffiasm/c/naf.cpp
+      vendor/ffiasm/c/splitparstr.cpp
+      vendor/ffiasm/c/alt_bn128.cpp
+  extra-libraries:
+      gmp
+      pthread
+      stdc++
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , directory
+    , filepath
+    , process
+    , temporary
+    , text
+    , vector
+  default-language: Haskell2010
+
+test-suite test-ffi
+  type: exitcode-stdio-1.0
+  main-is: TestFFI.hs
+  other-modules:
+      Paths_groth16_rapidsnark
+  autogen-modules:
+      Paths_groth16_rapidsnark
+  hs-source-dirs:
+      test
+  ghc-options: -Wall
+  build-depends:
+      base
+    , groth16-rapidsnark
+  default-language: Haskell2010

--- a/strato/libs/groth16-snarkjs/groth16-snarkjs.cabal
+++ b/strato/libs/groth16-snarkjs/groth16-snarkjs.cabal
@@ -1,0 +1,34 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           groth16-snarkjs
+version:        0.1.0
+synopsis:       Groth16 prover wrapper for snarkjs CLI
+description:    Wrapper for snarkjs (Node.js) Groth16 proof generation.
+                Handles witness calculation and proof generation via CLI calls.
+author:         BlockApps
+maintainer:     info@blockapps.net
+license:        AllRightsReserved
+build-type:     Simple
+
+library
+  exposed-modules:
+      Groth16.Snarkjs
+  other-modules:
+      Paths_groth16_snarkjs
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , filepath
+    , process
+    , temporary
+    , text
+    , vector
+  default-language: Haskell2010

--- a/strato/libs/kafka/milena-tools/.gitignore
+++ b/strato/libs/kafka/milena-tools/.gitignore
@@ -10,9 +10,6 @@ cabal-dev
 .virtualenv
 .hpc
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
 *.prof
 *.aux
 *.hp
-blockapps-util.cabal

--- a/strato/libs/kafka/milena-tools/milena-tools.cabal
+++ b/strato/libs/kafka/milena-tools/milena-tools.cabal
@@ -1,0 +1,27 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           milena-tools
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.MilenaTools
+  other-modules:
+      Paths_milena_tools
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , common-log
+    , milena
+    , monad-alter
+    , mtl
+    , text
+    , transformers
+  default-language: Haskell2010

--- a/strato/libs/kafka/milena/.gitignore
+++ b/strato/libs/kafka/milena/.gitignore
@@ -1,1 +1,0 @@
-blockapps-milena.cabal

--- a/strato/libs/kafka/milena/milena.cabal
+++ b/strato/libs/kafka/milena/milena.cabal
@@ -1,0 +1,95 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           milena
+version:        0.5.4.0
+synopsis:       A Kafka client for Haskell.
+description:    A Kafka client for Haskell.
+                The protocol module is stable (the only changes will be to support changes in the Kafka protocol). The API is functional but subject to change.
+category:       Network
+stability:      alpha
+homepage:       https://github.com/adamflott/milena.git#readme
+bug-reports:    https://github.com/adamflott/milena.git/issues
+author:         Tyler Holien
+maintainer:     Adam Flott <adam@adamflott.com>
+copyright:      2014, Tyler Holien
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+tested-with:
+    GHC==7.10.3 GHC==8.0.1
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/adamflott/milena.git
+
+library
+  exposed-modules:
+      Network.Kafka
+      Network.Kafka.Consumer
+      Network.Kafka.Protocol
+      Network.Kafka.Producer
+  other-modules:
+      DeprecatedNetworkFunction
+  default-extensions:
+      ConstraintKinds
+      DeriveGeneric
+      FlexibleContexts
+      GADTs
+      GeneralizedNewtypeDeriving
+      OverloadedStrings
+      Rank2Types
+      TemplateHaskell
+  ghc-options: -Wall -fwarn-unused-imports -Wincomplete-uni-patterns -Wincomplete-record-updates
+  build-depends:
+      base >=4.7 && <5
+    , bytestring >=0.10 && <0.12
+    , cereal >=0.4 && <0.6
+    , containers >=0.5 && <0.7
+    , digest >=0.0.1.0 && <0.1
+    , lens >=4.4 && <6.0
+    , lifted-base >=0.2.3.6 && <0.3
+    , monad-control ==1.0.*
+    , mtl >=2.1 && <2.4
+    , murmur-hash >=0.1.0.8 && <0.2
+    , network
+    , random >=1.0 && <1.3
+    , resource-pool >=0.2.3.2 && <0.5
+    , transformers >=0.3 && <0.7
+    , zlib >=0.6.1.2 && <0.7
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: tests.hs
+  other-modules:
+      Paths_milena
+  hs-source-dirs:
+      test
+  default-extensions:
+      ConstraintKinds
+      DeriveGeneric
+      FlexibleContexts
+      GADTs
+      GeneralizedNewtypeDeriving
+      OverloadedStrings
+      Rank2Types
+      TemplateHaskell
+  ghc-options: -Wall -fwarn-unused-imports -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts
+  build-depends:
+      base
+    , bytestring
+    , hspec
+    , lens
+    , milena
+    , mtl
+    , tasty
+    , tasty-hspec
+    , tasty-quickcheck
+  default-language: Haskell2010

--- a/strato/libs/labeled-error/labeled-error.cabal
+++ b/strato/libs/labeled-error/labeled-error.cabal
@@ -1,0 +1,23 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           labeled-error
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      LabeledError
+  other-modules:
+      Paths_labeled_error
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , base16-bytestring
+    , bytestring
+  default-language: Haskell2010

--- a/strato/libs/monad-alter/monad-alter.cabal
+++ b/strato/libs/monad-alter/monad-alter.cabal
@@ -1,0 +1,44 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           monad-alter
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/monad-alter#readme>
+homepage:       https://github.com/githubuser/monad-alter#readme
+bug-reports:    https://github.com/githubuser/monad-alter/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2019 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/monad-alter
+
+library
+  exposed-modules:
+      Control.Comonad.Change.Alter
+      Control.Monad.Change
+      Control.Monad.Change.Alter
+      Control.Monad.Change.Modify
+  other-modules:
+      Paths_monad_alter
+  hs-source-dirs:
+      src
+  ghc-options: -Werror
+  build-depends:
+      base
+    , comonad
+    , containers
+    , data-default
+    , lens
+    , mtl
+    , transformers
+  default-language: Haskell2010

--- a/strato/libs/nibblestring/nibblestring.cabal
+++ b/strato/libs/nibblestring/nibblestring.cabal
@@ -1,0 +1,25 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           nibblestring
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Data.NibbleString
+  other-modules:
+      Paths_nibblestring
+  hs-source-dirs:
+      src
+  build-depends:
+      Ranged-sets
+    , base
+    , base16-bytestring
+    , bytestring
+    , format
+  default-language: Haskell2010

--- a/strato/libs/partitioner/.gitignore
+++ b/strato/libs/partitioner/.gitignore
@@ -10,9 +10,6 @@ cabal-dev
 .virtualenv
 .hpc
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
 *.prof
 *.aux
 *.hp
-blockapps-util.cabal

--- a/strato/libs/partitioner/partitioner.cabal
+++ b/strato/libs/partitioner/partitioner.cabal
@@ -1,0 +1,22 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           partitioner
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.Partitioner
+  other-modules:
+      Paths_partitioner
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , containers
+  default-language: Haskell2010

--- a/strato/libs/poseidon-hash/poseidon-hash.cabal
+++ b/strato/libs/poseidon-hash/poseidon-hash.cabal
@@ -1,0 +1,61 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           poseidon-hash
+version:        0.1.0.0
+synopsis:       Poseidon hash function for ZK-SNARKs (BN254 curve)
+description:    A pure Haskell implementation of the Poseidon hash function,
+                designed for efficient computation inside ZK-SNARK circuits.
+                Uses the BN254 (alt_bn128) scalar field.
+category:       Cryptography
+author:         BlockApps
+maintainer:     info@blockapps.net
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+
+library
+  exposed-modules:
+      Crypto.Hash.Poseidon
+      Crypto.Hash.Poseidon.Field
+      Crypto.Hash.Poseidon.Constants
+  other-modules:
+      Paths_poseidon_hash
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -O2
+  build-depends:
+      base >=4.14 && <5
+    , vector >=0.12 && <0.14
+  default-language: Haskell2010
+
+executable poseidon
+  main-is: Main.hs
+  other-modules:
+      Paths_poseidon_hash
+  hs-source-dirs:
+      app
+  ghc-options: -Wall -O2
+  build-depends:
+      base >=4.14 && <5
+    , poseidon-hash
+  default-language: Haskell2010
+
+test-suite poseidon-hash-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_poseidon_hash
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -O2 -Wall
+  build-depends:
+      base >=4.14 && <5
+    , hspec >=2.7 && <2.12
+    , poseidon-hash
+  default-language: Haskell2010

--- a/strato/libs/prometheus/blockapps-init/blockapps-init.cabal
+++ b/strato/libs/prometheus/blockapps-init/blockapps-init.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-init
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Init
+  other-modules:
+      Paths_blockapps_init
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , common-log
+    , cross-monitoring
+    , prometheus-client
+    , resourcet
+    , text
+    , unix
+  default-language: Haskell2010
+
+executable test-reload
+  main-is: TestReload.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      base
+    , blockapps-init
+  default-language: Haskell2010

--- a/strato/libs/prometheus/cross-monitoring/cross-monitoring.cabal
+++ b/strato/libs/prometheus/cross-monitoring/cross-monitoring.cabal
@@ -1,0 +1,23 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           cross-monitoring
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Crossmon
+  other-modules:
+      Paths_cross_monitoring
+  hs-source-dirs:
+      src/
+  build-depends:
+      base
+    , prometheus-client
+    , text
+  default-language: Haskell2010

--- a/strato/libs/secp256k1-haskell/blockapps-secp256k1-haskell.cabal
+++ b/strato/libs/secp256k1-haskell/blockapps-secp256k1-haskell.cabal
@@ -30,12 +30,12 @@ source-repository head
 flag ecdh
   description: Enable (experimental) ECDH APIs
   manual: True
-  default: False
+  default: True
 
 flag recovery
   description: Enable signature key recovery APIs
   manual: True
-  default: False
+  default: True
 
 flag schnorr
   description: Enable BIP-340 (Schnorr) APIs

--- a/strato/libs/strato-auth/strato-auth.cabal
+++ b/strato/libs/strato-auth/strato-auth.cabal
@@ -1,0 +1,68 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-auth
+version:        0.1.0.0
+synopsis:       OAuth authentication library for STRATO CLI tools
+description:    Provides transparent OAuth device flow authentication for Servant clients and raw HTTP requests
+build-type:     Simple
+
+library
+  exposed-modules:
+      Strato.Auth
+      Strato.Auth.Client
+      Strato.Auth.ClientCredentials
+      Strato.Auth.Token
+  other-modules:
+      Paths_strato_auth
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , base64
+    , bytestring
+    , directory
+    , filelock
+    , filepath
+    , http-client
+    , http-client-tls
+    , http-types
+    , modern-uri
+    , req
+    , servant-client
+    , servant-client-core
+    , text
+    , time
+    , yaml
+  default-language: Haskell2010
+
+executable strato-auth
+  main-is: Main.hs
+  other-modules:
+      Paths_strato_auth
+  hs-source-dirs:
+      exec_src
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , base64
+    , bytestring
+    , directory
+    , filelock
+    , filepath
+    , http-client
+    , http-client-tls
+    , http-types
+    , modern-uri
+    , req
+    , servant-client
+    , servant-client-core
+    , strato-auth
+    , text
+    , time
+    , yaml
+  default-language: Haskell2010

--- a/strato/libs/strato-vault-client/strato-vault-client.cabal
+++ b/strato/libs/strato-vault-client/strato-vault-client.cabal
@@ -1,0 +1,24 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           strato-vault-client
+version:        0.1.0.0
+synopsis:       Client library for STRATO shared vault
+description:    Provides authenticated access to the shared vault service
+build-type:     Simple
+
+library
+  exposed-modules:
+      Strato.Vault.Client
+  other-modules:
+      Paths_strato_vault_client
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , servant-client
+    , strato-auth
+  default-language: Haskell2010

--- a/strato/libs/type-lits/type-lits.cabal
+++ b/strato/libs/type-lits/type-lits.cabal
@@ -1,0 +1,26 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           type-lits
+version:        0.0.0
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Blockchain.TypeLits
+  other-modules:
+      Paths_type_lits
+  hs-source-dirs:
+      src
+  build-depends:
+      QuickCheck
+    , aeson >=2.1.1.0 && <2.3
+    , base
+    , bifunctors
+    , comonad
+    , text
+  default-language: Haskell2010

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -125,11 +125,6 @@ extra-deps:
 #- git: https://github.com/blockapps/milena
 #  commit: 39dad725837f8d67721f3ac0f87a047ce36b2889
 
-flags:
-  blockapps-secp256k1-haskell:
-    ecdh: true
-    recovery: true
-
 nix:
   enable: false
   pure: false

--- a/strato/tools/airlock/airlock.cabal
+++ b/strato/tools/airlock/airlock.cabal
@@ -1,0 +1,110 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           airlock
+version:        0.1.0
+synopsis:       Railgun privacy wallet CLI for STRATO
+description:    Airlock is a command line wallet for Railgun privacy transactions on STRATO.
+                Supports shielding, unshielding, and managing private token balances.
+category:       Blockchain
+author:         BlockApps
+maintainer:     engineering@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+data-files:
+    circuits/01x02/circuit.wasm
+    circuits/01x02/vkey.json
+    circuits/01x02/vkey_check.json
+    circuits/01x02/wasm.br
+    circuits/01x02/zkey
+    circuits/01x02/zkey.br
+    data/english.txt
+
+library
+  exposed-modules:
+      Railgun.Keys
+      Railgun.Shield
+      Railgun.Unshield
+      Railgun.Transfer
+      Railgun.Crypto
+      Railgun.BIP39
+      Railgun.Types
+      Railgun.API
+      Railgun.Scan
+      Railgun.Balance
+      Railgun.Merkle
+      Railgun.Witness
+      Railgun.Prover
+      Railgun.Signing
+  other-modules:
+      Paths_airlock
+  hs-source-dirs:
+      src/
+  build-depends:
+      aeson
+    , baby-jubjub
+    , base
+    , base16-bytestring
+    , base64-bytestring
+    , bloc2api
+    , bloc2client
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-client
+    , bytestring
+    , containers
+    , core-api2
+    , cryptonite
+    , directory
+    , evm-solidity
+    , filepath
+    , groth16-native
+    , groth16-rapidsnark
+    , groth16-snarkjs
+    , http-client
+    , http-types
+    , memory
+    , poseidon-hash
+    , process
+    , servant-client
+    , servant-client-core
+    , strato-auth
+    , strato-conf
+    , strato-model
+    , temporary
+    , text
+    , transformers
+    , vector
+    , yaml
+  default-language: Haskell2010
+
+executable airlock
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson
+    , airlock
+    , base
+    , base16-bytestring
+    , bloc2api
+    , bytestring
+    , core-api2
+    , directory
+    , filepath
+    , http-client
+    , http-client-tls
+    , http-types
+    , network-uri
+    , optparse-applicative
+    , servant-client
+    , strato-auth
+    , strato-conf
+    , strato-model
+    , text
+    , time
+    , yaml
+  default-language: Haskell2010

--- a/strato/tools/blockapps-tools/.gitignore
+++ b/strato/tools/blockapps-tools/.gitignore
@@ -2,4 +2,3 @@
 *~
 dist
 .DS_Store
-blockapps-tools.cabal

--- a/strato/tools/blockapps-tools/blockapps-tools.cabal
+++ b/strato/tools/blockapps-tools/blockapps-tools.cabal
@@ -1,0 +1,119 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-tools
+version:        0.0.1
+synopsis:       A Haskell version of an Ethereum client
+description:    Tool to query the ethereum databases
+category:       Data Structures
+author:         Jamshid
+maintainer:     jamshidnh@gmail.com
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      BlockApps.Tools.Checkpoints
+      BlockApps.Tools.Code
+      BlockApps.Tools.DumpKafkaSequencer
+      BlockApps.Tools.DumpKafkaStateDiff
+      BlockApps.Tools.DumpKafkaUnSequencer
+      BlockApps.Tools.DumpKafkaVMEvents
+      BlockApps.Tools.DumpLevelDB
+      BlockApps.Tools.FRawMP
+      BlockApps.Tools.Hash
+      BlockApps.Tools.InsertP2P
+      BlockApps.Tools.InsertSeq
+      BlockApps.Tools.InsertTX
+      BlockApps.Tools.Psql
+      BlockApps.Tools.Raw
+      BlockApps.Tools.RawMP
+      BlockApps.Tools.Redis
+      BlockApps.Tools.RLP
+      BlockApps.Tools.State
+      BlockApps.Tools.SyncStats
+      BlockApps.Tools.Util
+  other-modules:
+      Paths_blockapps_tools
+  hs-source-dirs:
+      src/
+  build-depends:
+      aeson
+    , base
+    , binary
+    , blockDB
+    , blockapps-data
+    , blockapps-datadefs
+    , blockapps-mpdbs
+    , blockstanbul
+    , bytestring
+    , common-log
+    , data-default
+    , ethereum-discovery
+    , ethereum-rlp
+    , filepath
+    , format
+    , hedis
+    , hflags
+    , kafka-monad
+    , labeled-error
+    , leveldb-haskell
+    , merkle-patricia-db
+    , monad-logger
+    , monad-loops
+    , nibblestring
+    , persistent-postgresql
+    , resourcet
+    , seqevents
+    , solid-vm-model
+    , strato-conf
+    , strato-model
+    , strato-redis-blockdb
+    , text
+    , time
+    , transformers
+    , vm-tools
+  default-language: Haskell2010
+
+executable b16decode
+  main-is: B16Decode.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      base
+    , bytestring
+    , labeled-error
+  default-language: Haskell2010
+
+executable modifyDate
+  main-is: ModifyDate.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      base
+    , hflags
+    , time
+  default-language: Haskell2010
+
+executable strato-barometer
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      base
+    , blockapps-tools
+    , bytestring
+    , cmdargs
+    , directory
+    , filepath
+    , labeled-error
+    , merkle-patricia-db
+    , process
+    , seqevents
+    , strato-model
+    , strato-p2p
+    , text
+  default-language: Haskell2010

--- a/strato/tools/convoke/convoke.cabal
+++ b/strato/tools/convoke/convoke.cabal
@@ -1,0 +1,31 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           convoke
+version:        0.1.0.0
+build-type:     Simple
+
+executable convoke
+  main-is: Main.hs
+  other-modules:
+      WaitAnyOrInterrupt
+      Paths_convoke
+  hs-source-dirs:
+      exec_src
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      async
+    , base >=4.7 && <5
+    , containers
+    , directory
+    , filepath
+    , process
+    , shellwords
+    , stm
+    , text
+    , typed-process
+    , unix
+  default-language: Haskell2010

--- a/strato/tools/debugger-tools/debugger-tools.cabal
+++ b/strato/tools/debugger-tools/debugger-tools.cabal
@@ -1,0 +1,29 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           debugger-tools
+version:        0.0.1
+synopsis:       A toolkit for debugging in STRATO
+description:    A toolkit for debugging in STRATO
+category:       Debugging
+author:         jxuan101
+maintainer:     jin_huai_xuan@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+
+executable ghc-debug
+  main-is: ghc-debug.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      base
+    , containers
+    , ghc-debug-client
+    , ghc-debug-common
+    , language-dot
+    , mtl
+    , text
+  default-language: Haskell2010

--- a/strato/tools/process-monitor/process-monitor.cabal
+++ b/strato/tools/process-monitor/process-monitor.cabal
@@ -1,0 +1,45 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           process-monitor
+version:        0.0.1
+synopsis:       A per-process resource monitor for STRATO services
+description:    A per-process resource monitor for STRATO services
+category:       Monitoring?
+author:         Dustin
+maintainer:     dustin@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Data.Metrics
+      Data.ProcessInfo
+      Instrumentation
+  other-modules:
+      Paths_process_monitor
+  hs-source-dirs:
+      src/
+  build-depends:
+      base
+    , containers
+    , prometheus-client
+    , text
+  default-language: Haskell2010
+
+executable process-monitor-exe
+  main-is: Main.hs
+  hs-source-dirs:
+      exec_src/
+  build-depends:
+      async
+    , base
+    , process
+    , process-monitor
+    , prometheus-client
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010

--- a/strato/tools/x509-tools/x509-tools.cabal
+++ b/strato/tools/x509-tools/x509-tools.cabal
@@ -1,0 +1,68 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           x509-tools
+version:        0.0.1
+synopsis:       A toolkit for x509 usage in STRATO
+description:    A toolkit for x509 usage in STRATO
+category:       Data Structures
+author:         dpmesko
+maintainer:     daniel@blockapps.net
+license:        Apache-2.0
+build-type:     Simple
+
+executable x509-generator
+  main-is: X509CertGenerator.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      aeson
+    , base ==4.*
+    , bytestring
+    , hourglass
+    , strato-model
+    , transformers
+  default-language: Haskell2010
+
+executable x509-info
+  main-is: X509CertInfo.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      base ==4.*
+    , bytestring
+    , strato-model
+  default-language: Haskell2010
+
+executable x509-keygen
+  main-is: X509Keygen.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      aeson
+    , base ==4.*
+    , bytestring
+    , strato-model
+  default-language: Haskell2010
+
+executable x509-saltine-decrypt
+  main-is: X509SaltineDecrypt.hs
+  hs-source-dirs:
+      exec_src/
+  ghc-options: -Wall -Werror
+  build-depends:
+      base ==4.*
+    , base16-bytestring
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , optparse-applicative
+    , saltine
+    , strato-model
+  default-language: Haskell2010

--- a/strato/vault-proxy/api/blockapps-vault-proxy-api.cabal
+++ b/strato/vault-proxy/api/blockapps-vault-proxy-api.cabal
@@ -1,0 +1,41 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-vault-proxy-api
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/API#readme>
+homepage:       https://github.com/githubuser/API#readme
+bug-reports:    https://github.com/githubuser/API/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/API
+
+library
+  exposed-modules:
+      Strato.VaultProxy.API.Types
+      Strato.VaultProxy.DataTypes
+  other-modules:
+      Paths_blockapps_vault_proxy_api
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -threaded
+  build-depends:
+      aeson
+    , base
+    , cache
+    , concurrent-extra
+    , http-client
+    , openapi3
+    , scientific
+    , strato-model
+    , text
+  default-language: Haskell2010

--- a/strato/vault-proxy/server/blockapps-vault-proxy-server.cabal
+++ b/strato/vault-proxy/server/blockapps-vault-proxy-server.cabal
@@ -1,0 +1,96 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-vault-proxy-server
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/server#readme>
+homepage:       https://github.com/githubuser/vault-proxy#readme
+bug-reports:    https://github.com/githubuser/vault-proxy/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/vault-proxy
+
+library
+  exposed-modules:
+      Strato.VaultProxy.GetPing
+      Strato.VaultProxy.RawOauth
+      Strato.VaultProxy.Server.Token
+  other-modules:
+      Paths_blockapps_vault_proxy_server
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -threaded
+  build-depends:
+      base
+    , base64
+    , blockapps-vault-proxy-api
+    , cache
+    , clock
+    , concurrent-extra
+    , exceptions
+    , http-client
+    , modern-uri
+    , req
+    , servant
+    , servant-client
+    , stm
+    , text
+  default-language: Haskell2010
+
+executable blockapps-vault-proxy-server
+  main-is: Main.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  ghc-options: -Wall -Werror -threaded -threaded
+  build-depends:
+      base
+    , blockapps-init
+    , blockapps-vault-proxy-api
+    , blockapps-vault-proxy-server
+    , bytestring
+    , cache
+    , concurrent-extra
+    , hflags
+    , http-client
+    , http-conduit
+    , http-reverse-proxy
+    , http-types
+    , process-monitor
+    , regex-compat
+    , servant-client
+    , servant-client-core
+    , text
+    , wai
+    , warp
+  default-language: Haskell2010
+
+test-suite vault-proxy-spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_blockapps_vault_proxy_server
+  hs-source-dirs:
+      test/
+  ghc-options: -Wall -Werror -threaded -dynamic
+  build-depends:
+      async
+    , base
+    , blockapps-vault-proxy-api
+    , blockapps-vault-proxy-server
+    , cache
+    , concurrent-extra
+    , hspec
+    , mtl
+    , stm
+  default-language: Haskell2010

--- a/strato/vault/api/blockapps-vault-wrapper-api.cabal
+++ b/strato/vault/api/blockapps-vault-wrapper-api.cabal
@@ -1,0 +1,54 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-vault-wrapper-api
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/API#readme>
+homepage:       https://github.com/githubuser/API#readme
+bug-reports:    https://github.com/githubuser/API/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/API
+
+library
+  exposed-modules:
+      Strato.Strato23.API
+      Strato.Strato23.API.Key
+      Strato.Strato23.API.Password
+      Strato.Strato23.API.Ping
+      Strato.Strato23.API.Signature
+      Strato.Strato23.API.Types
+      Strato.Strato23.API.Users
+      Strato.Strato23.Crypto
+  other-modules:
+      Paths_blockapps_vault_wrapper_api
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , aeson-casing
+    , base
+    , base16-bytestring
+    , bytestring
+    , cryptonite
+    , labeled-error
+    , lens
+    , openapi3
+    , saltine
+    , servant
+    , servant-server
+    , strato-model
+    , text
+  default-language: Haskell2010

--- a/strato/vault/client/blockapps-vault-wrapper-client.cabal
+++ b/strato/vault/client/blockapps-vault-wrapper-client.cabal
@@ -1,0 +1,37 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-vault-wrapper-client
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/client#readme>
+homepage:       https://github.com/githubuser/client#readme
+bug-reports:    https://github.com/githubuser/client/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/client
+
+library
+  exposed-modules:
+      Strato.Strato23.Client
+  other-modules:
+      Paths_blockapps_vault_wrapper_client
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , blockapps-vault-wrapper-api
+    , servant-client
+    , text
+  default-language: Haskell2010

--- a/strato/vault/server/blockapps-vault-wrapper-server.cabal
+++ b/strato/vault/server/blockapps-vault-wrapper-server.cabal
@@ -1,0 +1,192 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           blockapps-vault-wrapper-server
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/server#readme>
+homepage:       https://github.com/githubuser/vault-wrapper#readme
+bug-reports:    https://github.com/githubuser/vault-wrapper/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2018 Author name here
+license:        Apache-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/vault-wrapper
+
+library
+  exposed-modules:
+      Strato.Strato23.Database.Create
+      Strato.Strato23.Database.Migrations
+      Strato.Strato23.Database.Queries
+      Strato.Strato23.Database.Tables
+      Strato.Strato23.Monad
+      Strato.Strato23.Server
+      Strato.Strato23.Server.Key
+      Strato.Strato23.Server.Password
+      Strato.Strato23.Server.Ping
+      Strato.Strato23.Server.Signature
+      Strato.Strato23.Server.User
+      Strato.Strato23.Server.Utils
+  other-modules:
+      Paths_blockapps_vault_wrapper_server
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , blockapps-vault-wrapper-api
+    , bytestring
+    , cache
+    , common-log
+    , cryptonite
+    , http-client
+    , lens
+    , mtl
+    , opaleye
+    , openapi3
+    , postgresql-simple
+    , product-profunctors
+    , profunctors
+    , resource-pool
+    , saltine
+    , servant-openapi3
+    , servant-server
+    , strato-model
+    , text
+    , transformers
+    , unliftio
+  default-language: Haskell2010
+
+executable blockapps-vault-wrapper-server
+  main-is: Main.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  ghc-options: -threaded
+  build-depends:
+      base
+    , blockapps-init
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , cache
+    , clock
+    , common-log
+    , hflags
+    , http-client
+    , postgresql-simple
+    , resource-pool
+    , servant-options
+    , servant-server
+    , wai-cors
+    , wai-extra
+    , wai-middleware-prometheus
+    , warp
+  default-language: Haskell2010
+
+executable migrate-keys
+  main-is: MigrateKeys.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  build-depends:
+      base
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , csv
+    , hflags
+    , lens
+    , opaleye
+    , postgresql-simple
+    , text
+  default-language: Haskell2010
+
+executable migrate-mercata
+  main-is: MigrateMercata.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  build-depends:
+      base
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , hflags
+    , lens
+    , opaleye
+    , postgresql-simple
+    , saltine
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+executable migrate-nodekey
+  main-is: MigrateNodeKey.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  build-depends:
+      base
+    , base64-bytestring
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , hflags
+    , opaleye
+    , postgresql-simple
+    , saltine
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+executable migrate-salt
+  main-is: MigrateSalt.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  build-depends:
+      base
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , hflags
+    , lens
+    , opaleye
+    , postgresql-simple
+    , saltine
+    , strato-model
+    , text
+  default-language: Haskell2010
+
+test-suite vault-wrapper-spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_blockapps_vault_wrapper_server
+  hs-source-dirs:
+      test/
+  build-depends:
+      base
+    , blockapps-data
+    , blockapps-secp256k1-haskell
+    , bytestring
+    , clockwork
+    , cryptonite
+    , ethereum-rlp
+    , hspec
+    , labeled-error
+    , strato-model
+  default-language: Haskell2010


### PR DESCRIPTION
Since `strato-platform` is public now, its Haskell packages can be used as `extra-deps` by other repos using Haskell and `stack`. However, since our packages aren't published to Hackage, stack requires the generated `.cabal` files to be included in the repo for them to be used as git dependencies. I was confused by this, but stack gave me many `DEPRECATED` errors when trying to import our packages into another project through git.
Michael Snoyman has a blog post about why he now recommends including the generated `.cabal` files in repos: https://academy.fpblock.com/blog/storing-generated-cabal-files/

I also made the `ecdh` and `recovery` flags default to `True` in `blockapps-secp256k1-haskell.cabal`, so that people don't have to manually enable those flags in downstream packages, and STRATO doesn't even compile with them disabled.