### PR TITLE
feat(mercata): add active-session Griphook MCP assistant UI + backend proxy

### DIFF
--- a/mercata/backend/src/api/controllers/chat.controller.ts
+++ b/mercata/backend/src/api/controllers/chat.controller.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from "express";
+import axios from "axios";
+import { griphookMcpTimeoutMs, griphookMcpUrl } from "../../config/config";
+
+class ChatController {
+  static async proxyMcp(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const accessToken = req.accessToken as string;
+      const mcpSessionId = req.headers["mcp-session-id"] as string | undefined;
+
+      const upstreamResponse = await axios.post(griphookMcpUrl, req.body, {
+        timeout: Number.isFinite(griphookMcpTimeoutMs) ? griphookMcpTimeoutMs : 30000,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${accessToken}`,
+          ...(mcpSessionId ? { "mcp-session-id": mcpSessionId } : {}),
+        },
+        validateStatus: () => true,
+      });
+
+      const nextSessionId = upstreamResponse.headers["mcp-session-id"] as string | undefined;
+      if (nextSessionId) {
+        res.setHeader("mcp-session-id", nextSessionId);
+      }
+
+      res.status(upstreamResponse.status).json(upstreamResponse.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default ChatController;

--- a/mercata/backend/src/api/routes.ts
+++ b/mercata/backend/src/api/routes.ts
@@ -17,6 +17,7 @@ import lendingRoutes from "./routes/lending.routes";
 import eventsRoutes from "./routes/events.routes";
 import bridgeRoutes from "./routes/bridge.routes";
 import creditCardRoutes from "./routes/creditCard.routes";
+import chatRoutes from "./routes/chat.routes";
 import cdpRoutes from "./routes/cdp.routes";
 import rewardsRoutes from "./routes/rewards.routes";
 import protocolFeeRoutes from "./routes/protocolFee.routes";
@@ -80,6 +81,9 @@ router.use("/bridge", bridgeRoutes);
 
 // ----- Crypto Credit Card Routes -----
 router.use("/credit-card", creditCardRoutes);
+
+// ----- AI Assistant Routes -----
+router.use("/chat", chatRoutes);
 
 // ----- CDP Routes -----
 router.use("/cdp", cdpRoutes);

--- a/mercata/backend/src/api/routes/chat.routes.ts
+++ b/mercata/backend/src/api/routes/chat.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import authHandler from "../middleware/authHandler";
+import ChatController from "../controllers/chat.controller";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /chat/mcp:
+ *   post:
+ *     summary: Proxy MCP JSON-RPC requests to Griphook using the active user session token
+ *     tags: [Chat]
+ *     responses:
+ *       200:
+ *         description: MCP response payload
+ *       401:
+ *         description: Unauthorized
+ */
+router.post("/mcp", authHandler.authorizeRequest(), ChatController.proxyMcp);
+
+export default router;

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -36,6 +36,8 @@ export const clientId = process.env.OAUTH_CLIENT_ID;
 export const clientSecret = process.env.OAUTH_CLIENT_SECRET;
 export const nodeUrl = process.env.NODE_URL;
 export const baseUrl = process.env.BASE_URL || "http://localhost";
+export const griphookMcpUrl = process.env.GRIPHOOK_MCP_URL || "https://griphook.strato.nexus/mcp";
+export const griphookMcpTimeoutMs = Number(process.env.GRIPHOOK_MCP_TIMEOUT_MS || 30000);
 
 // Smart contract addresses
 export const burnAddress = process.env.BURN_ADDRESS || "0000000000000000000000000000000000000000";

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -33,6 +33,7 @@ import ReferralsManagement from "./pages/ReferralsManagement";
 import Vault from "./pages/Vault";
 import OnrampPage from "./pages/OnrampPage";
 import CreditCardPage from "./pages/CreditCard";
+import AssistantPage from "./pages/Assistant";
 
 // Import dashboard components
 
@@ -268,6 +269,14 @@ const App = () => {
                                               <GuestAccessibleRoute>
                                                 <Transfer />
                                               </GuestAccessibleRoute>
+                                            }
+                                          />
+                                          <Route
+                                            path="/dashboard/assistant"
+                                            element={
+                                              <ProtectedRoute>
+                                                <AssistantPage />
+                                              </ProtectedRoute>
                                             }
                                           />
                                           <Route

--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -16,7 +16,8 @@ import {
   UserPlus,
   LucideIcon,
   Vault,
-  CreditCard
+  CreditCard,
+  MessageSquare
 } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import STRATOLOGO from '@/assets/strato.png';
@@ -39,6 +40,7 @@ const PRIMARY_NAV_ITEMS: NavItem[] = [
   { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
   { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
   { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+  { icon: MessageSquare, label: 'AI Assistant', path: '/dashboard/assistant' },
   { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
   { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
   { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },

--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -10,13 +10,13 @@ import {
   Gift, 
   Activity, 
   CreditCard,
+  MessageSquare,
   Download, 
   BarChart3, 
   Droplets, 
   Shield,
   UserPlus,
   Vault,
-  CreditCard,
   X
 } from 'lucide-react';
 import { Drawer, DrawerClose, DrawerContent } from '@/components/ui/drawer';
@@ -37,6 +37,7 @@ const MORE_ITEMS = [
   { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
   { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
   { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+  { icon: MessageSquare, label: 'AI Assistant', path: '/dashboard/assistant' },
   { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
   { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
   { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },

--- a/mercata/ui/src/pages/Assistant.tsx
+++ b/mercata/ui/src/pages/Assistant.tsx
@@ -1,0 +1,273 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import MobileBottomNav from "@/components/dashboard/MobileBottomNav";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { api } from "@/lib/axios";
+import { Bot, Send } from "lucide-react";
+
+type ChatRole = "assistant" | "user";
+
+type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  text: string;
+};
+
+type McpTool = {
+  name: string;
+  description?: string;
+};
+
+type JsonRpcResponse = {
+  result?: any;
+  error?: { message?: string };
+};
+
+const AssistantPage = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: "welcome",
+      role: "assistant",
+      text: "Connected to Griphook via your active login. Ask about balances, rewards, swaps, bridge, vault, or lending.\n\nCommands: /tools, /call <tool> <json-args>, /help",
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const [isWorking, setIsWorking] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [tools, setTools] = useState<McpTool[]>([]);
+  const [initialized, setInitialized] = useState(false);
+  const nextRequestId = useRef(1);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    document.title = "AI Assistant | STRATO";
+  }, []);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const addMessage = (role: ChatRole, text: string) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        role,
+        text,
+      },
+    ]);
+  };
+
+  const mcpPost = async (payload: Record<string, unknown>): Promise<JsonRpcResponse> => {
+    const response = await api.post("/chat/mcp", payload, {
+      headers: sessionId ? { "mcp-session-id": sessionId } : undefined,
+    });
+    const nextSessionId = response.headers["mcp-session-id"] as string | undefined;
+    if (nextSessionId && nextSessionId !== sessionId) {
+      setSessionId(nextSessionId);
+    }
+    return response.data;
+  };
+
+  const mcpRequest = async (method: string, params?: Record<string, unknown>): Promise<JsonRpcResponse> => {
+    const id = nextRequestId.current++;
+    return mcpPost({
+      jsonrpc: "2.0",
+      id,
+      method,
+      ...(params ? { params } : {}),
+    });
+  };
+
+  const initializeMcp = async () => {
+    if (initialized) return;
+
+    const initResponse = await mcpRequest("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "mercata-assistant", version: "1.0.0" },
+    });
+
+    if (initResponse.error) {
+      throw new Error(initResponse.error.message || "Failed to initialize MCP");
+    }
+
+    await mcpPost({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+
+    const toolsResponse = await mcpRequest("tools/list", {});
+    if (toolsResponse.error) {
+      throw new Error(toolsResponse.error.message || "Failed to fetch tools");
+    }
+
+    const listedTools = (toolsResponse.result?.tools || []) as McpTool[];
+    setTools(listedTools);
+    setInitialized(true);
+  };
+
+  const pickReadOnlyTool = (text: string): { name: string; args: Record<string, unknown> } => {
+    const normalized = text.toLowerCase();
+
+    if (normalized.includes("reward")) return { name: "strato.rewards", args: {} };
+    if (normalized.includes("borrow") || normalized.includes("lend") || normalized.includes("loan")) {
+      return { name: "strato.lending", args: {} };
+    }
+    if (normalized.includes("vault") || normalized.includes("cdp")) {
+      return { name: "strato.cdp", args: {} };
+    }
+    if (normalized.includes("bridge") || normalized.includes("withdraw") || normalized.includes("deposit")) {
+      return { name: "strato.bridge", args: { includeSummary: true } };
+    }
+    if (normalized.includes("swap") || normalized.includes("liquidity") || normalized.includes("pool")) {
+      return { name: "strato.swap", args: { includePositions: true } };
+    }
+
+    return {
+      name: "strato.tokens",
+      args: { includeBalances: true, includeEarningAssets: true, includeStats: true },
+    };
+  };
+
+  const runTool = async (name: string, args: Record<string, unknown>) => {
+    const response = await mcpRequest("tools/call", {
+      name,
+      arguments: args,
+    });
+
+    if (response.error) {
+      throw new Error(response.error.message || `Tool call failed: ${name}`);
+    }
+
+    const content = response.result?.content;
+    if (Array.isArray(content)) {
+      const textParts = content
+        .map((item) => (typeof item?.text === "string" ? item.text : JSON.stringify(item)))
+        .join("\n\n");
+      addMessage("assistant", textParts || JSON.stringify(response.result, null, 2));
+      return;
+    }
+
+    addMessage("assistant", JSON.stringify(response.result ?? response, null, 2));
+  };
+
+  const toolsSummary = useMemo(() => {
+    if (tools.length === 0) return "No tools loaded yet.";
+    return tools
+      .slice(0, 24)
+      .map((tool) => `- ${tool.name}${tool.description ? `: ${tool.description}` : ""}`)
+      .join("\n");
+  }, [tools]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const text = input.trim();
+    if (!text || isWorking) return;
+
+    addMessage("user", text);
+    setInput("");
+    setIsWorking(true);
+
+    try {
+      await initializeMcp();
+
+      if (text === "/help") {
+        addMessage(
+          "assistant",
+          "Use /tools to list available MCP tools, or /call <tool> <json-args> for explicit calls.\nWithout commands, I map your message to a read-only STRATO snapshot tool."
+        );
+      } else if (text === "/tools") {
+        addMessage("assistant", toolsSummary);
+      } else if (text.startsWith("/call ")) {
+        const match = text.match(/^\/call\s+([^\s]+)(?:\s+([\s\S]+))?$/);
+        if (!match) {
+          addMessage("assistant", "Invalid call syntax. Use: /call <tool> <json-args>");
+        } else {
+          const toolName = match[1];
+          const argsJson = match[2];
+          const args = argsJson ? JSON.parse(argsJson) : {};
+          await runTool(toolName, args);
+        }
+      } else {
+        const selected = pickReadOnlyTool(text);
+        addMessage("assistant", `Running ${selected.name}...`);
+        await runTool(selected.name, selected.args);
+      }
+    } catch (error: any) {
+      addMessage("assistant", `Request failed: ${error?.message || "Unknown error"}`);
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-16 md:pb-0">
+      <DashboardSidebar />
+
+      <div className="transition-all duration-300" style={{ paddingLeft: "var(--sidebar-width, 0px)" }}>
+        <DashboardHeader title="AI Assistant" />
+        <main className="p-4 md:p-6">
+          <div className="mx-auto max-w-5xl">
+            <Card className="border border-border shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <Bot className="h-5 w-5" />
+                  Griphook Assistant
+                </CardTitle>
+                <CardDescription>
+                  Uses your active STRATO login and calls the Griphook MCP endpoint through the backend proxy.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="h-[480px] overflow-y-auto rounded-md border bg-muted/20 p-4">
+                  <div className="space-y-3">
+                    {messages.map((message) => (
+                      <div
+                        key={message.id}
+                        className={`max-w-[92%] rounded-md p-3 text-sm whitespace-pre-wrap ${
+                          message.role === "user"
+                            ? "ml-auto bg-blue-600 text-white"
+                            : "bg-card border border-border text-foreground"
+                        }`}
+                      >
+                        {message.text}
+                      </div>
+                    ))}
+                    <div ref={endRef} />
+                  </div>
+                </div>
+
+                <form className="space-y-3" onSubmit={handleSubmit}>
+                  <Textarea
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    placeholder="Ask about balances, rewards, swaps, bridge, vault, lending, or use /call..."
+                    className="min-h-[96px]"
+                  />
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs text-muted-foreground">
+                      Commands: /tools, /call &lt;tool&gt; &lt;json-args&gt;, /help
+                    </p>
+                    <Button type="submit" disabled={isWorking || !input.trim()}>
+                      <Send className="mr-2 h-4 w-4" />
+                      {isWorking ? "Running..." : "Send"}
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        </main>
+      </div>
+
+      <MobileBottomNav />
+    </div>
+  );
+};
+
+export default AssistantPage;


### PR DESCRIPTION
## Summary
This PR introduces a first-party Mercata AI Assistant flow that reuses the user's active OAuth session and removes manual Griphook token copy/paste.

## Scope
### Backend (`mercata/backend`)
- Added `POST /api/chat/mcp` proxy endpoint.
- Proxy forwards authenticated `req.accessToken` as `Authorization: Bearer <token>` to Griphook MCP.
- Preserves MCP session continuity by forwarding `mcp-session-id` header in both directions.
- Added env config:
  - `GRIPHOOK_MCP_URL` (default: `https://griphook.strato.nexus/mcp`)
  - `GRIPHOOK_MCP_TIMEOUT_MS` (default: `30000`)

### Frontend (`mercata/ui`)
- Added new dashboard page: `/dashboard/assistant`.
- Added chat text window with:
  - MCP initialize flow
  - tool listing (`/tools`)
  - explicit tool calls (`/call <tool> <json-args>`)
  - simple read-only intent-to-tool mapping for quick UX.
- Added navigation entry in desktop sidebar and mobile More menu.

## Why
- Removes user friction (no manual token handling).
- Keeps auth and token flow server-side.
- Uses existing Mercata auth middleware and session model.

## Security / Auth Notes
- Endpoint is protected by existing `authorizeRequest()` middleware.
- Browser never stores/handles a separate Griphook refresh token.
- Session token is injected server-side at request time.

## Testing
- Verified route/controller wiring and MCP request flow in code.
- Build checks attempted in this environment:
  - `mercata/backend`: `npm run build` failed because `tsc` is not installed in this runtime.
  - `mercata/ui`: `npm run build` fails due unrelated existing import issue (`@stripe/crypto` in `OnrampPage.tsx`).

## Follow-ups
- Add server-side allowlist/guardrails for tool invocation policy.
- Improve conversational orchestration/summarization layer above direct tool calls.
