### PR TITLE
Hotfix for credit card flow

### DIFF
--- a/mercata/backend/src/api/services/creditCard.service.ts
+++ b/mercata/backend/src/api/services/creditCard.service.ts
@@ -464,7 +464,7 @@ export async function getPendingWithdrawalsForCard(
   accessToken: string,
   cardWalletAddress: string
 ): Promise<Array<{ amount: string; status: number; timestamp: string }>> {
-  const bridgeAddress = process.env.BRIDGE_ADDRESS;
+  const bridgeAddress = process.env.BRIDGE_ADDRESS || '0000000000000000000000000000000000001008';
   if (!bridgeAddress) return [];
   const normalizedWallet = normalizeAddress(cardWalletAddress);
   if (!normalizedWallet) return [];

--- a/mercata/backend/src/config/constants.ts
+++ b/mercata/backend/src/config/constants.ts
@@ -1,4 +1,4 @@
-import { lendingRegistry, poolFactory, tokenFactory, adminRegistry, mercataBridge, cdpRegistry, voucher, creditCardTopUp } from "./config";
+import { lendingRegistry, poolFactory, tokenFactory, adminRegistry, mercataBridge, cdpRegistry, voucher } from "./config";
 import * as config from "./config";
 import {
   SWAP_CONTRACTS,
@@ -149,7 +149,7 @@ export const constants = (() => {
     VaultFactory,
     get vaultFactory() { return config.vaultFactory; },  // Use getter to get current value after init
     mercataBridge,
-    creditCardTopUp,
+    get creditCardTopUp() { return config.creditCardTopUp; },  // Use getter to get current value after init
     Event,
     tokenSelectFields,
     tokenBalanceSelectFields,


### PR DESCRIPTION
Small fixes to credit card for noticed after testing on prod. The main one is that the app backend container was not loading the network id correctly during API calls, which result in transaction failures to the addCard function. Since the config defaults to the address from testnet, this makes the problem when running on testnet, only seeing it once moving to prod