### PR TITLE
Fix MetaMask connection hang caused by oversized STRATO chain ID

### DIFF
--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -117,7 +117,7 @@ const App = () => {
       const appName = "Mercata";
       const stratoChainId = networkId ? Number(networkId) : null;
       const stratoChain =
-        stratoChainId != null && !Number.isNaN(stratoChainId)
+        stratoChainId != null && !Number.isNaN(stratoChainId) && Number.isSafeInteger(stratoChainId)
           ? defineChain({
               id: stratoChainId,
               name: "STRATO",


### PR DESCRIPTION
## Summary
- Guard `defineChain` with `Number.isSafeInteger()` to skip STRATO chain IDs that exceed JS safe integer range
- Prevents viem `IntegerOutOfRangeError` that crashes provider init and hangs MetaMask connect

Closes #6458