### PR TITLE
node starts with isSynced=false by default

### DIFF
--- a/strato/core/blockDB/src/Blockchain/SyncDB.hs
+++ b/strato/core/blockDB/src/Blockchain/SyncDB.hs
@@ -240,8 +240,10 @@ checkAndUpdateSyncStatus = do
 
   case (status, nodeNumber, worldNumber) of
     (Just False, Just ntd, Just wtd) -> when (ntd >= wtd) (void $ putSyncStatus True)
+    (Just True, Just ntd, Just wtd) -> when (ntd < wtd) (void $ putSyncStatus False)
     (Nothing, Just ntd, Just wtd) -> void $ putSyncStatus (ntd >= wtd)
     (Nothing, Nothing, Just _) -> void $ putSyncStatus False
+    (_, Just _, Nothing) -> void $ putSyncStatus True
     _ -> pure ()
 
 getSyncStatusNow :: Redis (Maybe Bool)
@@ -259,7 +261,7 @@ getSyncStatusNow = do
           (Just False, Just ntd, Just wtd) -> ntd >= wtd
           (Nothing, Just ntd, Just wtd)    -> ntd >= wtd
           (Nothing, Nothing, Just _)       -> False
-          _                                -> True
+          _                                -> False
 
 syncStatusKey :: S8.ByteString
 syncStatusKey = "<sync_status>"


### PR DESCRIPTION
Changes in strato/core/blockDB/src/Blockchain/SyncDB.hs
1. getSyncStatusNow — line 264: _ -> True changed to _ -> False

Fixes the reported bug (https://github.com/strato-net/strato-platform/issues/6470). When a node starts and hasn't connected to peers yet, the state is (Nothing, Just 0, Nothing) — we have a local best block (genesis) but no world best block. The old catch-all returned True (synced), now it correctly returns False.

2. checkAndUpdateSyncStatus — line 243: new (Just True, ...) case

Pre-existing bug fix. Once syncStatus was set to True, it could never be reset to False even if the node fell behind. This adds the mirror case: if the node is marked synced but its block number is now behind the world best, reset to False. This also guards against a race condition where p2p's updateWorldBestBlockInfo and the sequencer's putBestBlockInfo fire concurrently.

3. checkAndUpdateSyncStatus — line 246: new (_, Just _, Nothing) case

Handles single-node networks. If the node has a local best block but no world best block has ever been reported (no peers), it assumes it's synced — because it IS the world. This case is only reached via putBestBlockInfo (sequencer producing blocks), which for multi-node networks only happens after p2p has already set the world best block.