### PR TITLE
Minor P2P improvements

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -44,7 +44,6 @@ import           Data.Bits                             (shiftL)
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Char8                 as BC
 import qualified Data.Conduit.Binary                   as CB
-import           Data.Conduit.TQueue
 import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
@@ -63,14 +62,14 @@ blockstanbulVersion = 1
 
 debounceTxSendsAndUnseq :: (MonadIO m, m `Mod.Outputs` [IngestEvent]) => ConduitT (Either P2PCNC Message) Message m ()
 debounceTxSendsAndUnseq = do
-  txq <- atomically newTQueue
+  txq <- atomically $ newTBQueue 10000
   awaitForever $ \case
     Right (W.Transactions txs) -> do
-      atomically $ mapM_ (writeTQueue txq) txs
+      atomically $ mapM_ (writeTBQueue txq) txs
       recordQueuedTxs txs
     Right other -> yield other
     Left TXQueueTimeout -> do
-      txs <- atomically $ flushTQueue txq
+      txs <- atomically $ flushTBQueue txq
       recordEmptyQueue
       yieldMany . map W.Transactions $ chunksOf 100 txs
     Left (ToUnseq ie) -> lift $ Mod.output ie

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -389,7 +389,8 @@ handleEvents peer = awaitForever $ \case
     P2pMPNodesResponse o nds -> when (shouldRespond peer o) . yieldR $ MPNodes nds
   TimerEvt -> do
     WorldBestBlock (BestBlock _ worldNumber) <- lift $ Mod.get (Proxy @WorldBestBlock)
-    syncDone <- return $ Just False -- RBDB.withRedisBlockDB $ getSyncStatus
+    BestSequencedBlock _ myNumber _ <- lift $ Mod.get (Proxy @BestSequencedBlock)
+    let syncDone = if worldNumber >= 0 then Just (myNumber >= worldNumber) else Nothing
     unless (syncDone == Just True) $ do
       maybeSyncTask <- lift $ getCurrentSyncTask $ pPeerHost peer
       case maybeSyncTask of

--- a/strato/core/strato-p2p/src/Blockchain/HeaderCache.hs
+++ b/strato/core/strato-p2p/src/Blockchain/HeaderCache.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MonoLocalBinds #-}
@@ -39,7 +40,8 @@ instance MonadP2P m => HasHeaderCache m where
 
   addToHeaderCache headers = do
     alreadyRequestedRemainingHeaders <- getRemainingBHeaders
-    putRemainingBHeaders $ alreadyRequestedRemainingHeaders ++ headers
+    let !combined = alreadyRequestedRemainingHeaders ++ headers
+    length combined `seq` putRemainingBHeaders combined
 
   getBodiesToFetch = do
     alreadyRequestedHeaders <- getBlockHeaders -- check what already requested
@@ -57,9 +59,9 @@ instance MonadP2P m => HasHeaderCache m where
           return newNeededHeaders
         (first, rest) -> do
           let (newNeededHeaders, remainingHeaders) = splitNeededHeaders first
-              newRemainingHeaders = remainingHeaders ++ rest
+              !newRemainingHeaders = remainingHeaders ++ rest
           $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putRemainingBHeaders called: range = " ++ showRanges (map BlockHeader.number newRemainingHeaders)
-          putRemainingBHeaders newRemainingHeaders -- save it to handle later
+          length newRemainingHeaders `seq` putRemainingBHeaders newRemainingHeaders
           $logInfoS "handleEvents/BlockHeaders" $
             "Not requesting BlockBodies because cache is currently in use, but will request after next batch of BlockBodies arrives."
           return newNeededHeaders


### PR DESCRIPTION
I asked Claude to investigate memory usage in P2P. For instance, node1 on prod is currently using over 3GB of memory and a persistent 10-20% CPU on multiple cores, despite being in sync and the network being idle. Although I don't expect these changes to solve the problem entirely, Claude recommended fixing the `syncDone` check to prevent unconditional sync task fetching, which I believe is part of the CPU problem. node1's p2p logs are flooded with lines attempting to get a new sync task, followed by "I've grabbed a new syncTask: Nothing", over and over. I am suspicious that this also prevents some of these threads from terminating, further contributing to the sustained memory and CPU usage. Claude also recommended bounding the size of the outbound transaction queue, as well as adding strictness to `HeaderCache.hs` as potential improvements to memory usage. I'll test these changes out to see if they yield better utilization by p2p, but I think overall they will be marginal at best.