### PR TITLE
strato auth connection error handling

### DIFF
--- a/strato/libs/strato-auth/package.yaml
+++ b/strato/libs/strato-auth/package.yaml
@@ -28,6 +28,7 @@ library:
     - Strato.Auth
     - Strato.Auth.Client
     - Strato.Auth.ClientCredentials
+    - Strato.Auth.Retry
     - Strato.Auth.Token
 
 executables:

--- a/strato/libs/strato-auth/src/Strato/Auth/Client.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Client.hs
@@ -12,7 +12,7 @@ module Strato.Auth.Client
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, try)
 import Data.Text (Text)
-import Network.HTTP.Client (Manager, newManager)
+import Network.HTTP.Client (Manager, newManager, managerResponseTimeout, responseTimeoutMicro)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types.Status (Status(..))
 import Servant.Client
@@ -31,6 +31,8 @@ newAuthEnv :: String -> IO AuthEnv
 newAuthEnv url = do
   baseUrl <- parseBaseUrl url
   mgr <- newManager tlsManagerSettings
+    { managerResponseTimeout = responseTimeoutMicro 10000000 -- 10 seconds
+    }
   pure AuthEnv
     { aeBaseUrl = baseUrl
     , aeManager = mgr

--- a/strato/libs/strato-auth/src/Strato/Auth/Client.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Client.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Strato.Auth.Client
   ( AuthEnv
@@ -8,6 +9,8 @@ module Strato.Auth.Client
   , runWithUserToken
   ) where
 
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, try)
 import Data.Text (Text)
 import Network.HTTP.Client (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -16,6 +19,7 @@ import Servant.Client
 import Servant.Client.Core (Request, addHeader)
 import Strato.Auth.ClientCredentials
 import Strato.Auth.Token
+import System.IO (hPutStrLn, stderr)
 
 data AuthEnv = AuthEnv
   { aeBaseUrl :: BaseUrl
@@ -32,16 +36,41 @@ newAuthEnv url = do
     , aeManager = mgr
     }
 
--- | Run a Servant client action with OAuth authentication (retries once on 401)
+-- | Run a Servant client action with OAuth authentication.
+--
+-- Retries on 401 (with token refresh) and on connection errors
+-- (up to 4 attempts with exponential backoff: 1s, 2s, 4s).
 runWithAuth :: AuthEnv -> ClientM a -> IO (Either ClientError a)
-runWithAuth ae action = do
-  result <- runOnce ae
-  case result of
-    Left (FailureResponse _ resp) | responseStatusCode resp == status401 -> do
-      _ <- refreshToken (discoveryUrl clientCredentialsConfig)
-      runOnce ae
-    _ -> pure result
+runWithAuth ae action = withConnectionRetry (1 :: Int)
   where
+    maxAttempts = 4 :: Int
+
+    withConnectionRetry attempt = do
+      result <- try $ doRequestWith401Retry
+      case joinResult result of
+        Left (ConnectionError e)
+          | attempt < maxAttempts -> do
+              let delaySec = min 30 (2 ^ (attempt - 1) :: Int)
+              hPutStrLn stderr $
+                "Vault request: attempt " ++ show attempt ++ "/" ++ show maxAttempts ++
+                " failed (" ++ show e ++ "), retrying in " ++ show delaySec ++ "s"
+              threadDelay (delaySec * 1000000)
+              withConnectionRetry (attempt + 1)
+        r -> return r
+
+    -- Collapse exceptions from try into ConnectionError
+    joinResult :: Either SomeException (Either ClientError a) -> Either ClientError a
+    joinResult (Left e) = Left (ConnectionError e)
+    joinResult (Right r) = r
+
+    doRequestWith401Retry = do
+      result <- runOnce ae
+      case result of
+        Left (FailureResponse _ resp) | responseStatusCode resp == status401 -> do
+          _ <- refreshToken (discoveryUrl clientCredentialsConfig)
+          runOnce ae
+        _ -> pure result
+
     runOnce AuthEnv{..} = do
       token <- getToken (discoveryUrl clientCredentialsConfig)
       let addAuth :: Request -> Request

--- a/strato/libs/strato-auth/src/Strato/Auth/Retry.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Retry.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Strato.Auth.Retry (withRetry) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, throwIO, try)
+import System.IO (hPutStrLn, stderr)
+
+-- | Retry an IO action on exception with exponential backoff.
+--
+-- Waits 1s, 2s, 4s, 8s, ... (capped at 30s) between retries.
+-- Logs each failed attempt to stderr.
+-- After all attempts are exhausted, re-throws the last exception.
+withRetry
+  :: String  -- ^ Label for log messages
+  -> Int     -- ^ Maximum number of attempts (>= 1)
+  -> IO a
+  -> IO a
+withRetry label maxAttempts action = go 1
+  where
+    go attempt = do
+      result <- try action
+      case result of
+        Right val -> return val
+        Left (e :: SomeException)
+          | attempt >= maxAttempts -> throwIO e
+          | otherwise -> do
+              let delaySec = min 30 (2 ^ (attempt - 1) :: Int)
+              hPutStrLn stderr $
+                label ++ ": attempt " ++ show attempt ++ "/" ++ show maxAttempts ++
+                " failed (" ++ show e ++ "), retrying in " ++ show delaySec ++ "s"
+              threadDelay (delaySec * 1000000)
+              go (attempt + 1)

--- a/strato/libs/strato-auth/src/Strato/Auth/Token.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Token.hs
@@ -9,17 +9,18 @@ module Strato.Auth.Token
   ) where
 
 import Control.Exception (catch, SomeException)
-import Data.Aeson (FromJSON(..), withObject, (.:))
+import Data.Aeson (FromJSON(..), decode, encode, object, withObject, (.:), (.=))
 import Data.Base64.Types as B64
 import Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (fromJust)
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
 import Data.Text.Encoding as TE
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Req as R
 import Strato.Auth.ClientCredentials
 import Strato.Auth.Retry (withRetry)
-import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.Directory (createDirectoryIfMissing)
 import System.FileLock (withFileLock, SharedExclusive(Exclusive))
 import System.FilePath (takeDirectory)
 import Text.URI as URI
@@ -47,21 +48,32 @@ refreshToken discUrl = withFileLock lockFilePath Exclusive $ \_ ->
   withRetry "OAuth token fetch" 4 $ do
     let ClientCredentialsConfig{..} = clientCredentialsConfig
     tokenEndpoint <- getTokenEndpoint discUrl
-    token <- fetchToken tokenEndpoint clientId clientSecret
-    writeCachedToken token
-    pure token
+    TokenResponse{..} <- fetchToken tokenEndpoint clientId clientSecret
+    writeCachedToken trAccessToken trExpiresIn
+    pure trAccessToken
 
 readCachedToken :: IO (Maybe T.Text)
-readCachedToken = do
-  exists <- doesFileExist tokenFilePath
-  if not exists
-    then pure Nothing
-    else (Just <$> TIO.readFile tokenFilePath) `catch` (\(_ :: SomeException) -> pure Nothing)
+readCachedToken =
+  (do
+    content <- LBS.readFile tokenFilePath
+    case decode content of
+      Nothing -> pure Nothing  -- invalid JSON or old plain-text format
+      Just (CachedToken token expiresAt) -> do
+        now <- round <$> getPOSIXTime
+        if now >= expiresAt - 60
+          then pure Nothing  -- expired or within 60s of expiry
+          else pure (Just token)
+  ) `catch` (\(_ :: SomeException) -> pure Nothing)
 
-writeCachedToken :: T.Text -> IO ()
-writeCachedToken token = do
+writeCachedToken :: T.Text -> Integer -> IO ()
+writeCachedToken token expiresIn = do
+  now <- round <$> getPOSIXTime
+  let tokenData = object
+        [ "access_token" .= token
+        , "expires_at" .= (now + expiresIn)
+        ]
   createDirectoryIfMissing True (takeDirectory tokenFilePath)
-  TIO.writeFile tokenFilePath token
+  LBS.writeFile tokenFilePath (encode tokenData)
 
 -- | Fetch token endpoint from OpenID discovery document
 getTokenEndpoint :: T.Text -> IO T.Text
@@ -78,22 +90,30 @@ instance FromJSON DiscoveryDocument where
   parseJSON = withObject "DiscoveryDocument" $ \o ->
     DiscoveryDocument <$> o .: "token_endpoint"
 
-fetchToken :: T.Text -> T.Text -> T.Text -> IO T.Text
+fetchToken :: T.Text -> T.Text -> T.Text -> IO TokenResponse
 fetchToken tokenEndpoint clientId' clientSecret' = do
   uri <- URI.mkURI tokenEndpoint
   let (url, _) = fromJust (useHttpsURI uri)
-      authHeader = R.header "Authorization" $ TE.encodeUtf8 $ 
+      authHeader = R.header "Authorization" $ TE.encodeUtf8 $
         "Basic " <> B64.extractBase64 (B64.encodeBase64 $ TE.encodeUtf8 $ clientId' <> ":" <> clientSecret')
       contentType = R.header "Content-Type" "application/x-www-form-urlencoded"
       body = ReqBodyUrlEnc $ "grant_type" =: ("client_credentials" :: String)
-  
   response <- runReq defaultHttpConfig $
     R.req R.POST url body jsonResponse (authHeader <> contentType <> R.responseTimeout 10000000) -- 10 seconds
-  
-  pure $ trAccessToken (responseBody response)
+  pure $ responseBody response
 
-newtype TokenResponse = TokenResponse { trAccessToken :: T.Text }
+data TokenResponse = TokenResponse
+  { trAccessToken :: T.Text
+  , trExpiresIn :: Integer
+  }
 
 instance FromJSON TokenResponse where
   parseJSON = withObject "TokenResponse" $ \o ->
-    TokenResponse <$> o .: "access_token"
+    TokenResponse <$> o .: "access_token" <*> o .: "expires_in"
+
+-- | On-disk JSON format: {"access_token":"...","expires_at":...}
+data CachedToken = CachedToken T.Text Integer
+
+instance FromJSON CachedToken where
+  parseJSON = withObject "CachedToken" $ \o ->
+    CachedToken <$> o .: "access_token" <*> o .: "expires_at"

--- a/strato/libs/strato-auth/src/Strato/Auth/Token.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Token.hs
@@ -18,6 +18,7 @@ import qualified Data.Text.IO as TIO
 import Data.Text.Encoding as TE
 import Network.HTTP.Req as R
 import Strato.Auth.ClientCredentials
+import Strato.Auth.Retry (withRetry)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FileLock (withFileLock, SharedExclusive(Exclusive))
 import System.FilePath (takeDirectory)
@@ -38,13 +39,17 @@ getToken discUrl = do
     Nothing -> refreshToken discUrl
 
 -- | Force refresh the token (call this on 401)
+--
+-- Retries up to 4 times with exponential backoff on network failures
+-- (e.g. connection timeout, DNS failure, TLS errors).
 refreshToken :: T.Text -> IO T.Text
-refreshToken discUrl = withFileLock lockFilePath Exclusive $ \_ -> do
-  let ClientCredentialsConfig{..} = clientCredentialsConfig
-  tokenEndpoint <- getTokenEndpoint discUrl
-  token <- fetchToken tokenEndpoint clientId clientSecret
-  writeCachedToken token
-  pure token
+refreshToken discUrl = withFileLock lockFilePath Exclusive $ \_ ->
+  withRetry "OAuth token fetch" 4 $ do
+    let ClientCredentialsConfig{..} = clientCredentialsConfig
+    tokenEndpoint <- getTokenEndpoint discUrl
+    token <- fetchToken tokenEndpoint clientId clientSecret
+    writeCachedToken token
+    pure token
 
 readCachedToken :: IO (Maybe T.Text)
 readCachedToken = do

--- a/strato/libs/strato-auth/src/Strato/Auth/Token.hs
+++ b/strato/libs/strato-auth/src/Strato/Auth/Token.hs
@@ -68,7 +68,8 @@ getTokenEndpoint :: T.Text -> IO T.Text
 getTokenEndpoint discoveryUrl = do
   uri <- URI.mkURI discoveryUrl
   let (url, _) = fromJust (useHttpsURI uri)
-  response <- runReq defaultHttpConfig $ R.req R.GET url NoReqBody jsonResponse mempty
+  response <- runReq defaultHttpConfig $ R.req R.GET url NoReqBody jsonResponse
+    (R.responseTimeout 10000000) -- 10 seconds
   pure $ ddTokenEndpoint (responseBody response)
 
 newtype DiscoveryDocument = DiscoveryDocument { ddTokenEndpoint :: T.Text }
@@ -87,7 +88,7 @@ fetchToken tokenEndpoint clientId' clientSecret' = do
       body = ReqBodyUrlEnc $ "grant_type" =: ("client_credentials" :: String)
   
   response <- runReq defaultHttpConfig $
-    R.req R.POST url body jsonResponse (authHeader <> contentType)
+    R.req R.POST url body jsonResponse (authHeader <> contentType <> R.responseTimeout 10000000) -- 10 seconds
   
   pure $ trAccessToken (responseBody response)
 

--- a/strato/libs/strato-auth/strato-auth.cabal
+++ b/strato/libs/strato-auth/strato-auth.cabal
@@ -15,6 +15,7 @@ library
       Strato.Auth
       Strato.Auth.Client
       Strato.Auth.ClientCredentials
+      Strato.Auth.Retry
       Strato.Auth.Token
   other-modules:
       Paths_strato_auth


### PR DESCRIPTION
TL;DR - retry logic for calling Keycloak; better timeout handling; token expiration check added.

--- 

The issue: https://github.com/strato-net/strato-platform/issues/6472

The proposed solution was to mimic the behavioe that the old vault-proxy had.

Problem
A single network timeout/connection error when calling the OAuth server or Vault API would crash the strato container. The new strato-auth library had no retry logic, unlike the old vault-proxy which had lock-based retry and exception safety.

Changes Made
1. New file: strato/libs/strato-auth/src/Strato/Auth/Retry.hs

    Reusable withRetry function: catches SomeException, logs to stderr, retries with exponential backoff (1s, 2s, 4s, 8s... capped at 30s)
    After exhausting all attempts, re-throws the last exception

2. Modified: strato/libs/strato-auth/src/Strato/Auth/Token.hs

    refreshToken now wraps its body in withRetry "OAuth token fetch" 4 — retries the OAuth discovery + token fetch up to 4 times with backoff
    Covers: connection timeouts, DNS failures, TLS errors when calling Keycloak/OAuth server

3. Modified: strato/libs/strato-auth/src/Strato/Auth/Client.hs

    runWithAuth now has a withConnectionRetry loop that retries on ConnectionError (from Vault API calls) and also catches uncaught exceptions (from getToken) — up to 4 attempts with exponential backoff
    The existing 401 retry logic is preserved inside the retry loop
    Uses joinResult to collapse both thrown exceptions and Left (ConnectionError _) into a single retry path

4. Modified: strato/libs/strato-auth/package.yaml

    Added Strato.Auth.Retry to exposed modules

<img width="585" height="226" alt="image" src="https://github.com/user-attachments/assets/3f84259c-2a2d-45b0-a2b5-8543e6b6f877" />

This matches the resilience pattern from the old vault-proxy: transient failures (packet loss, brief timeouts) are retried with backoff, while persistent failures eventually propagate as errors.

---
Also the check of a token expiration added:
 Here's a summary of what changed in Token.hs:

TokenResponse now extracts both access_token and expires_in from the OAuth response (previously expires_in was discarded)
CachedToken — new type for the on-disk JSON format (access_token + expires_at as POSIX timestamp)
readCachedToken — parses JSON, checks now >= expiresAt - 60. Returns Nothing if expired or within 60 seconds of expiry, triggering a proactive refresh. Old plain-text files gracefully fail JSON decode → treated as cache miss
writeCachedToken — writes JSON with expires_at = now + expires_in instead of raw text
fetchToken — returns TokenResponse (both fields) instead of just T.Text
refreshToken — threads through TokenResponse fields; return type unchanged (IO T.Text)
No signature changes to getToken, refreshToken, or tokenFilePath — no breakage for consumers.