### PR TITLE
Add metalForge to MercataBridge.initialize()

### DIFF
--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -241,7 +241,8 @@ contract record MercataBridge is Ownable {
      */
     function initialize(
         address _tokenFactory,
-        address _lendingRegistry
+        address _lendingRegistry,
+        address _metalForge
     ) external onlyOwner {
         DECIMAL_PLACES = 18;
         USDST_ADDRESS = address(0x937efa7e3a77e20bbdbd7c0d32b6514f368c1010);
@@ -249,6 +250,7 @@ contract record MercataBridge is Ownable {
 
         setTokenFactory(_tokenFactory);
         setLendingRegistry(_lendingRegistry);
+        setMetalForge(_metalForge);
     }
 
     // ───────────── Admin related functions ─────────────


### PR DESCRIPTION
Prevents metalForge from being unset after fresh deploy or re-initialize.