### PR TITLE
Fix initialize arity after metalForge parameter addition

### DIFF
--- a/mercata/contracts/concrete/BaseCodeCollection.sol
+++ b/mercata/contracts/concrete/BaseCodeCollection.sol
@@ -156,8 +156,6 @@ contract record Mercata is Authorizable {
         // Create Services
         address mercataBridgeImpl = address(new MercataBridge(implOwnerIgnored));
         mercataBridge = MercataBridge(address(new Proxy(mercataBridgeImpl, this)));
-        mercataBridge.initialize(address(tokenFactory), address(lendingRegistry));
-        Ownable(mercataBridge).transferOwnership(address(adminRegistry));
 
         // Create RewardsChef (without initialization - to be initialized in tests)
         address rewardsChefImpl = address(new RewardsChef(implOwnerIgnored));
@@ -208,6 +206,9 @@ contract record Mercata is Authorizable {
             address(0x937efa7e3a77e20bbdbd7c0d32b6514f368c1010)
         );
         Ownable(metalForge).transferOwnership(address(0x000000000000000000000000000000000000100c));
+
+        mercataBridge.initialize(address(tokenFactory), address(lendingRegistry), address(metalForge));
+        Ownable(mercataBridge).transferOwnership(address(adminRegistry));
 
         adminRegistry.swapAdmin(this, msg.sender);
     }

--- a/mercata/contracts/tests/Bridge/MercataBridge.test.sol
+++ b/mercata/contracts/tests/Bridge/MercataBridge.test.sol
@@ -205,7 +205,7 @@ contract Describe_MercataBridge is Authorizable {
     function it_bridge_reverts_with_zero_addresses() {
         bool reverted = false;
         try {
-            new MercataBridge(owner).initialize(address(0), address(lendingRegistry));
+            new MercataBridge(owner).initialize(address(0), address(lendingRegistry), address(metalForge));
         } catch {
             reverted = true;
         }
@@ -213,11 +213,19 @@ contract Describe_MercataBridge is Authorizable {
 
         reverted = false;
         try {
-            new MercataBridge(owner).initialize(address(tokenFactory), address(0));
+            new MercataBridge(owner).initialize(address(tokenFactory), address(0), address(metalForge));
         } catch {
             reverted = true;
         }
         require(reverted, "Should revert with zero lending registry");
+
+        reverted = false;
+        try {
+            new MercataBridge(owner).initialize(address(tokenFactory), address(lendingRegistry), address(0));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should revert with zero metal forge");
     }
 
     // ============ CHAIN MANAGEMENT TESTS ============


### PR DESCRIPTION
- Update BaseCodeCollection.sol: defer mercataBridge.initialize() until after metalForge is created so address(metalForge) can be passed
- Update MercataBridge.test.sol: pass metalForge to initialize calls and add zero-address revert test for the new parameter

Made-with: Cursor