### PR TITLE
Rename "Login" to "Login/Sign Up" on dashboard and navbar

### DIFF
--- a/mercata/ui/src/components/Navbar.tsx
+++ b/mercata/ui/src/components/Navbar.tsx
@@ -70,7 +70,7 @@ const Navbar = () => {
                     : 'text-strato-blue dark:text-strato-lightblue border border-strato-blue/30 dark:border-strato-lightblue/50 hover:bg-strato-blue/5 dark:hover:bg-strato-lightblue/10'
               }`}
             >
-              {loading ? <Spinner /> : isLoggedIn ? 'Log Out' : 'Login'}
+              {loading ? <Spinner /> : isLoggedIn ? 'Log Out' : 'Login/Sign Up'}
             </button>
           </div>
           <div className="flex md:hidden">
@@ -118,7 +118,7 @@ const Navbar = () => {
                       : 'text-strato-blue dark:text-strato-lightblue border border-strato-blue dark:border-strato-lightblue hover:bg-strato-blue/5 dark:hover:bg-strato-lightblue/10'
                 }`}
               >
-                {loading ? <Spinner /> : isLoggedIn ? 'Log Out' : 'Login'}
+                {loading ? <Spinner /> : isLoggedIn ? 'Log Out' : 'Login/Sign Up'}
               </button>
             </div>
           </div>

--- a/mercata/ui/src/components/dashboard/DashboardHeader.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardHeader.tsx
@@ -205,7 +205,7 @@ const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
             className="h-8 md:h-9 px-3 md:px-4 bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90 gap-1.5"
           >
             <LogIn size={14} />
-            <span className="text-xs md:text-sm font-medium">Login</span>
+            <span className="text-xs md:text-sm font-medium">Login/Sign Up</span>
           </Button>
         )}
       </div>


### PR DESCRIPTION
Closes #6506
Updates the login button label in DashboardHeader and Navbar (desktop + mobile) to reflect that the button also supports new account sign-up.