### PR TITLE
Add saveUSDST vault spec, contract, and tests

### DIFF
--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -79,6 +79,10 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
         if (!vaultInitialized || paused()) return 0;
         uint256 assets = _convertToAssets(balanceOf(ownerAddress), false);
         uint256 available = _managedAssets;
+        uint256 liveBalance = IERC20(assetToken).balanceOf(address(this));
+        if (liveBalance < available) {
+            available = liveBalance;
+        }
         return assets < available ? assets : available;
     }
 
@@ -145,6 +149,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function notifyReward(uint256 amount) external onlyOwner {
         _requireInitialized();
         require(amount > 0, "SaveUSDST: zero reward");
+        require(totalSupply() > 0, "SaveUSDST: no shares");
 
         uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
         require(IERC20(assetToken).transferFrom(_msgSender(), address(this), amount), "SaveUSDST: reward transfer failed");

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -1,0 +1,266 @@
+import "../../abstract/ERC20/ERC20.sol";
+import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Ownable.sol";
+import "../../abstract/ERC20/extensions/IERC20Metadata.sol";
+import "../../abstract/ERC20/utils/Pausable.sol";
+
+/// @title SaveUSDSTVault
+/// @notice A standalone USDST savings vault with ERC-4626-style accounting.
+/// @dev The vault itself is the ERC-20 share token. Yield is added explicitly
+///      through reward notifications rather than lending-pool utilization.
+contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
+    address public assetToken;
+    bool public vaultInitialized;
+    uint8 private _underlyingDecimals;
+    uint256 private _managedAssets;
+
+    event VaultInitialized(address indexed assetToken, string name, string symbol);
+    event RewardNotified(address indexed sender, uint256 amount);
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
+
+    constructor(address initialOwner)
+        Ownable(initialOwner)
+        ERC20("", "")
+    {}
+
+    function initialize(address _assetToken, string name_, string symbol_) external onlyOwner {
+        require(!vaultInitialized, "SaveUSDST: already initialized");
+        require(_assetToken != address(0), "SaveUSDST: asset=0");
+        require(_assetToken != address(this), "SaveUSDST: invalid asset");
+
+        __ERC20_init(name_, symbol_);
+
+        assetToken = _assetToken;
+        _underlyingDecimals = _tryGetAssetDecimals(_assetToken);
+        vaultInitialized = true;
+
+        emit VaultInitialized(_assetToken, name_, symbol_);
+    }
+
+    function decimals() public view override returns (uint8) {
+        if (!vaultInitialized) return 18;
+        return _underlyingDecimals;
+    }
+
+    function asset() public view returns (address) {
+        _requireInitialized();
+        return assetToken;
+    }
+
+    function totalAssets() public view returns (uint256) {
+        _requireInitialized();
+        return _managedAssets;
+    }
+
+    function managedAssets() external view returns (uint256) {
+        return totalAssets();
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, false);
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, false);
+    }
+
+    function maxDeposit(address) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return 2 ** 256 - 1;
+    }
+
+    function maxMint(address) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return 2 ** 256 - 1;
+    }
+
+    function maxWithdraw(address ownerAddress) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        uint256 assets = _convertToAssets(balanceOf(ownerAddress), false);
+        uint256 available = _managedAssets;
+        return assets < available ? assets : available;
+    }
+
+    function maxRedeem(address ownerAddress) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return balanceOf(ownerAddress);
+    }
+
+    function previewDeposit(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, false);
+    }
+
+    function previewMint(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, true);
+    }
+
+    function previewWithdraw(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, true);
+    }
+
+    function previewRedeem(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, false);
+    }
+
+    function deposit(uint256 assets, address receiver) external whenNotPaused returns (uint256 shares) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        shares = previewDeposit(assets);
+        _deposit(_msgSender(), receiver, assets, shares);
+    }
+
+    function mint(uint256 shares, address receiver) external whenNotPaused returns (uint256 assets) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        assets = previewMint(shares);
+        _deposit(_msgSender(), receiver, assets, shares);
+    }
+
+    function withdraw(uint256 assets, address receiver, address ownerAddress) external whenNotPaused returns (uint256 shares) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        require(assets <= maxWithdraw(ownerAddress), "SaveUSDST: withdraw exceeds max");
+
+        shares = previewWithdraw(assets);
+        _withdraw(_msgSender(), receiver, ownerAddress, assets, shares);
+    }
+
+    function redeem(uint256 shares, address receiver, address ownerAddress) external whenNotPaused returns (uint256 assets) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        require(shares <= maxRedeem(ownerAddress), "SaveUSDST: redeem exceeds max");
+
+        assets = previewRedeem(shares);
+        _withdraw(_msgSender(), receiver, ownerAddress, assets, shares);
+    }
+
+    function exchangeRate() external view returns (uint256) {
+        _requireInitialized();
+        if (totalSupply() == 0) return 1e18;
+        return (totalAssets() * 1e18) / totalSupply();
+    }
+
+    /// @notice Pull USDST from the owner and credit it as savings rewards.
+    function notifyReward(uint256 amount) external onlyOwner {
+        _requireInitialized();
+        require(amount > 0, "SaveUSDST: zero reward");
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transferFrom(_msgSender(), address(this), amount), "SaveUSDST: reward transfer failed");
+        uint256 delta = IERC20(assetToken).balanceOf(address(this)) - beforeBalance;
+        require(delta > 0, "SaveUSDST: no reward delta");
+
+        _managedAssets += delta;
+        emit RewardNotified(_msgSender(), delta);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function recoverStrayAssets(address to) external onlyOwner {
+        _requireInitialized();
+        require(to != address(0), "SaveUSDST: bad recipient");
+
+        uint256 balance = IERC20(assetToken).balanceOf(address(this));
+        require(balance >= _managedAssets, "SaveUSDST: balance underflow");
+        uint256 stray = balance - _managedAssets;
+        require(stray > 0, "SaveUSDST: no stray");
+
+        require(IERC20(assetToken).transfer(to, stray), "SaveUSDST: stray transfer failed");
+    }
+
+    function rescueToken(address token, address to, uint256 amount) external onlyOwner {
+        require(token != assetToken, "SaveUSDST: no asset rescue");
+        require(to != address(0), "SaveUSDST: bad recipient");
+        require(IERC20(token).transfer(to, amount), "SaveUSDST: rescue transfer failed");
+    }
+
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal {
+        require(assets > 0, "SaveUSDST: zero assets");
+        require(shares > 0, "SaveUSDST: zero shares");
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transferFrom(caller, address(this), assets), "SaveUSDST: deposit transfer failed");
+        uint256 delta = IERC20(assetToken).balanceOf(address(this)) - beforeBalance;
+        require(delta > 0, "SaveUSDST: no deposit delta");
+
+        if (totalSupply() == 0) {
+            require(_managedAssets == 0, "SaveUSDST: bad init state");
+        }
+
+        // If the underlying ever becomes fee-on-transfer, mint against actual assets received.
+        if (delta != assets) {
+            shares = _convertToShares(delta, false);
+            require(shares > 0, "SaveUSDST: fee-on-transfer dust");
+        }
+
+        _managedAssets += delta;
+        _mint(receiver, shares);
+
+        emit Deposit(caller, receiver, delta, shares);
+    }
+
+    function _withdraw(address caller, address receiver, address ownerAddress, uint256 assets, uint256 shares) internal {
+        require(assets > 0, "SaveUSDST: zero assets");
+        require(shares > 0, "SaveUSDST: zero shares");
+
+        if (caller != ownerAddress) {
+            _spendAllowance(ownerAddress, caller, shares);
+        }
+
+        _burn(ownerAddress, shares);
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transfer(receiver, assets), "SaveUSDST: withdraw transfer failed");
+        uint256 delta = beforeBalance - IERC20(assetToken).balanceOf(address(this));
+        require(delta > 0, "SaveUSDST: no withdraw delta");
+
+        require(delta <= _managedAssets, "SaveUSDST: managed underflow");
+        _managedAssets -= delta;
+
+        emit Withdraw(caller, receiver, ownerAddress, delta, shares);
+    }
+
+    function _convertToShares(uint256 assets, bool roundUp) internal view returns (uint256) {
+        _requireInitialized();
+        uint256 supply = totalSupply();
+        if (assets == 0) return 0;
+        if (supply == 0 || _managedAssets == 0) return assets;
+        return _mulDiv(assets, supply, _managedAssets, roundUp);
+    }
+
+    function _convertToAssets(uint256 shares, bool roundUp) internal view returns (uint256) {
+        _requireInitialized();
+        uint256 supply = totalSupply();
+        if (shares == 0) return 0;
+        if (supply == 0 || _managedAssets == 0) return shares;
+        return _mulDiv(shares, _managedAssets, supply, roundUp);
+    }
+
+    function _mulDiv(uint256 x, uint256 y, uint256 denominator, bool roundUp) internal pure returns (uint256) {
+        require(denominator > 0, "SaveUSDST: div by zero");
+        uint256 z = (x * y) / denominator;
+        if (roundUp && ((x * y) % denominator) > 0) {
+            z += 1;
+        }
+        return z;
+    }
+
+    function _requireInitialized() internal view {
+        require(vaultInitialized, "SaveUSDST: not initialized");
+    }
+
+    function _tryGetAssetDecimals(address token) internal view returns (uint8) {
+        try IERC20Metadata(token).decimals() returns (uint8 tokenDecimals) {
+            return tokenDecimals;
+        } catch {
+            return 18;
+        }
+    }
+}

--- a/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
+++ b/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
@@ -41,6 +41,15 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(vault.previewMint(1e18) == 1e18, "initial mint should be 1:1");
     }
 
+    function it_cannot_be_initialized_twice() public {
+        bool reverted = false;
+        try vault.initialize(USDST, "Save USDST 2", "saveUSDST2") {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "second initialize should revert");
+    }
+
     function it_prevents_donation_attacks_from_changing_total_assets() public {
         User attacker = new User();
         User victim = new User();
@@ -83,6 +92,20 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(vault.previewDeposit(10e18) < 10e18, "post-reward deposits should mint fewer shares");
     }
 
+    function it_reverts_reward_notification_when_no_shares_exist() public {
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+
+        bool reverted = false;
+        try vault.notifyReward(20e18) {
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "notifyReward should revert when no shares exist");
+        require(vault.totalAssets() == 0, "managed assets should remain zero");
+    }
+
     function it_allows_withdrawal_of_principal_plus_rewards() public {
         User saver = new User();
 
@@ -101,6 +124,28 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(saverBalanceAfter == saverBalanceBefore + 60e18, "redeem should return principal plus rewards");
         require(vault.totalSupply() == 0, "all shares should be burned");
         require(vault.totalAssets() == 0, "managed assets should be empty");
+    }
+
+    function it_reverts_reward_notification_after_vault_has_been_fully_redeemed() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 50e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 50e18, address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 50e18, address(saver), address(saver));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+
+        bool reverted = false;
+        try vault.notifyReward(10e18) {
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "notifyReward should revert after full redeem");
+        require(vault.totalSupply() == 0, "supply should remain zero");
+        require(vault.totalAssets() == 0, "managed assets should remain zero");
     }
 
     function it_distributes_rewards_proportionally_to_multiple_users() public {
@@ -260,10 +305,35 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(saverGot == 100e18, "saver gets full principal after recovery");
     }
 
+    function it_caps_max_withdraw_by_live_balance_when_balance_drops_below_managed_assets() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        // Simulate unexpected live-balance loss while internal accounting stays unchanged.
+        Token(USDST).burn(address(vault), 40e18);
+
+        require(vault.totalAssets() == 100e18, "managed assets unchanged");
+        require(IERC20(USDST).balanceOf(address(vault)) == 60e18, "live balance reduced");
+        require(vault.maxWithdraw(address(saver)) == 60e18, "maxWithdraw should cap to live balance");
+    }
+
+    function it_blocks_underlying_rescue() public {
+        bool reverted = false;
+        try vault.rescueToken(USDST, address(this), 1) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "underlying rescue should revert");
+    }
+
     function it_blocks_operations_when_paused() public {
         User saver = new User();
         Token(USDST).mint(address(saver), 100e18);
         saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
 
         vault.pause();
 
@@ -279,10 +349,16 @@ contract Describe_SaveUSDSTVault is Authorizable {
         }
         require(reverted, "deposit should revert when paused");
 
-        vault.unpause();
+        reverted = false;
+        try saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "redeem should revert when paused");
 
-        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
-        require(IERC20(address(vault)).balanceOf(address(saver)) == 100e18, "deposit works after unpause");
+        vault.unpause();
+        saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver));
+        require(IERC20(address(vault)).balanceOf(address(saver)) == 0, "redeem works after unpause");
     }
 
     function it_supports_allowance_based_redeem() public {
@@ -392,5 +468,33 @@ contract Describe_SaveUSDSTVault is Authorizable {
         u2.do(address(vault), "deposit(uint256,address)", dep2, address(u2));
         uint rate3 = vault.exchangeRate();
         require(rate3 >= rate2 - 1, "rate must not decrease after deposit (within 1 wei rounding)");
+    }
+
+    /// @notice maxWithdraw should never exceed both live balance and the owner's economic claim.
+    function property_max_withdraw_is_bounded(uint seedDeposit, uint seedReward, uint seedBurn) public {
+        uint dep = ((seedDeposit % 500000) + 1) * 1e12;
+        uint rew = ((seedReward % 200000) + 1) * 1e12;
+
+        User u = new User();
+        Token(USDST).mint(address(u), dep);
+        u.do(USDST, "approve", address(vault), INFINITY);
+        u.do(address(vault), "deposit(uint256,address)", dep, address(u));
+
+        Token(USDST).mint(address(this), rew);
+        Token(USDST).approve(address(vault), rew);
+        vault.notifyReward(rew);
+
+        uint liveBalanceBeforeBurn = IERC20(USDST).balanceOf(address(vault));
+        uint burnAmt = seedBurn % (liveBalanceBeforeBurn + 1);
+        if (burnAmt > 0) {
+            Token(USDST).burn(address(vault), burnAmt);
+        }
+
+        uint maxW = vault.maxWithdraw(address(u));
+        uint liveBalance = IERC20(USDST).balanceOf(address(vault));
+        uint claim = vault.convertToAssets(IERC20(address(vault)).balanceOf(address(u)));
+
+        require(maxW <= liveBalance, "maxWithdraw exceeds live balance");
+        require(maxW <= claim, "maxWithdraw exceeds economic claim");
     }
 }

--- a/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
+++ b/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
@@ -1,0 +1,396 @@
+import "../../concrete/BaseCodeCollection.sol";
+import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
+import "../../concrete/Tokens/Token.sol";
+import "../../concrete/Savings/SaveUSDSTVault.sol";
+
+contract User {
+    function do(address a, string f, variadic args) public returns (variadic) {
+        variadic result = address(a).call(f, args);
+        return result;
+    }
+}
+
+contract Describe_SaveUSDSTVault is Authorizable {
+    uint public INFINITY = 2 ** 256 - 1;
+
+    Mercata m;
+    SaveUSDSTVault vault;
+    address USDST;
+
+    function beforeAll() public {
+        bypassAuthorizations = true;
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
+    }
+
+    function beforeEach() public {
+        vault = new SaveUSDSTVault(address(this));
+
+        USDST = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        Token(USDST).setStatus(2);
+
+        vault.initialize(USDST, "Save USDST", "saveUSDST");
+    }
+
+    function it_initializes_as_an_exchange_rate_vault() public {
+        require(vault.asset() == USDST, "asset not set");
+        require(vault.totalSupply() == 0, "unexpected initial supply");
+        require(vault.totalAssets() == 0, "unexpected initial assets");
+        require(vault.previewDeposit(1e18) == 1e18, "initial deposit should be 1:1");
+        require(vault.previewMint(1e18) == 1e18, "initial mint should be 1:1");
+    }
+
+    function it_prevents_donation_attacks_from_changing_total_assets() public {
+        User attacker = new User();
+        User victim = new User();
+
+        Token(USDST).mint(address(attacker), 10000e18 + 1);
+        attacker.do(USDST, "approve", address(vault), INFINITY);
+        attacker.do(address(vault), "deposit(uint256,address)", 1, address(attacker));
+
+        uint attackerShares = IERC20(address(vault)).balanceOf(address(attacker));
+        require(attackerShares == 1, "attacker share mismatch");
+
+        attacker.do(USDST, "transfer", address(vault), 10000e18);
+        require(vault.totalAssets() == 1, "donation should not change managed assets");
+        require(vault.totalSupply() == 1, "supply should remain unchanged");
+
+        Token(USDST).mint(address(victim), 1000e18);
+        victim.do(USDST, "approve", address(vault), INFINITY);
+        victim.do(address(vault), "deposit(uint256,address)", 1000e18, address(victim));
+
+        uint victimShares = IERC20(address(vault)).balanceOf(address(victim));
+        require(victimShares == 1000e18, "victim should receive fair shares");
+        require(vault.totalAssets() == 1000e18 + 1, "managed assets incorrect");
+    }
+
+    function it_increases_exchange_rate_when_rewards_are_notified() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        require(vault.convertToAssets(100e18) == 100e18, "initial assets mismatch");
+
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+        vault.notifyReward(20e18);
+
+        require(vault.totalAssets() == 120e18, "reward should raise assets");
+        require(vault.convertToAssets(100e18) == 120e18, "share value should increase");
+        require(vault.previewDeposit(10e18) < 10e18, "post-reward deposits should mint fewer shares");
+    }
+
+    function it_allows_withdrawal_of_principal_plus_rewards() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 50e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 50e18, address(saver));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+        vault.notifyReward(10e18);
+
+        uint saverBalanceBefore = IERC20(USDST).balanceOf(address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 50e18, address(saver), address(saver));
+        uint saverBalanceAfter = IERC20(USDST).balanceOf(address(saver));
+
+        require(saverBalanceAfter == saverBalanceBefore + 60e18, "redeem should return principal plus rewards");
+        require(vault.totalSupply() == 0, "all shares should be burned");
+        require(vault.totalAssets() == 0, "managed assets should be empty");
+    }
+
+    function it_distributes_rewards_proportionally_to_multiple_users() public {
+        User alice = new User();
+        User bob = new User();
+
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        Token(USDST).mint(address(bob), 100e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 100e18, address(bob));
+
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+        vault.notifyReward(20e18);
+
+        // 220 managed, 200 shares. Each user has 100 shares = 110 USDST.
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", 100e18, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+        require(aliceGot == 110e18, "alice should get 110");
+
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", 100e18, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+        require(bobGot == 110e18, "bob should get 110");
+
+        require(vault.totalSupply() == 0, "all shares burned");
+        require(vault.totalAssets() == 0, "vault fully drained");
+    }
+
+    function it_prices_deposits_correctly_after_reward() public {
+        User alice = new User();
+        User bob = new User();
+
+        // Alice deposits 100 at 1:1, gets 100 shares
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        // Reward of 100 doubles the rate to 2:1
+        Token(USDST).mint(address(this), 100e18);
+        Token(USDST).approve(address(vault), 100e18);
+        vault.notifyReward(100e18);
+
+        // Bob deposits 100 at 2:1, gets 50 shares
+        Token(USDST).mint(address(bob), 100e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 100e18, address(bob));
+
+        uint bobShares = IERC20(address(vault)).balanceOf(address(bob));
+        require(bobShares == 50e18, "bob should get 50 shares at 2:1 rate");
+
+        // Another reward of 30. Total managed = 330, total shares = 150.
+        Token(USDST).mint(address(this), 30e18);
+        Token(USDST).approve(address(vault), 30e18);
+        vault.notifyReward(30e18);
+
+        // Alice: 100/150 * 330 = 220. Bob: 50/150 * 330 = 110.
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", 100e18, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+        require(aliceGot == 220e18, "alice should get 220");
+
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", 50e18, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+        require(bobGot == 110e18, "bob should get 110");
+
+        require(vault.totalAssets() == 0, "vault empty");
+    }
+
+    function it_lets_last_user_drain_vault_cleanly() public {
+        User alice = new User();
+        User bob = new User();
+        User charlie = new User();
+
+        Token(USDST).mint(address(alice), 50e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 50e18, address(alice));
+
+        Token(USDST).mint(address(bob), 30e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 30e18, address(bob));
+
+        Token(USDST).mint(address(charlie), 20e18);
+        charlie.do(USDST, "approve", address(vault), INFINITY);
+        charlie.do(address(vault), "deposit(uint256,address)", 20e18, address(charlie));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+        vault.notifyReward(10e18);
+
+        // Alice and bob withdraw. Charlie is last.
+        alice.do(address(vault), "redeem(uint256,address,address)", 50e18, address(alice), address(alice));
+        bob.do(address(vault), "redeem(uint256,address,address)", 30e18, address(bob), address(bob));
+
+        uint charlieShares = IERC20(address(vault)).balanceOf(address(charlie));
+        uint charlieBefore = IERC20(USDST).balanceOf(address(charlie));
+        charlie.do(address(vault), "redeem(uint256,address,address)", charlieShares, address(charlie), address(charlie));
+        uint charlieGot = IERC20(USDST).balanceOf(address(charlie)) - charlieBefore;
+
+        require(charlieGot > 0, "charlie should get something");
+        require(vault.totalSupply() == 0, "all shares burned");
+        require(vault.totalAssets() == 0, "vault fully drained");
+    }
+
+    function it_reverts_deposit_of_1_wei_when_rate_is_above_1() public {
+        User alice = new User();
+
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        Token(USDST).mint(address(this), 100e18);
+        Token(USDST).approve(address(vault), 100e18);
+        vault.notifyReward(100e18);
+
+        // Rate is now 2:1. Depositing 1 wei should yield 0 shares and revert.
+        User dust = new User();
+        Token(USDST).mint(address(dust), 1);
+        dust.do(USDST, "approve", address(vault), INFINITY);
+
+        bool reverted = false;
+        try dust.do(address(vault), "deposit(uint256,address)", 1, address(dust)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "1 wei deposit should revert at 2:1 rate");
+    }
+
+    function it_recovers_stray_assets_without_affecting_accounting() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        // Donate 500 USDST directly
+        Token(USDST).mint(address(this), 500e18);
+        Token(USDST).transfer(address(vault), 500e18);
+
+        require(vault.totalAssets() == 100e18, "managed assets unchanged by donation");
+
+        uint recoveryBefore = IERC20(USDST).balanceOf(address(this));
+        vault.recoverStrayAssets(address(this));
+        uint recovered = IERC20(USDST).balanceOf(address(this)) - recoveryBefore;
+        require(recovered == 500e18, "should recover exactly 500");
+        require(vault.totalAssets() == 100e18, "managed assets still unchanged");
+
+        // Saver can still redeem normally
+        uint saverBefore = IERC20(USDST).balanceOf(address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver));
+        uint saverGot = IERC20(USDST).balanceOf(address(saver)) - saverBefore;
+        require(saverGot == 100e18, "saver gets full principal after recovery");
+    }
+
+    function it_blocks_operations_when_paused() public {
+        User saver = new User();
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+
+        vault.pause();
+
+        require(vault.maxDeposit(address(saver)) == 0, "maxDeposit should be 0 when paused");
+        require(vault.maxMint(address(saver)) == 0, "maxMint should be 0 when paused");
+        require(vault.maxWithdraw(address(saver)) == 0, "maxWithdraw should be 0 when paused");
+        require(vault.maxRedeem(address(saver)) == 0, "maxRedeem should be 0 when paused");
+
+        bool reverted = false;
+        try saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "deposit should revert when paused");
+
+        vault.unpause();
+
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+        require(IERC20(address(vault)).balanceOf(address(saver)) == 100e18, "deposit works after unpause");
+    }
+
+    function it_supports_allowance_based_redeem() public {
+        User owner = new User();
+        User spender = new User();
+
+        Token(USDST).mint(address(owner), 100e18);
+        owner.do(USDST, "approve", address(vault), INFINITY);
+        owner.do(address(vault), "deposit(uint256,address)", 100e18, address(owner));
+
+        // Owner approves spender to spend vault shares
+        owner.do(address(vault), "approve", address(spender), 100e18);
+
+        // Spender redeems on behalf of owner, receives the USDST
+        uint spenderBefore = IERC20(USDST).balanceOf(address(spender));
+        spender.do(address(vault), "redeem(uint256,address,address)", 100e18, address(spender), address(owner));
+        uint spenderGot = IERC20(USDST).balanceOf(address(spender)) - spenderBefore;
+
+        require(spenderGot == 100e18, "spender should receive the USDST");
+        require(IERC20(address(vault)).balanceOf(address(owner)) == 0, "owner shares burned");
+        require(vault.totalSupply() == 0, "all shares burned");
+    }
+
+    /// @notice For any deposit amount, deposit then full redeem returns the original amount (within 1 wei rounding).
+    function property_deposit_redeem_round_trip_conserves_value(uint seed) public {
+        uint amount = (seed % 1000000) + 1;
+        amount = amount * 1e12;
+
+        User u = new User();
+        Token(USDST).mint(address(u), amount);
+        u.do(USDST, "approve", address(vault), INFINITY);
+        u.do(address(vault), "deposit(uint256,address)", amount, address(u));
+
+        uint shares = IERC20(address(vault)).balanceOf(address(u));
+        require(shares > 0, "should have shares");
+
+        uint balBefore = IERC20(USDST).balanceOf(address(u));
+        u.do(address(vault), "redeem(uint256,address,address)", shares, address(u), address(u));
+        uint got = IERC20(USDST).balanceOf(address(u)) - balBefore;
+
+        require(got >= amount - 1 && got <= amount, "round trip should conserve value within 1 wei");
+        require(vault.totalSupply() == 0, "no shares left");
+        require(vault.totalAssets() == 0, "no assets left");
+    }
+
+    /// @notice Two users deposit random amounts, a random reward arrives. Total redeemed == total deposited + reward (within rounding).
+    function property_rewards_conserve_total_value(uint seedA, uint seedB, uint seedR) public {
+        uint amountA = ((seedA % 500000) + 1) * 1e12;
+        uint amountB = ((seedB % 500000) + 1) * 1e12;
+        uint reward  = ((seedR % 100000) + 1) * 1e12;
+
+        User alice = new User();
+        User bob = new User();
+
+        Token(USDST).mint(address(alice), amountA);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", amountA, address(alice));
+
+        Token(USDST).mint(address(bob), amountB);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", amountB, address(bob));
+
+        Token(USDST).mint(address(this), reward);
+        Token(USDST).approve(address(vault), reward);
+        vault.notifyReward(reward);
+
+        uint aliceShares = IERC20(address(vault)).balanceOf(address(alice));
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", aliceShares, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+
+        uint bobShares = IERC20(address(vault)).balanceOf(address(bob));
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", bobShares, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+
+        uint totalIn = amountA + amountB + reward;
+        uint totalOut = aliceGot + bobGot;
+
+        require(totalOut >= totalIn - 2 && totalOut <= totalIn, "total value must be conserved within 2 wei rounding");
+        require(vault.totalSupply() == 0, "no shares left");
+        require(vault.totalAssets() <= 2, "vault should be empty within rounding");
+    }
+
+    /// @notice Exchange rate must never decrease after a deposit or reward.
+    function property_exchange_rate_never_decreases(uint seedDeposit, uint seedReward, uint seedDeposit2) public {
+        uint dep1 = ((seedDeposit % 500000) + 1) * 1e12;
+        uint rew  = ((seedReward % 200000) + 1) * 1e12;
+        uint dep2 = ((seedDeposit2 % 500000) + 1) * 1e12;
+
+        User u1 = new User();
+        User u2 = new User();
+
+        Token(USDST).mint(address(u1), dep1);
+        u1.do(USDST, "approve", address(vault), INFINITY);
+        u1.do(address(vault), "deposit(uint256,address)", dep1, address(u1));
+        uint rate1 = vault.exchangeRate();
+
+        Token(USDST).mint(address(this), rew);
+        Token(USDST).approve(address(vault), rew);
+        vault.notifyReward(rew);
+        uint rate2 = vault.exchangeRate();
+        require(rate2 >= rate1, "rate must not decrease after reward");
+
+        Token(USDST).mint(address(u2), dep2);
+        u2.do(USDST, "approve", address(vault), INFINITY);
+        u2.do(address(vault), "deposit(uint256,address)", dep2, address(u2));
+        uint rate3 = vault.exchangeRate();
+        require(rate3 >= rate2 - 1, "rate must not decrease after deposit (within 1 wei rounding)");
+    }
+}

--- a/techdocs/design-docs/save-usdst.md
+++ b/techdocs/design-docs/save-usdst.md
@@ -1,0 +1,459 @@
+# saveUSDST Technical Spec
+
+Draft: 2026-03-18
+
+## Business Context
+
+The protocol needs `USDST` to do three things well:
+
+1. circulate
+2. trade at size
+3. be worth holding
+
+The first comes from CDP minting. The second comes from stable liquidity. `saveUSDST` is the third leg: the native hold asset for `USDST`.
+
+This matches the current internal framing:
+
+- mint `USDST` against collateral
+- LP in the metastable stable surface
+- hold `saveUSDST`
+
+The point of `saveUSDST` is not to replace lending or external yieldcoins. It is to give Mercata a simple native savings product for `USDST` and a clean path from bootstrap incentives to fee-funded savings yield.
+
+## Current Protocol Context
+
+This spec assumes the current Mercata / STRATO product stack has four relevant pieces:
+
+1. `USDST`
+   - the protocol stablecoin
+   - the unit users mint, borrow, swap, spend, and save
+
+2. `CDP`
+   - the lower-cost path for minting new `USDST` against collateral
+   - intended to be the primary supply engine for `USDST`
+
+3. Lending pool
+   - a separate money market for supplying and borrowing `USDST`
+   - yield for suppliers depends on borrow demand and utilization
+
+4. Stable liquidity surface
+   - pools that let users move between `USDST` and external stable or yield-bearing assets such as `syrupUSDC`, `sUSDS`, and `sUSDe`
+
+The current strategic picture is:
+
+- CDP grows `USDST` supply
+- stable liquidity makes `USDST` usable
+- `saveUSDST` creates hold demand
+
+## Definitions
+
+### USDST
+
+The protocol stablecoin. It is the base asset for this spec.
+
+### saveUSDST
+
+The proposed native savings token for `USDST`. Users deposit `USDST` and receive a non-rebasing claim whose value rises over time.
+
+### CDP
+
+Collateralized debt position system. Users lock collateral and mint new `USDST` against it. In current protocol economics, this is the cheaper borrowing path and the main source of new `USDST` circulation.
+
+### Lending pool
+
+Separate from the CDP. Users supply `USDST` or supported collateral to a money market. Supplier yield comes from borrower demand, not from a protocol savings rate.
+
+### safetyUSDST
+
+The safety-module token. It exists for protocol backstop and bad-debt handling. It is not the savings product described here.
+
+### Metastable pool
+
+The main stable liquidity surface for `USDST` against other stable or yield-bearing stable assets. Its job is to keep `USDST` easy to move into and out of at size.
+
+### PSM
+
+Peg stability mechanism. A backstop convertibility path, typically against `USDC` or `USDT`, used to anchor the peg and support arbitrage during larger deviations. It is not intended to be the normal day-to-day user route.
+
+### External yield assets
+
+Stable or dollar-like assets outside the native `saveUSDST` product that already earn yield, such as `syrupUSDC`, `sUSDS`, and `sUSDe`.
+
+## Scope Assumptions
+
+This document assumes:
+
+- `saveUSDST` is a new product, not a rename of an existing token
+- the lending pool remains in place
+- `safetyUSDST` remains in place
+- launch support comes from explicit rewards first
+- fee-share support comes later
+- collateral use is out of scope for launch
+
+## Product Definition
+
+`saveUSDST` is a non-rebasing, exchange-rate token backed by deposited `USDST`.
+
+User flow:
+
+1. deposit `USDST`
+2. receive `saveUSDST`
+3. hold while the exchange rate rises
+4. redeem back to `USDST`
+
+`saveUSDST` is:
+
+- the savings product for `USDST`
+- separate from the lending pool
+- separate from `safetyUSDST`
+- intended to look and behave like an `sDAI` / `sUSDS` style asset
+
+`saveUSDST` is not:
+
+- a lending-pool receipt token
+- a bad-debt recovery token
+- a CDP position
+- a rebasing balance token
+
+## Goals
+
+- Create a simple reason to hold `USDST`
+- Increase sticky `USDST` balances in the system
+- Give the protocol a native savings-rate outlet
+- Make the asset easy to explain and integrate
+- Start with explicit support, then transition to fee share
+
+## Non-Goals
+
+- Do not use `saveUSDST` for protocol safety
+- Do not tie core yield to lending-pool utilization
+- Do not allow collateral use at launch
+- Do not rely on permanent token emissions
+
+## System Model
+
+### Underlying and share asset
+
+- underlying: `USDST`
+- share token: `saveUSDST`
+
+### Accounting model
+
+The vault tracks:
+
+- total managed `USDST`
+- total `saveUSDST` shares
+- user share balances
+
+Economic identity:
+
+- `exchangeRate = totalManagedUSDST / totalSaveUSDSTShares`
+
+User value:
+
+- `userUnderlyingValue = userShares * exchangeRate`
+
+When rewards are added:
+
+- managed `USDST` increases
+- share supply stays unchanged
+- exchange rate rises
+
+This is the right model for the product because it is simple, non-rebasing, and familiar to users who know `sDAI` or `sUSDS`.
+
+### Accounting requirement
+
+The implementation should account against managed assets, not blindly against raw token balance. Reward injections must be explicit. Unexpected direct transfers should not silently distort the exchange rate.
+
+## Functional Requirements
+
+### User actions
+
+- deposit `USDST`
+- mint shares
+- withdraw `USDST`
+- redeem shares
+- view exchange rate
+- view current redeemable value
+
+### Protocol / governance actions
+
+- configure or approve any fee-share routing into the product
+- pause / unpause if needed
+- recover stray assets without affecting core accounting
+
+### Interface shape
+
+The interface should be ERC-4626-shaped:
+
+- `deposit`
+- `mint`
+- `withdraw`
+- `redeem`
+- `totalAssets`
+- `convertToShares`
+- `convertToAssets`
+- preview functions
+
+The important point is standard savings-vault semantics, even if the implementation uses repo-specific accounting patterns internally.
+
+## Product Positioning Relative To Existing Components
+
+### Lending pool
+
+The lending pool remains the money-market layer for `USDST`. It is not being replaced.
+
+The reason not to make it the primary savings product is that supplier yield depends on borrow demand in a venue where users already have cheaper ways to borrow through the CDP path. If utilization has to be subsidized to make the savings story work, it is cleaner to support `saveUSDST` directly.
+
+### safetyUSDST
+
+`safetyUSDST` is the safety layer. It exists for bad-debt recovery and protocol backstop functions.
+
+`saveUSDST` is the savings layer. It should not inherit cooldown, slashing, or backstop semantics.
+
+### External yield assets
+
+`saveUSDST` does not need to outyield every external asset in every regime. It does need to be the best native destination for `USDST`.
+
+## Funding Model
+
+### Phase 1: bootstrap incentives
+
+At launch, `saveUSDST` should not use a hard `USDST` cash subsidy as the main incentive.
+
+Reason:
+
+- cheap internal borrow paths make a hard-cash savings subsidy mechanically loopable
+- if users can mint or borrow `USDST` below the headline `saveUSDST` rate, the protocol is just paying for a carry trade
+- that is especially unattractive before fee-funded yield is real
+
+The launch posture should therefore be:
+
+- no hard-cash `USDST` base subsidy
+- use the floating token for temporary promotional incentives if needed
+- reserve direct exchange-rate growth for real fee-funded cash flows or very deliberate governance decisions
+
+This keeps early incentives softer, reduces obvious carry extraction, and preserves the long-run meaning of `saveUSDST` as a savings product rather than a farm.
+
+At launch, the exchange rate starts at 1:1 and remains flat. Exchange-rate growth begins when fee-share routing is activated.
+
+### Phase 2: fee-share transition
+
+As protocol revenues grow, part of protocol revenue should be routed to `saveUSDST`.
+
+Candidate sources:
+
+- stability fees
+- lending fees
+- swap fees
+- other protocol revenues, subject to governance choice
+
+### Phase 3: steady state
+
+Long-term target:
+
+- fee-funded base savings rate
+- market-level stability fees over time
+- temporary token incentives only when strategically justified
+
+The product should move from "promotion-supported" to "fee-supported", not remain a perpetual emissions sink.
+
+## Economics
+
+### Strategic target
+
+The current internal materials imply a working `saveUSDST` hold-demand target around `$20M`.
+
+That is a useful planning target because it is large enough to matter for `USDST` retention, but still small enough to bootstrap deliberately.
+
+### Implied fee-funded base rate
+
+The useful thing about `saveUSDST` is that the long-run exchange-rate growth is modelable before fee share is turned on.
+
+Very roughly:
+
+- `saveUSDST base rate ~= (USDST debt outstanding * stability fee * allocation to saveUSDST) / saveUSDST TVL`
+
+This should be the anchor for the product.
+
+It allows the team to estimate:
+
+- the fee-funded rate the product can support later
+- the gap between that rate and the headline launch rate
+- how much temporary promotion is actually needed
+
+If the protocol becomes widely used and stability fees rise toward market, the fee-funded base rate should rise with it.
+
+### Launch yield range
+
+The current internal materials point to a visible launch rate in the mid-single digits. That is still the right qualitative range for the headline number.
+
+Recommended working range:
+
+- `5-8%` headline launch APY, assuming the floating token launches and incentives are active
+
+This should be understood as a combined number, not a pure fee-funded rate.
+
+Why:
+
+- below that, the product may not feel different enough from idle `USDST`
+- far above that, it starts to look like a short-lived subsidy rather than a real savings product
+
+## Yield Presentation
+
+Users should see one headline yield number.
+
+That is how vault products are understood in practice.
+
+Recommended presentation:
+
+- headline APY: one combined current rate
+- below the fold: breakdown by source
+
+The breakdown should separate:
+
+- modeled or actual fee-funded base rate
+- temporary floating-token incentive rate
+- any other temporary promotional components
+
+The product should not expect users to parse the decomposition before deciding whether the vault is attractive.
+
+At the same time, the protocol must track the decomposition internally so it is always clear which part of the yield is durable and which part is promotional.
+
+## Launch Policy
+
+### Scope
+
+Launch `saveUSDST` as:
+
+- deposit
+- hold
+- redeem
+
+Only.
+
+### Collateral policy
+
+Do not allow `saveUSDST` as collateral anywhere at launch.
+
+That means:
+
+- no CDP collateral
+- no lending-pool collateral
+
+### Rationale
+
+CDP collateral is too reflexive:
+
+- mint `USDST`
+- wrap into `saveUSDST`
+- use a claim on `USDST` to mint more `USDST`
+
+Lending collateral is more defensible because there is a financing cost and actual pool liquidity constraints. Even so, launch exclusion is still preferable because bootstrap rewards would distort the loop and complicate the rollout.
+
+Future lending-collateral eligibility can be revisited once:
+
+- fee share is the dominant yield source
+- bootstrap support is no longer the main APY driver
+- haircut, cap, and monitoring policy are defined
+
+CDP collateral should remain out of scope.
+
+## Integrations
+
+The system needs to support:
+
+- wallet / portfolio visibility for `saveUSDST`
+- exchange-rate and redeemable-value display
+- API endpoints for public and user-specific vault state
+- standard preview functions for integrators
+- clear labeling distinct from lending and safety
+
+User-facing copy should consistently frame:
+
+- `USDST` as the routing and transaction asset
+- `saveUSDST` as the native savings asset
+
+## KPIs
+
+Primary KPIs:
+
+- `saveUSDST` TVL
+- share of circulating `USDST` held in `saveUSDST`
+- average holding duration
+- retention after incentives taper
+- share of newly minted / borrowed `USDST` that ends up saved
+- fee-share coverage ratio over time
+
+## Risks
+
+- If launch support is too low, users route directly into external yield assets
+- If launch support is too high, TVL can become mercenary
+- If taper is too sharp, retention will be poor
+- If product boundaries are blurry, users will confuse savings, lending, and safety
+- If collateral is enabled too early, recursive loops complicate risk before the savings product is proven
+
+## Recommendation
+
+Launch `saveUSDST` as the native savings-rate product for `USDST`.
+
+Keep the story simple:
+
+- mint `USDST`
+- use `USDST`
+- save `USDST`
+
+Keep the first version simple too:
+
+- exchange-rate token
+- no hard-cash `USDST` launch subsidy
+- optional floating-token promotional incentives
+- later fee share
+- no collateral at launch
+
+That is the cleanest way to create durable hold demand for `USDST` without mixing savings, leverage, and safety into one product.
+
+## Implementation Notes
+
+### Existing contract
+
+`SaveUSDSTVault.sol` in `mercata/contracts/concrete/Savings/` already implements the core vault. It is the share token itself (ERC-20), with ERC-4626-shaped deposit / mint / withdraw / redeem and managed-asset accounting.
+
+### Contract interactions at launch
+
+The vault's only runtime dependency is the `USDST` ERC-20 token. It does not interact with the CDP, lending pool, safety module, or any rewards system.
+
+This is the key architectural difference from `SafetyModule` (safetyUSDST), which imports and calls `LendingPool`, `LiquidityPool`, and `LendingRegistry`. `SaveUSDSTVault` is standalone.
+
+At launch:
+
+- `deposit` / `mint`: pull `USDST` from user via `transferFrom`, mint shares
+- `withdraw` / `redeem`: burn shares, transfer `USDST` to user
+- `exchangeRate`: read-only, returns `totalAssets * 1e18 / totalSupply`
+
+No other contract calls. No external state reads. The vault holds `USDST` and tracks `_managedAssets` internally.
+
+### What `notifyReward` is and when it matters
+
+The current contract has a `notifyReward` method that pulls `USDST` from the owner and adds it to `_managedAssets`, raising the exchange rate for all holders.
+
+At launch, this is unused. The exchange rate is flat at 1:1. Promotional incentives use the floating token through a separate system that does not touch the vault.
+
+When fee-share routing activates (Phase 2), the vault will need a mechanism to receive protocol revenue and credit it as managed assets. Whether that mechanism is the existing `notifyReward` (pull from owner), a push-style `recordTransfer` (like SafetyModule uses for LendingPool), or a continuous drip is a Phase 2 design decision. The launch contract does not need to commit to one.
+
+### Deployment sequence
+
+1. Deploy `SaveUSDSTVault` behind proxy (via `BaseCodeCollection`)
+2. Call `initialize(USDST, "Save USDST", "saveUSDST")`
+3. Set pause authority
+4. Register in UI and API as a first-class product
+
+### UI and API
+
+The system needs:
+
+- public vault state (total assets, total supply, exchange rate)
+- user share balance and redeemable value
+- deposit and redeem actions
+
+Present `saveUSDST` as its own product, not as a tab inside lending or safety.


### PR DESCRIPTION
## Summary

- saveUSDST technical spec (`techdocs/design-docs/save-usdst.md`)
- SaveUSDSTVault contract with `type(uint256).max` compatibility fix
- 14 tests: 11 unit tests covering deposit/redeem, donation attack, multi-user proportional distribution, pause, allowance, stray asset recovery + 3 property tests (round-trip conservation, total value conservation, exchange rate monotonicity)

All 14 tests pass locally via `solid-vm-cli`.

## Test plan

- [x] `solid-vm-cli test tests/Savings/SaveUSDSTVault.test.sol` — 14/14 pass
- [ ] Review spec for product accuracy
- [ ] Review contract for any remaining concerns


Made with [Cursor](https://cursor.com)