### PR TITLE
Add category groupings to sidebar navigation

### DIFF
--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -31,22 +31,46 @@ interface NavItem {
   adminOnly?: boolean;
 }
 
-const PRIMARY_NAV_ITEMS: NavItem[] = [
-  { icon: LayoutDashboard, label: 'Portfolio', path: '/dashboard' },
-  { icon: ArrowDownToLine, label: 'Fund', path: '/dashboard/deposits' },
-  { icon: Send, label: 'Transfer', path: '/dashboard/transfer' },
-  { icon: Landmark, label: 'Borrow', path: '/dashboard/borrow' },
-  { icon: ArrowLeftRight, label: 'Swap', path: '/dashboard/swap' },
-  { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
-  { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-  { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
-  { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
-  { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
-  { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
-  { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
-  { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
-  { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
-  { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
+interface NavCategory {
+  label?: string;
+  items: NavItem[];
+}
+
+const NAV_CATEGORIES: NavCategory[] = [
+  {
+    items: [
+      { icon: LayoutDashboard, label: 'Portfolio', path: '/dashboard' },
+    ],
+  },
+  {
+    label: 'TRADE',
+    items: [
+      { icon: ArrowDownToLine, label: 'Fund', path: '/dashboard/deposits' },
+      { icon: ArrowLeftRight, label: 'Swap', path: '/dashboard/swap' },
+      { icon: Landmark, label: 'Borrow', path: '/dashboard/borrow' },
+      { icon: Send, label: 'Transfer', path: '/dashboard/transfer' },
+      { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
+    ],
+  },
+  {
+    label: 'EARN',
+    items: [
+      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+    ],
+  },
+  {
+    label: 'PRO',
+    items: [
+      { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
+      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
+      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+      { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
+      { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
+      { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
+      { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
+    ],
+  },
 ];
 
 const DashboardSidebar = () => {
@@ -99,12 +123,22 @@ const DashboardSidebar = () => {
       </div>
 
       <nav className="flex-1 py-4 px-3 overflow-y-auto">
-        {/* Navigation */}
-        <ul className="space-y-1">
-          {PRIMARY_NAV_ITEMS
-            .filter(item => !item.adminOnly || isAdmin)
-            .map(renderNavItem)}
-        </ul>
+        {NAV_CATEGORIES.map((category, idx) => {
+          const visibleItems = category.items.filter(item => !item.adminOnly || isAdmin);
+          if (visibleItems.length === 0) return null;
+          return (
+            <div key={idx} className={idx > 0 ? 'mt-4' : ''}>
+              {category.label && (
+                <div className="px-4 py-1.5 text-[11px] font-semibold tracking-wider text-gray-400 dark:text-gray-500 uppercase">
+                  {category.label}
+                </div>
+              )}
+              <ul className="space-y-1">
+                {visibleItems.map(renderNavItem)}
+              </ul>
+            </div>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -23,8 +23,20 @@ import {
 } from 'lucide-react';
 import { Drawer, DrawerClose, DrawerContent } from '@/components/ui/drawer';
 import { useUser } from '@/context/UserContext';
+import { LucideIcon } from 'lucide-react';
 
-// Primary navigation items shown in bottom bar
+interface MoreNavItem {
+  icon: LucideIcon;
+  label: string;
+  path: string;
+  adminOnly?: boolean;
+}
+
+interface MoreNavCategory {
+  label?: string;
+  items: MoreNavItem[];
+}
+
 const PRIMARY_NAV_ITEMS = [
   { icon: LayoutDashboard, label: 'Portfolio', path: '/dashboard' },
   { icon: ArrowDownToLine, label: 'Fund', path: '/dashboard/deposits' },
@@ -32,20 +44,33 @@ const PRIMARY_NAV_ITEMS = [
   { icon: ArrowLeftRight, label: 'Swap', path: '/dashboard/swap' },
 ];
 
-// Items shown in "More" drawer
-const MORE_ITEMS = [
-
-  { icon: Send, label: 'Transfer', path: '/dashboard/transfer' },
-  { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
-  { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-  { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
-  { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
-  { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
-  { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
-  { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
-  { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
-  { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
-  { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
+const MORE_CATEGORIES: MoreNavCategory[] = [
+  {
+    label: 'TRADE',
+    items: [
+      { icon: Send, label: 'Transfer', path: '/dashboard/transfer' },
+      { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
+    ],
+  },
+  {
+    label: 'EARN',
+    items: [
+      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+    ],
+  },
+  {
+    label: 'PRO',
+    items: [
+      { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
+      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
+      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+      { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
+      { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
+      { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
+      { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
+    ],
+  },
 ];
 
 const MobileBottomNav = () => {
@@ -57,14 +82,12 @@ const MobileBottomNav = () => {
   const isActive = (path: string) =>
     path === '/dashboard' ? pathname === '/dashboard' : pathname.startsWith(path);
 
-  const isMoreActive = MORE_ITEMS.some(item => isActive(item.path));
+  const isMoreActive = MORE_CATEGORIES.some(cat => cat.items.some(item => isActive(item.path)));
 
   const handleMoreItemClick = (path: string) => {
     setIsMoreOpen(false);
     navigate(path);
   };
-
-  const filteredMoreItems = MORE_ITEMS.filter(item => !item.adminOnly || isAdmin);
 
   return (
     <>
@@ -113,19 +136,32 @@ const MobileBottomNav = () => {
 
           {/* Menu Items */}
           <div className="px-3 pb-4">
-            {filteredMoreItems.map(({ icon: Icon, label, path }) => (
-              <button
-                key={path}
-                onClick={() => handleMoreItemClick(path)}
-                className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg transition-colors ${isActive(path)
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
-                    : 'text-foreground hover:bg-muted'
-                  }`}
-              >
-                <Icon size={20} />
-                <span className="text-sm font-medium">{label}</span>
-              </button>
-            ))}
+            {MORE_CATEGORIES.map((category, idx) => {
+              const visibleItems = category.items.filter(item => !item.adminOnly || isAdmin);
+              if (visibleItems.length === 0) return null;
+              return (
+                <div key={idx} className={idx > 0 ? 'mt-3' : ''}>
+                  {category.label && (
+                    <div className="px-4 py-1.5 text-[11px] font-semibold tracking-wider text-gray-400 dark:text-gray-500 uppercase">
+                      {category.label}
+                    </div>
+                  )}
+                  {visibleItems.map(({ icon: Icon, label, path }) => (
+                    <button
+                      key={path}
+                      onClick={() => handleMoreItemClick(path)}
+                      className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg transition-colors ${isActive(path)
+                          ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
+                          : 'text-foreground hover:bg-muted'
+                        }`}
+                    >
+                      <Icon size={20} />
+                      <span className="text-sm font-medium">{label}</span>
+                    </button>
+                  ))}
+                </div>
+              );
+            })}
           </div>
         </DrawerContent>
       </Drawer>

--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -1,9 +1,22 @@
+import { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from 'next-themes';
-import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3, Droplets, Download, Coins, UserPlus, Vault } from 'lucide-react';
+import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3, Droplets, Download, Coins, UserPlus, Vault, CreditCard, HandCoins, ArrowDownToLine } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import STRATOLOGO from '@/assets/strato.png';
 import STRATOLOGODARK from '@/assets/strato-dark.png';
+
+interface MobileNavItem {
+  icon: ReactNode;
+  label: string;
+  path: string;
+  adminOnly?: boolean;
+}
+
+interface MobileNavCategory {
+  label?: string;
+  items: MobileNavItem[];
+}
 
 interface MobileSidebarProps {
   isOpen: boolean;
@@ -16,23 +29,42 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
   const { resolvedTheme } = useTheme();
   const logo = resolvedTheme === 'dark' ? STRATOLOGODARK : STRATOLOGO;
 
-  const allNavItems = [
-    { icon: <LayoutDashboard size={20} />, label: 'Portfolio', path: '/dashboard' },
-    { icon: <Wallet size={20} />, label: 'Deposits', path: '/dashboard/deposits' },
-    { icon: <Send size={20} />, label: 'Transfer', path: '/dashboard/transfer' },
-    { icon: <Book size={20} />, label: 'Borrow', path: '/dashboard/borrow' },
-    { icon: <ArrowRightLeft size={20} />, label: 'Swap', path: '/dashboard/swap' },
-    { icon: <Vault size={20} />, label: 'Vault', path: '/dashboard/vault' },
-    { icon: <Droplets size={20} />, label: 'Advanced', path: '/dashboard/advanced' },
-    { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
-    { icon: <UserPlus size={20} />, label: 'My Referrals', path: '/dashboard/referrals' },
-    { icon: <BarChart3 size={20} />, label: 'STRATO Stats', path: '/dashboard/stats' },
-    { icon: <Download size={20} />, label: 'Withdrawals', path: '/dashboard/withdrawals' },
-    { icon: <Activity size={20} />, label: 'Activity Feed', path: '/dashboard/activity' },
-    { icon: <Shield size={20} />, label: 'Admin', path: '/dashboard/admin' },
+  const navCategories: MobileNavCategory[] = [
+    {
+      items: [
+        { icon: <LayoutDashboard size={20} />, label: 'Portfolio', path: '/dashboard' },
+      ],
+    },
+    {
+      label: 'TRADE',
+      items: [
+        { icon: <ArrowDownToLine size={20} />, label: 'Fund', path: '/dashboard/deposits' },
+        { icon: <ArrowRightLeft size={20} />, label: 'Swap', path: '/dashboard/swap' },
+        { icon: <Book size={20} />, label: 'Borrow', path: '/dashboard/borrow' },
+        { icon: <Send size={20} />, label: 'Transfer', path: '/dashboard/transfer' },
+        { icon: <Download size={20} />, label: 'Withdrawals', path: '/dashboard/withdrawals' },
+      ],
+    },
+    {
+      label: 'EARN',
+      items: [
+        { icon: <CreditCard size={20} />, label: 'Card', path: '/dashboard/credit-card' },
+        { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
+      ],
+    },
+    {
+      label: 'PRO',
+      items: [
+        { icon: <Vault size={20} />, label: 'Vault', path: '/dashboard/vault' },
+        { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
+        { icon: <Activity size={20} />, label: 'Activity Feed', path: '/dashboard/activity' },
+        { icon: <BarChart3 size={20} />, label: 'STRATO Stats', path: '/dashboard/stats' },
+        { icon: <Droplets size={20} />, label: 'Advanced', path: '/dashboard/advanced' },
+        { icon: <UserPlus size={20} />, label: 'My Referrals', path: '/dashboard/referrals' },
+        { icon: <Shield size={20} />, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
+      ],
+    },
   ];
-
-  const navItems = allNavItems.filter(item => item.label !== 'Admin' || isAdmin);
 
   const isActive = (itemPath: string) => {
     if (itemPath === '/dashboard') return location.pathname === '/dashboard';
@@ -71,27 +103,40 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
 
         <div className="flex flex-col flex-1 overflow-y-auto py-4">
           <nav className="flex-1">
-            <ul className="space-y-1">
-              {navItems.map((item, index) => {
-                const active = isActive(item.path);
-                return (
-                  <li key={index}>
-                    <Link
-                      to={item.path}
-                      onClick={onClose}
-                        className={`flex items-center px-4 py-2.5 rounded-md mx-2 transition-colors duration-200 ${active
-                          ? 'bg-muted text-primary font-semibold border-l-4 border-primary'
-                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                        }`}
-                      >
-                        <span className={`flex-shrink-0 ${active ? 'text-primary' : ''}`}>{item.icon}</span>
-                      <span className={`ml-3 ${active ? 'font-semibold' : ''}`}>{item.label}</span>
-                    </Link>
-                  </li>
-              )})}
-            </ul>
+            {navCategories.map((category, idx) => {
+              const visibleItems = category.items.filter(item => !item.adminOnly || isAdmin);
+              if (visibleItems.length === 0) return null;
+              return (
+                <div key={idx} className={idx > 0 ? 'mt-4' : ''}>
+                  {category.label && (
+                    <div className="px-4 py-1.5 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
+                      {category.label}
+                    </div>
+                  )}
+                  <ul className="space-y-1">
+                    {visibleItems.map((item, index) => {
+                      const active = isActive(item.path);
+                      return (
+                        <li key={index}>
+                          <Link
+                            to={item.path}
+                            onClick={onClose}
+                            className={`flex items-center px-4 py-2.5 rounded-md mx-2 transition-colors duration-200 ${active
+                              ? 'bg-muted text-primary font-semibold border-l-4 border-primary'
+                              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                            }`}
+                          >
+                            <span className={`flex-shrink-0 ${active ? 'text-primary' : ''}`}>{item.icon}</span>
+                            <span className={`ml-3 ${active ? 'font-semibold' : ''}`}>{item.label}</span>
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              );
+            })}
           </nav>
-
         </div>
       </div>
     </>


### PR DESCRIPTION
Closes #6524

## Summary
- Organize sidebar nav into TRADE, EARN, PRO category sections
- Applied to desktop sidebar, mobile sidebar, and mobile bottom nav drawer
- Category labels rendered as small uppercase headers


Made with [Cursor](https://cursor.com)