### PR TITLE
Move Card to SPEND category in sidebar nav

### DIFF
--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -53,15 +53,15 @@ const NAV_CATEGORIES: NavCategory[] = [
     ],
   },
   {
-    label: 'EARN',
-    items: [
-      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-    ],
-  },
-  {
     label: 'SPEND',
     items: [
       { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
+    ],
+  },
+  {
+    label: 'EARN',
+    items: [
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
     ],
   },
   {

--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -55,8 +55,13 @@ const NAV_CATEGORIES: NavCategory[] = [
   {
     label: 'EARN',
     items: [
-      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
       { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+    ],
+  },
+  {
+    label: 'SPEND',
+    items: [
+      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
     ],
   },
   {

--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -55,8 +55,13 @@ const MORE_CATEGORIES: MoreNavCategory[] = [
   {
     label: 'EARN',
     items: [
-      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
       { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+    ],
+  },
+  {
+    label: 'SPEND',
+    items: [
+      { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
     ],
   },
   {

--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -53,15 +53,15 @@ const MORE_CATEGORIES: MoreNavCategory[] = [
     ],
   },
   {
-    label: 'EARN',
-    items: [
-      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-    ],
-  },
-  {
     label: 'SPEND',
     items: [
       { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
+    ],
+  },
+  {
+    label: 'EARN',
+    items: [
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
     ],
   },
   {

--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -46,15 +46,15 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
       ],
     },
     {
-      label: 'EARN',
-      items: [
-        { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
-      ],
-    },
-    {
       label: 'SPEND',
       items: [
         { icon: <CreditCard size={20} />, label: 'Card', path: '/dashboard/credit-card' },
+      ],
+    },
+    {
+      label: 'EARN',
+      items: [
+        { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
       ],
     },
     {

--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -48,8 +48,13 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
     {
       label: 'EARN',
       items: [
-        { icon: <CreditCard size={20} />, label: 'Card', path: '/dashboard/credit-card' },
         { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
+      ],
+    },
+    {
+      label: 'SPEND',
+      items: [
+        { icon: <CreditCard size={20} />, label: 'Card', path: '/dashboard/credit-card' },
       ],
     },
     {


### PR DESCRIPTION
Closes #6526

## Summary
- Add new SPEND category between EARN and PRO
- Move Card from EARN into SPEND
- EARN now contains only Earn
