### PR TITLE
Add per-flow recent transactions and metal purchases page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,32 @@
 ## Learned User Preferences
 
-- Prefer the simplest possible approach; keep code lean and minimal; never touch files outside the task scope
+- Prefer the simplest possible approach; keep code lean and minimal; never touch files outside the task scope; prefer stepwise implementation for multi-step work
 - Do not over-explain or repeat analysis already provided; answer the actual question directly
-- Self-review every diff line before presenting; never modify existing comments, formatting, or unrelated code
-- When asked to "figure it out yourself," read env files and configs autonomously; always test endpoints with real auth tokens from `.env`
+- "Clean lean clinical" is the standard: no redundancy, no dead code, no unnecessary abstractions; extract large presentational blocks into separate components when files grow big
+- Self-review every diff line before presenting; never modify existing comments, formatting, or unrelated code; preserve step-flow comments and section headers during refactors
+- When asked to "figure it out yourself," read env files and configs autonomously; always test endpoints with real auth tokens from `.env`; call Cirrus/backend endpoints with `curl` to verify data before claiming things work
 - Put interfaces, types, and constants in canonical locations (types file, config index) not inline in service files; avoid creating new files when an existing one is the right home
-- When asked to push changes, push only the specific files requested -- never include extras
-- Ask for approval before making design-level decisions (e.g., sum vs max for bonus percentages)
-- Remove debug logs immediately after confirming a fix
-- Cursor IDE: primary sidebar on the right side (profile: `-75b6a7f1`)
-- When reverting staged changes, only revert files unrelated to the current task
-- Use `in.(...)` filter syntax (not `eq.`) for Cirrus queries with multiple addresses
+- Helper functions should only build params and parse results -- all Cirrus/API calls belong in the service layer
+- Ask for approval before making design-level decisions (e.g., sum vs max for bonus percentages); when asked to push, push only the specific files requested
+- Remove debug logs immediately after confirming a fix; reuse existing constants (e.g. WAD) instead of redefining locally
+- Always trace through to the actual backend code (service, contract calls) before assuming fees, data shapes, or tx costs from frontend constants alone
 - PR descriptions should be short summaries (2-3 bullets), not long write-ups; never mention Cursor or AI tools in PRs/issues
-- Follow mockups closely; match layout, styling, and behavior exactly
-- Tab switches use true crossfades (both panels rendered, opacity toggle); network/data switches should NOT animate -- just swap data in place; skeleton loaders only for genuinely async first-loads
+- Follow mockups closely; match layout, styling, and behavior exactly; when user says "like the mockup" they mean pixel-level fidelity
+- Tab switches use true crossfades (both panels rendered, opacity toggle); network/data switches should NOT animate -- just swap data in place; skeleton loaders only for genuinely async first-loads, never for cached data; data must be ready before animation starts
+- Avoid unnecessary `useEffect`; prefer derived state, event handlers, or `useMemo` over effects; user explicitly dislikes effect-heavy code
 
 ## Learned Workspace Facts
 
-- STRATO network IDs exceed JS `Number.MAX_SAFE_INTEGER`; must guard with `Number.isSafeInteger()` before passing to viem/wagmi
-- MetaMask connector specifically crashes on oversized chain IDs because `initProvider()` eagerly calls `numberToHex` on all configured chains; Coinbase connector only passes raw IDs at init and defers hex conversion to `switchChain`
-- Bridge-out flow: `bridgeService.confirmWithdrawalBatch` -> `safeService.createSafeTransactions` -> `safeHelper.createWithdrawalProposals` -> `safeHelper.proposeTransactions` (submits to Safe via `apiKit.proposeTransaction`)
+- STRATO network IDs exceed JS `Number.MAX_SAFE_INTEGER`; must guard with `Number.isSafeInteger()` before passing to viem/wagmi; MetaMask crashes on oversized chain IDs (`initProvider` → `numberToHex`)
 - Backend config is fetched from STRATO node metadata at startup (`/eth/v1.2/metadata`); `NODE_URL` determines which network (upquark mainnet vs helium testnet)
-- `WAGMI_PROJECT_ID` env var is required on backend for WalletConnect; absence causes 400 errors on WalletConnect telemetry but does not block MetaMask extension connections
-- `TokenContext.getActiveTokens()` is only called from admin components; regular user pages (Fund, Dashboard) never call it, so `activeTokens` is always `[]` for non-admin users
-- Token.sol `burn()` is `onlyOwner` (TokenFactory); regular token holders cannot burn their own tokens
-- MercataBridge requires both `asset.enabled` and `Token.status == ACTIVE` (via `TokenFactory.isTokenActive`) for deposits and withdrawals
-- Rewards.sol `sourceContract` is a pure mapping key; registering an address before deployment is safe since the contract is never called
-- `mercata/services/rewards-poller` uses atomic JSON file writes (tmp + rename) for state tracking (`lastProcessedBlock.json`, `lastBonusRun.json`)
-- OpenAPI doc comments in routes must use quoted YAML strings for descriptions containing `{`, `}`, or `|` characters
-- Buy Metals flow is integrated into BridgeIn.tsx (no separate page/route); `BuyMetals.tsx` and `BuyMetalsWidget.tsx` were deleted; `metalForgeService.getConfigs()` returns metals + pay tokens + oracle prices in 2 Cirrus calls
-- Cirrus 503 "No space left on device" errors originate from the remote STRATO node's PostgreSQL shared memory, not the local dev machine
-- Cirrus query optimization: use `or=()` to batch filters; use phased parallel `Promise.all` (fetch data first, then resolve metadata from results in parallel); query contract-specific tables (e.g. `MercataBridge-assets`) directly instead of generic `/mapping`; `authorizeRequest(true)` enables public endpoints with service token fallback
-- Send data with API responses rather than relying on frontend context being pre-loaded (e.g. oracle prices should come from backend, not depend on OracleContext)
-- BridgeToken routes: `externalToken` + `stratoToken` + `isDefaultRoute`; default route = VIA WRAP, non-default = VIA MINT (used for auto-save/auto-forge)
-- MetalForge `mintMetal` mints to `msg.sender`; MercataBridge `_autoForge` calls it, then transfers metal to the deposit recipient
-- MercataBridge `confirmDeposit` dispatches on `DepositAction` enum (`NONE`, `AUTO_SAVE`, `AUTO_FORGE`) stored via `requestDepositAction`; falls back to direct mint on action failure
-- SolidVM contract tests: run `solid-vm-cli test <file>` from test dir; pattern is `Describe_*` contract with `beforeAll`/`beforeEach`/`it_*` functions
+- STRATO tx fee is 0.01 USDST per contract call; parallel batches cost 0.01 * N; use `computeMaxTransferable` to deduct fees from max amount
+- Bridge-out flow: `bridgeService.confirmWithdrawalBatch` → `safeService.createSafeTransactions` → `safeHelper.createWithdrawalProposals` → `safeHelper.proposeTransactions` (submits to Safe via `apiKit.proposeTransaction`)
+- BridgeToken routes: `externalToken` + `stratoToken` + `isDefaultRoute`; default = VIA WRAP, non-default = VIA MINT; `MercataBridge.confirmDeposit` dispatches on `DepositAction` enum (`NONE`, `AUTO_SAVE`, `AUTO_FORGE`); bridge status: 1=Initiated, 2=Pending Review, 3=Completed, 4=Aborted
+- Cirrus query optimization: `or=()` to batch filters; phased parallel `Promise.all`; `attributes->>` for selective field extraction in enrichment queries (smaller payload), but full `attributes` blob for data queries (nested JSON is more compact than repeated column names); `history@mapping` for historical data; `authorizeRequest(true)` for public endpoints; multiple `or=` params are ANDed — use `and=(or(...),or(...))` to combine
+- Cirrus event table: canonical events (`DepositInitiated`, `WithdrawalRequested`, `MetalMinted`) provide one row per transaction with native `limit`/`offset` pagination; status derived from follow-up events (`DepositCompleted`, `WithdrawalCompleted`, etc.) via batch enrichment; outcome (`AutoForged`, `AutoSaved`) included in same enrichment call; mixed-contract filter: `or=(and(address.eq.{bridge}, event_name.in.(...)), and(address.eq.{forge}, event_name.eq.MetalMinted, attributes->>buyer.neq.{bridge}))`; auto-forge `MetalMinted` events (buyer=bridge) must be excluded from direct metal purchases
+- Cirrus `count()` with additional select fields triggers implicit `GROUP BY` (e.g. `select=event_name,count()` returns per-event-name counts); `max()` and `DISTINCT ON` are NOT supported by PostgREST/Cirrus
+- Fund page IS BridgeIn page; Buy Metals integrated into BridgeIn.tsx; `tokenCacheRef` caches bridgeable tokens per chainId; `RecentTransactions` is a separate component showing last 5 deposit/withdrawal txns with local-storage optimistic entries
+- `UserTokensContext` provides user token balances (auto-fetches from `/tokens/balance` on login); `TokenContext.activeTokens` is admin-only and always `[]` for regular users; refetch `earningAssets` after bridge-in and metals purchases
+- MercataBridge requires both `asset.enabled` and `Token.status == ACTIVE` for deposits/withdrawals; Token.sol `burn()` is `onlyOwner` (TokenFactory); MetalForge `mintMetal` mints to `msg.sender`
+- Sidebar nav uses category groupings (TRADE, SPEND, EARN, PRO) defined in `DashboardSidebar.tsx`, `MobileSidebar.tsx`, and `MobileBottomNav.tsx`; all three must stay in sync; Card is under SPEND
+- SolidVM contract tests: `solid-vm-cli test <file>` from test dir; pattern is `Describe_*` contract with `beforeAll`/`beforeEach`/`it_*` functions; `fetchMinDepositAmount` depends on both `selectedToken` AND `currentNetwork`/`chainId`

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -42,6 +42,7 @@ import CreditCardPage from "./pages/CreditCard";
 // Import dashboard components
 
 import BridgeTransactionsPage from "./pages/BridgeTransactionsPage";
+import MetalTransactionsPage from "./pages/MetalTransactionsPage";
 import WithdrawalsPage from "./pages/WithdrawalsPage";
 import Admin from "./pages/Admin";
 import ProtectedRoute from "./components/ProtectedRoute";
@@ -325,6 +326,15 @@ const App = () => {
                                             element={
                                               <ProtectedRoute>
                                                 <BridgeTransactionsPage />
+                                              </ProtectedRoute>
+                                            }
+                                          />
+
+                                          <Route
+                                            path="/metal-transactions"
+                                            element={
+                                              <ProtectedRoute>
+                                                <MetalTransactionsPage />
                                               </ProtectedRoute>
                                             }
                                           />

--- a/mercata/ui/src/components/bridge/BridgeIn.tsx
+++ b/mercata/ui/src/components/bridge/BridgeIn.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DepositAction } from "@mercata/shared-types";
@@ -51,7 +51,7 @@ import {
 import DepositProgressModal, { DepositStep } from "./DepositProgressModal";
 import { redirectToLogin } from "@/lib/auth";
 import { Link } from "react-router-dom";
-import { ArrowDownToLine, Gem, CheckCircle2, TrendingUp } from "lucide-react";
+import { ArrowDownToLine, Gem, CheckCircle2, TrendingUp, ChevronLeft, ChevronRight } from "lucide-react";
 import { usdstAddress, WAD, METAL_BUY_FEE } from "@/lib/constants";
 
 const METAL_BUY_FEE_WEI = safeParseUnits(METAL_BUY_FEE).toString();
@@ -75,7 +75,7 @@ const CrossfadePanel = ({ active, children }: { active: boolean; children: React
 );
 
 const CardSkeleton = ({ id }: { id: string }) => (
-  <div key={id} className="relative text-left rounded-md border-2 border-border p-3 animate-pulse">
+  <div key={id} className="relative text-left rounded-md border-2 border-border p-3 animate-pulse snap-start">
     <div className="flex items-center gap-2 mb-1">
       <div className="w-6 h-6 rounded-full bg-muted shrink-0" />
       <div className="h-[1.25rem] w-16 bg-muted rounded" />
@@ -92,7 +92,7 @@ const TokenCard = ({ active, image, symbol, estimated, label, onClick, disabled,
   apyBadge: React.ReactNode;
 }) => (
   <button type="button" onClick={onClick} disabled={disabled}
-    className={`relative text-left rounded-md border-2 p-3 transition-colors ${
+    className={`relative text-left rounded-md border-2 p-3 transition-colors snap-start ${
       active ? "border-blue-500 bg-blue-500/5 dark:bg-blue-500/10" : "border-border hover:bg-muted/30"
     }`}>
     {active && <div className="absolute top-2 right-2"><CheckCircle2 className="w-4 h-4 text-blue-500" /></div>}
@@ -108,11 +108,73 @@ const TokenCard = ({ active, image, symbol, estimated, label, onClick, disabled,
   </button>
 );
 
+const ScrollRow = ({ children }: { children: React.ReactNode }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+  const count = React.Children.count(children);
+
+  const check = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setCanLeft(el.scrollLeft > 2);
+    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
+  }, []);
+
+  useEffect(() => {
+    if (count <= 3) return;
+    check();
+    const el = ref.current;
+    if (!el) return;
+    el.addEventListener("scroll", check, { passive: true });
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => { el.removeEventListener("scroll", check); ro.disconnect(); };
+  }, [check, count]);
+
+  const scroll = (dir: number) => {
+    const el = ref.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * Math.floor(el.clientWidth / 3), behavior: "smooth" });
+  };
+
+  const needsScroll = count > 3;
+  const gridStyle: React.CSSProperties = needsScroll
+    ? {
+        gridTemplateColumns: `repeat(${count}, calc((100% - 16px) / 3))`,
+        overflowX: "auto",
+        scrollbarWidth: "none",
+      }
+    : {
+        gridTemplateColumns: `repeat(${count || 1}, minmax(0, 1fr))`,
+      };
+
+  return (
+    <div className="relative group">
+      <div ref={ref} className="grid gap-2 snap-x" style={gridStyle}>
+        {children}
+      </div>
+      {needsScroll && ([
+        { dir: -1, enabled: canLeft, pos: "left-0", grad: "bg-gradient-to-r", Icon: ChevronLeft },
+        { dir: 1, enabled: canRight, pos: "right-0", grad: "bg-gradient-to-l", Icon: ChevronRight },
+      ] as const).map(({ dir, enabled, pos, grad, Icon }) => (
+        <button key={dir} type="button" onClick={() => scroll(dir)} disabled={!enabled}
+          className={`absolute ${pos} top-0 bottom-0 w-7 flex items-center justify-center ${grad} from-card to-transparent z-10 transition-opacity ${enabled ? "opacity-100" : "opacity-30 pointer-events-none"}`}>
+          <Icon className="w-4 h-4 text-muted-foreground" />
+        </button>
+      ))}
+    </div>
+  );
+};
+
 interface BridgeInProps {
   guestMode?: boolean;
+  fundingMode?: "bridge" | "metals";
+  onFundingModeChange?: (mode: "bridge" | "metals") => void;
+  onMetalPurchase?: () => void;
 }
 
-const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
+const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false, fundingMode: externalFundingMode, onFundingModeChange, onMetalPurchase }) => {
   // Hooks & Context
   const { address, isConnected } = useAccount();
   const chainId = useChainId();
@@ -136,8 +198,10 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
   } = useBridgeContext();
   const { tokenApys, tokenApysLoaded } = useEarnContext();
 
-  // State
-  const [fundingMode, setFundingMode] = useState<"bridge" | "metals">("bridge");
+  // State -- fundingMode can be controlled externally or managed internally
+  const [internalMode, setInternalMode] = useState<"bridge" | "metals">("bridge");
+  const fundingMode = externalFundingMode ?? internalMode;
+  const setFundingMode = onFundingModeChange ?? setInternalMode;
   const [amount, setAmount] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [amountError, setAmountError] = useState("");
@@ -462,6 +526,7 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
       setAmount("");
       fetchTokens();
       fetchUsdstBalance();
+      onMetalPurchase?.();
     } catch (error: any) {
       toast({ title: "Transaction failed", description: error?.message || "Unknown error", variant: "destructive" });
     } finally {
@@ -891,7 +956,7 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
 
           <div className="relative">
             <CrossfadePanel active={fundingMode === "metals"}>
-              <div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${Math.min((metalsConfig?.metals.filter(m => m.isEnabled).length || 2), 3)}, 1fr)` }}>
+              <ScrollRow>
                 {!metalsConfig
                   ? Array.from({ length: 2 }).map((_, i) => <CardSkeleton key={`ms-${i}`} id={`ms-${i}`} />)
                   : metalsConfig.metals.filter(m => m.isEnabled).map((metal) => {
@@ -909,12 +974,12 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
                       );
                     })
                 }
-              </div>
+              </ScrollRow>
             </CrossfadePanel>
             <CrossfadePanel active={fundingMode === "bridge"}>
-              <div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${Math.min((sourceTokenRoutes.length + matchingActions.length) || prevRouteCountRef.current, 3)}, 1fr)` }}>
-                {sourceTokenRoutes.length > 0 ? (<>
-                  {sourceTokenRoutes.map((rt) => (
+              <ScrollRow>
+                {sourceTokenRoutes.length > 0 ? [
+                  ...sourceTokenRoutes.map((rt) => (
                     <TokenCard key={rt.id}
                       active={rt.id === selectedToken?.id && !selectedAction}
                       image={rt.stratoTokenImage} symbol={rt.stratoTokenSymbol}
@@ -924,8 +989,8 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
                       disabled={guestMode || isLoading}
                       apyBadge={<ApyBadge addr={rt.stratoToken} />}
                     />
-                  ))}
-                  {matchingActions.map((action) => {
+                  )),
+                  ...matchingActions.map((action) => {
                     let est = amount || "0";
                     if (action.action === 2 && action.oraclePrice && amount) {
                       try {
@@ -948,11 +1013,11 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false }) => {
                         apyBadge={<ApyBadge addr={action.stratoToken} />}
                       />
                     );
-                  })}
-                </>) : (
+                  }),
+                ] : (
                   Array.from({ length: prevRouteCountRef.current }).map((_, i) => <CardSkeleton key={`bs-${i}`} id={`bs-${i}`} />)
                 )}
-              </div>
+              </ScrollRow>
             </CrossfadePanel>
           </div>
         </section>

--- a/mercata/ui/src/components/bridge/RecentTransactions.tsx
+++ b/mercata/ui/src/components/bridge/RecentTransactions.tsx
@@ -1,15 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
-import { ArrowDown, ArrowUp } from 'lucide-react';
+import { ArrowDown, ArrowUp, Gem, Frown } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import { useBridgeContext } from '@/context/BridgeContext';
 import { formatBalance } from '@/utils/numberUtils';
 import { mergePendingDeposits } from '@/lib/bridge/utils';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { activityFeedApi } from '@/lib/activityFeed';
+import { METAL_ACTIVITY_PAIR, resolveTokenSymbols, collectMetalTokenAddrs, mapEventsToMetalTxs } from '@/lib/metalActivity';
 
 type RecentTx = {
-  _type: 'deposit' | 'withdrawal';
+  _type: 'deposit' | 'withdrawal' | 'metal';
   block_timestamp?: string;
   externalChainId?: number | string;
   externalSymbol?: string;
@@ -19,16 +21,21 @@ type RecentTx = {
   depositOutcome?: 'bridge' | 'save' | 'forge';
   finalTokenSymbol?: string;
   finalAmount?: string;
+  paySymbol?: string;
+  payAmount?: string;
+  metalSymbol?: string;
 };
 
-const getStatusLabel = (status?: string | number) => {
-  const s = parseInt(String(status || "0"));
-  if (s === 3) return { text: "Complete", color: "bg-emerald-500/15 text-emerald-500" };
-  if (s === 2) return { text: "Pending", color: "bg-amber-500/15 text-amber-500" };
-  if (s === 4) return { text: "Aborted", color: "bg-red-500/15 text-red-500" };
-  if (s === 1) return { text: "Initiated", color: "bg-blue-500/15 text-blue-500" };
-  return { text: "Unknown", color: "bg-muted text-muted-foreground" };
+const STATUS_LABELS: Record<number, { text: string; color: string }> = {
+  3: { text: "Complete", color: "bg-emerald-500/15 text-emerald-500" },
+  2: { text: "Pending", color: "bg-amber-500/15 text-amber-500" },
+  4: { text: "Aborted", color: "bg-red-500/15 text-red-500" },
+  1: { text: "Initiated", color: "bg-blue-500/15 text-blue-500" },
 };
+const UNKNOWN_STATUS = { text: "Unknown", color: "bg-muted text-muted-foreground" };
+const METAL_STATUS = STATUS_LABELS[3];
+
+const getStatusLabel = (status?: string | number) => STATUS_LABELS[parseInt(String(status || "0"))] || UNKNOWN_STATUS;
 
 const formatTimeAgo = (time?: string) => {
   if (!time) return "-";
@@ -43,168 +50,200 @@ const formatTimeAgo = (time?: string) => {
   return `${days} day${days > 1 ? "s" : ""} ago`;
 };
 
-const RecentTransactions = () => {
+const TxRow = ({ icon, iconBg, label, status, timeLabel, fromAmount, fromSymbol, toAmount, toSymbol }: {
+  icon: React.ReactNode; iconBg: string; label: string;
+  status: { text: string; color: string };
+  timeLabel: string; fromAmount: string; fromSymbol: string;
+  toAmount: string; toSymbol: string;
+}) => (
+  <div className="flex items-center gap-3 px-4 py-4">
+    <div className={`w-9 h-9 rounded-full flex items-center justify-center shrink-0 ${iconBg}`}>{icon}</div>
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-2">
+        <p className="text-sm font-semibold text-foreground">{label}</p>
+        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${status.color}`}>{status.text}</span>
+      </div>
+      <p className="text-xs text-muted-foreground mt-0.5">{timeLabel}</p>
+    </div>
+    <div className="text-right shrink-0">
+      <p className="text-sm font-semibold text-foreground">{fromAmount} {fromSymbol}</p>
+      <p className="text-xs text-muted-foreground">{"\u2192"} {toAmount} {toSymbol}</p>
+    </div>
+  </div>
+);
+
+const mapDeposit = (tx: Record<string, unknown>, type: 'api' | 'pending'): RecentTx => {
+  const info = tx.DepositInfo as Record<string, unknown> | undefined;
+  return {
+    _type: 'deposit', block_timestamp: tx.block_timestamp as string,
+    externalChainId: (tx.externalChainId ?? info?.externalChainId) as string,
+    externalSymbol: tx.externalSymbol as string, stratoTokenSymbol: tx.stratoTokenSymbol as string,
+    amount: info?.stratoTokenAmount as string, status: info?.bridgeStatus as string,
+    depositOutcome: (type === 'pending'
+      ? (tx.type === 'saving' ? 'save' : tx.type === 'forge' ? 'forge' : 'bridge')
+      : tx.depositOutcome) as RecentTx['depositOutcome'],
+    finalTokenSymbol: tx.finalTokenSymbol as string | undefined,
+    finalAmount: tx.finalAmount as string | undefined,
+  };
+};
+
+const mapWithdrawal = (tx: Record<string, unknown>): RecentTx => {
+  const info = tx.WithdrawalInfo as Record<string, unknown> | undefined;
+  return {
+    _type: 'withdrawal', block_timestamp: tx.block_timestamp as string,
+    externalChainId: (info?.externalChainId ?? tx.externalChainId) as string,
+    externalSymbol: tx.externalSymbol as string, stratoTokenSymbol: tx.stratoTokenSymbol as string,
+    amount: info?.stratoTokenAmount as string, status: info?.bridgeStatus as string,
+  };
+};
+
+function useMetalTransactions(limit: number, isLoggedIn: boolean) {
+  const [transactions, setTransactions] = useState<RecentTx[]>([]);
+  const [loading, setLoading] = useState(false);
+  const loadedRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (!isLoggedIn) { setTransactions([]); loadedRef.current = true; return; }
+    if (!loadedRef.current) setLoading(true);
+    try {
+      const result = await activityFeedApi.getActivities(METAL_ACTIVITY_PAIR, { limit, myActivity: true });
+      const events = result.events || [];
+      const symbolMap = await resolveTokenSymbols([...collectMetalTokenAddrs(events)]);
+      setTransactions(mapEventsToMetalTxs(events, symbolMap).map((tx) => ({
+        ...tx, _type: 'metal' as const, amount: tx.metalAmount, status: "3",
+      })));
+    } catch { setTransactions([]); }
+    finally { setLoading(false); loadedRef.current = true; }
+  }, [limit, isLoggedIn]);
+
+  return { transactions, loading, load };
+}
+
+interface RecentTransactionsProps {
+  fundingMode?: "bridge" | "metals";
+  metalRefreshKey?: number;
+}
+
+const RecentTransactions = ({ fundingMode = "bridge", metalRefreshKey = 0 }: RecentTransactionsProps) => {
   const { isLoggedIn } = useUser();
   const {
-    fetchDepositTransactions,
-    fetchWithdrawTransactions,
-    availableNetworks,
-    depositRefreshKey,
-    withdrawalRefreshKey,
+    fetchDepositTransactions, fetchWithdrawTransactions,
+    availableNetworks, depositRefreshKey, withdrawalRefreshKey,
   } = useBridgeContext();
 
   const chainNameMap = new Map(availableNetworks.map(n => [String(n.chainId), n.chainName]));
   const isMobile = useIsMobile();
   const recentLimit = isMobile ? 6 : 8;
-  const [transactions, setTransactions] = useState<RecentTx[]>([]);
-  const [loading, setLoading] = useState(true);
+
+  const [bridgeTxs, setBridgeTxs] = useState<RecentTx[]>([]);
+  const [bridgeLoading, setBridgeLoading] = useState(false);
+  const bridgeLoadedRef = useRef(false);
+
+  const metal = useMetalTransactions(recentLimit, isLoggedIn);
+  const [lastMetalRefreshKey, setLastMetalRefreshKey] = useState(-1);
 
   useEffect(() => {
-    if (!isLoggedIn) {
-      setTransactions([]);
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
+    if (fundingMode !== "bridge") return;
+    if (!isLoggedIn) { setBridgeTxs([]); bridgeLoadedRef.current = true; return; }
+    if (!bridgeLoadedRef.current) setBridgeLoading(true);
     const params = { limit: String(recentLimit), offset: "0", order: "block_timestamp.desc" };
-
     Promise.all([
       fetchDepositTransactions(params, "deposits"),
       fetchWithdrawTransactions(params, "deposits"),
-    ])
-      .then(([depositResult, withdrawalResult]) => {
-        const apiDeposits = (depositResult.data || []) as unknown as Record<string, unknown>[];
-        const { remaining: remainingPending } = mergePendingDeposits(apiDeposits);
+    ]).then(([depositResult, withdrawalResult]) => {
+      const apiDeposits = (depositResult.data || []) as unknown as Record<string, unknown>[];
+      const { remaining } = mergePendingDeposits(apiDeposits);
+      const all = [
+        ...remaining.map((p: Record<string, unknown>) => mapDeposit(p, 'pending')),
+        ...apiDeposits.map((tx) => mapDeposit(tx, 'api')),
+        ...((withdrawalResult.data || []) as unknown as Record<string, unknown>[]).map(mapWithdrawal),
+      ].sort((a, b) => new Date(b.block_timestamp || 0).getTime() - new Date(a.block_timestamp || 0).getTime())
+       .slice(0, recentLimit);
+      setBridgeTxs(all);
+      setBridgeLoading(false);
+      bridgeLoadedRef.current = true;
+    }).catch(() => { setBridgeTxs([]); setBridgeLoading(false); bridgeLoadedRef.current = true; });
+  }, [isLoggedIn, fundingMode, fetchDepositTransactions, fetchWithdrawTransactions, depositRefreshKey, withdrawalRefreshKey, recentLimit]);
 
-        const pendingTxs: RecentTx[] = remainingPending.map((p) => ({
-          _type: 'deposit' as const,
-          block_timestamp: p.block_timestamp as string,
-          externalChainId: p.externalChainId as string,
-          externalSymbol: p.externalSymbol as string,
-          stratoTokenSymbol: p.stratoTokenSymbol as string,
-          amount: (p.DepositInfo as Record<string, unknown>)?.stratoTokenAmount as string,
-          status: (p.DepositInfo as Record<string, unknown>)?.bridgeStatus as string,
-          depositOutcome: (p.type === 'saving' ? 'save' : p.type === 'forge' ? 'forge' : 'bridge') as RecentTx['depositOutcome'],
-          finalTokenSymbol: p.finalTokenSymbol as string | undefined,
-        }));
+  if (fundingMode === "metals" && isLoggedIn && lastMetalRefreshKey !== metalRefreshKey) {
+    setLastMetalRefreshKey(metalRefreshKey);
+    metal.load();
+  }
 
-        const deposits: RecentTx[] = apiDeposits.map((tx) => ({
-          _type: 'deposit' as const,
-          block_timestamp: tx.block_timestamp as string,
-          externalChainId: (tx.externalChainId ?? (tx.DepositInfo as Record<string, unknown>)?.externalChainId) as string,
-          externalSymbol: tx.externalSymbol as string,
-          stratoTokenSymbol: tx.stratoTokenSymbol as string,
-          amount: (tx.DepositInfo as Record<string, unknown>)?.stratoTokenAmount as string,
-          status: (tx.DepositInfo as Record<string, unknown>)?.bridgeStatus as string,
-          depositOutcome: tx.depositOutcome as RecentTx['depositOutcome'],
-          finalTokenSymbol: tx.finalTokenSymbol as string | undefined,
-          finalAmount: tx.finalAmount as string | undefined,
-        }));
+  const isBridge = fundingMode === "bridge";
 
-        const withdrawals: RecentTx[] = ((withdrawalResult.data || []) as unknown as Record<string, unknown>[]).map((tx) => ({
-          _type: 'withdrawal' as const,
-          block_timestamp: tx.block_timestamp as string,
-          externalChainId: ((tx.WithdrawalInfo as Record<string, unknown>)?.externalChainId ?? tx.externalChainId) as string,
-          externalSymbol: tx.externalSymbol as string,
-          stratoTokenSymbol: tx.stratoTokenSymbol as string,
-          amount: (tx.WithdrawalInfo as Record<string, unknown>)?.stratoTokenAmount as string,
-          status: (tx.WithdrawalInfo as Record<string, unknown>)?.bridgeStatus as string,
-        }));
+  const renderTxRows = (txs: RecentTx[]) => (
+    <div className="divide-y divide-border/40">
+      {txs.map((tx, index) => {
+        const amt = formatBalance(tx.amount || "0", undefined, 18, 2, 4);
+        const key = `${tx.block_timestamp || "tx"}-${index}`;
 
-        const merged = [...pendingTxs, ...deposits, ...withdrawals]
-          .sort((a, b) => new Date(b.block_timestamp || 0).getTime() - new Date(a.block_timestamp || 0).getTime())
-          .slice(0, recentLimit);
+        if (tx._type === 'metal') {
+          return <TxRow key={key} icon={<Gem className="w-4 h-4 text-yellow-600" />} iconBg="bg-yellow-500/15"
+            label="Metal Mint" status={METAL_STATUS} timeLabel={formatTimeAgo(tx.block_timestamp)}
+            fromAmount={formatBalance(tx.payAmount || "0", undefined, 18, 2, 4)} fromSymbol={tx.paySymbol || "-"}
+            toAmount={amt} toSymbol={tx.metalSymbol || "-"} />;
+        }
 
-        setTransactions(merged);
-        setLoading(false);
-      })
-      .catch(() => { setTransactions([]); setLoading(false); });
-  }, [isLoggedIn, fetchDepositTransactions, fetchWithdrawTransactions, depositRefreshKey, withdrawalRefreshKey, recentLimit]);
+        const isW = tx._type === 'withdrawal';
+        const status = getStatusLabel(tx.status);
+        const hasOutcome = !isW && tx.depositOutcome && tx.depositOutcome !== "bridge" && tx.finalTokenSymbol;
+        return <TxRow key={key}
+          icon={isW ? <ArrowUp className="w-4 h-4 text-amber-500" /> : <ArrowDown className="w-4 h-4 text-emerald-500" />}
+          iconBg={isW ? "bg-amber-500/15" : "bg-emerald-500/15"}
+          label={isW ? "Withdrawal" : "Deposit"} status={status}
+          timeLabel={`${formatTimeAgo(tx.block_timestamp)} · ${chainNameMap.get(String(tx.externalChainId)) || "Unknown Chain"}`}
+          fromAmount={amt} fromSymbol={(isW ? tx.stratoTokenSymbol : tx.externalSymbol) || "-"}
+          toAmount={hasOutcome && tx.finalAmount ? formatBalance(tx.finalAmount, undefined, 18, 2, 4) : amt}
+          toSymbol={(hasOutcome ? tx.finalTokenSymbol : (isW ? tx.externalSymbol : tx.stratoTokenSymbol)) || "-"} />;
+      })}
+    </div>
+  );
+
+  const activeTxs = isBridge ? bridgeTxs : metal.transactions;
+  const activeLoading = isBridge ? bridgeLoading : metal.loading;
+  const viewAllLink = isBridge ? "/bridge-transactions?from=deposits" : "/metal-transactions?from=deposits";
+  const linkClass = `text-sm font-semibold ${isLoggedIn ? "text-blue-500 hover:text-blue-700" : "text-muted-foreground pointer-events-none opacity-50"}`;
+
+  const emptyState = !isBridge ? (
+    <div className="flex flex-col items-center justify-center h-full min-h-[300px] text-muted-foreground">
+      <Frown className="w-10 h-10 mb-2 opacity-30" />
+      <span className="text-sm font-medium">No metal purchases found</span>
+    </div>
+  ) : <p className="text-sm text-muted-foreground px-4 py-4">No recent transactions.</p>;
+
+  const skeleton = (
+    <div className="divide-y divide-border/40">
+      {Array.from({ length: isMobile ? 4 : 6 }).map((_, i) => (
+        <div key={`tx-skel-${i}`} className="flex items-center gap-3 px-4 py-4 animate-pulse">
+          <div className="w-9 h-9 rounded-full bg-muted shrink-0" />
+          <div className="flex-1 space-y-1.5"><div className="h-3.5 w-24 bg-muted rounded" /><div className="h-3 w-16 bg-muted rounded" /></div>
+          <div className="space-y-1.5 text-right"><div className="h-3.5 w-20 bg-muted rounded ml-auto" /><div className="h-3 w-14 bg-muted rounded ml-auto" /></div>
+        </div>
+      ))}
+    </div>
+  );
 
   return (
     <Card className="shadow-sm border border-border/70">
       <CardContent className="p-0">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border/70">
-          <CardTitle className="text-base">Recent Transactions</CardTitle>
-          <Link
-            to="/bridge-transactions?from=deposits"
-            className={`text-sm font-semibold ${
-              isLoggedIn
-                ? "text-blue-500 hover:text-blue-700"
-                : "text-muted-foreground pointer-events-none opacity-50"
-            }`}
-          >
+          <CardTitle className="text-base">
+            {isBridge ? "Recent Transactions" : "Recent Metal Purchases"}
+          </CardTitle>
+          <Link to={viewAllLink} className={linkClass}>
             View All {"\u2192"}
           </Link>
         </div>
 
-        {!isLoggedIn ? (
-          <p className="text-sm text-muted-foreground px-4 py-4">Sign in to view your recent activity.</p>
-        ) : loading ? (
-          <div className="divide-y divide-border/40">
-            {Array.from({ length: isMobile ? 4 : 6 }).map((_, i) => (
-              <div key={`tx-skel-${i}`} className="flex items-center gap-3 px-4 py-4 animate-pulse">
-                <div className="w-9 h-9 rounded-full bg-muted shrink-0" />
-                <div className="flex-1 space-y-1.5">
-                  <div className="h-3.5 w-24 bg-muted rounded" />
-                  <div className="h-3 w-16 bg-muted rounded" />
-                </div>
-                <div className="space-y-1.5 text-right">
-                  <div className="h-3.5 w-20 bg-muted rounded ml-auto" />
-                  <div className="h-3 w-14 bg-muted rounded ml-auto" />
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : transactions.length === 0 ? (
-          <p className="text-sm text-muted-foreground px-4 py-4">No recent transactions.</p>
-        ) : (
-          <div className="divide-y divide-border/40">
-            {transactions.map((tx, index) => {
-              const status = getStatusLabel(tx.status);
-              const isWithdrawal = tx._type === 'withdrawal';
-              const amountFormatted = formatBalance(tx.amount || "0", undefined, 18, 2, 4);
-              const hasOutcome = !isWithdrawal && tx.depositOutcome && tx.depositOutcome !== "bridge" && tx.finalTokenSymbol;
-              const toAmount = hasOutcome && tx.finalAmount ? formatBalance(tx.finalAmount, undefined, 18, 2, 4) : amountFormatted;
-              const label = isWithdrawal ? "Withdrawal" : "Deposit";
-              const fromSymbol = isWithdrawal ? tx.stratoTokenSymbol : tx.externalSymbol;
-              const toSymbol = hasOutcome ? tx.finalTokenSymbol : (isWithdrawal ? tx.externalSymbol : tx.stratoTokenSymbol);
-              return (
-                <div key={`${tx.block_timestamp || "tx"}-${index}`} className="flex items-center gap-3 px-4 py-4">
-                  <div className={`w-9 h-9 rounded-full flex items-center justify-center shrink-0 ${
-                    isWithdrawal ? "bg-amber-500/15" : "bg-emerald-500/15"
-                  }`}>
-                    {isWithdrawal ? (
-                      <ArrowUp className="w-4 h-4 text-amber-500" />
-                    ) : (
-                      <ArrowDown className="w-4 h-4 text-emerald-500" />
-                    )}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-semibold text-foreground">{label}</p>
-                      <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${status.color}`}>
-                        {status.text}
-                      </span>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      {formatTimeAgo(tx.block_timestamp)} · {chainNameMap.get(String(tx.externalChainId)) || "Unknown Chain"}
-                    </p>
-                  </div>
-                  <div className="text-right shrink-0">
-                    <p className="text-sm font-semibold text-foreground">
-                      {amountFormatted} {fromSymbol || "-"}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {"\u2192"} {toAmount} {toSymbol || "-"}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
+        {!isLoggedIn
+          ? <p className="text-sm text-muted-foreground px-4 py-4">Sign in to view your recent activity.</p>
+          : activeLoading
+            ? skeleton
+            : !activeTxs.length
+              ? emptyState
+              : renderTxRows(activeTxs)
+        }
       </CardContent>
     </Card>
   );

--- a/mercata/ui/src/components/dashboard/DashboardHeader.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardHeader.tsx
@@ -42,7 +42,7 @@ const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
   // Handle back navigation - check for 'from' query param for bridge-transactions page
   const handleBackClick = () => {
     const fromPage = searchParams.get('from');
-    if (pathname === '/bridge-transactions' && fromPage) {
+    if ((pathname === '/bridge-transactions' || pathname === '/metal-transactions') && fromPage) {
       if (fromPage === 'deposits') {
         navigate('/dashboard/deposits');
       } else if (fromPage === 'withdrawals') {

--- a/mercata/ui/src/components/dashboard/MetalTransactionDetails.tsx
+++ b/mercata/ui/src/components/dashboard/MetalTransactionDetails.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { CheckCircle2 } from "lucide-react";
+import { Table } from "antd";
+import { FrownOutlined } from "@ant-design/icons";
+import { ITEMS_PER_PAGE } from "@/lib/bridge/constants";
+import { formatDate } from "@/lib/bridge/utils";
+import { formatWeiToDecimalHP } from "@/utils/numberUtils";
+import { activityFeedApi } from "@/lib/activityFeed";
+import { METAL_ACTIVITY_PAIR, MetalTx, resolveTokenSymbols, collectMetalTokenAddrs, mapEventsToMetalTxs } from "@/lib/metalActivity";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+async function fetchMetalPage(page: number): Promise<{ txs: MetalTx[]; total: number }> {
+  const result = await activityFeedApi.getActivities(
+    METAL_ACTIVITY_PAIR,
+    { limit: ITEMS_PER_PAGE, offset: (page - 1) * ITEMS_PER_PAGE, myActivity: true }
+  );
+  const events = result.events || [];
+  const symbolMap = await resolveTokenSymbols([...collectMetalTokenAddrs(events)]);
+  return { total: result.total || 0, txs: mapEventsToMetalTxs(events, symbolMap) };
+}
+
+const columns = [
+  {
+    title: "Paid", key: "paid", width: 180,
+    render: (_: unknown, r: MetalTx) => (
+      <span className="text-sm text-foreground">{formatWeiToDecimalHP(r.payAmount, 18)} {r.paySymbol}</span>
+    ),
+  },
+  {
+    title: "Received", key: "received", width: 180,
+    render: (_: unknown, r: MetalTx) => (
+      <span className="text-sm text-foreground">{formatWeiToDecimalHP(r.metalAmount, 18)} {r.metalSymbol}</span>
+    ),
+  },
+  {
+    title: "Status", key: "status", width: 120,
+    render: () => (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+        <CheckCircle2 className="h-3 w-3 mr-1" />
+        Completed
+      </span>
+    ),
+  },
+  {
+    title: "Time", dataIndex: "block_timestamp", key: "block_timestamp", width: 200,
+    render: (text: string) => formatDate(text),
+  },
+];
+
+const MetalTransactionDetails = () => {
+  const isMobile = useIsMobile();
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [transactions, setTransactions] = useState<MetalTx[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [initialized, setInitialized] = useState(false);
+
+  const loadPage = async (page: number) => {
+    setIsLoading(true);
+    try {
+      const { txs, total } = await fetchMetalPage(page);
+      setTransactions(txs);
+      setTotalCount(total);
+    } catch {
+      setTransactions([]);
+      setTotalCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!initialized) {
+    setInitialized(true);
+    loadPage(1);
+  }
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    loadPage(page);
+  };
+
+  return (
+    <div className="bg-card rounded-xl shadow-sm border border-border overflow-x-auto ant-table-themed">
+      <Table
+        columns={columns}
+        dataSource={transactions}
+        loading={isLoading}
+        scroll={isMobile ? { x: 'max-content' } : undefined}
+        pagination={{
+          current: currentPage,
+          total: totalCount,
+          pageSize: ITEMS_PER_PAGE,
+          onChange: handlePageChange,
+          showSizeChanger: false,
+          showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} items`,
+          simple: isMobile,
+        }}
+        locale={{
+          emptyText: (
+            <div className="py-12 text-center text-muted-foreground">
+              <div className="flex flex-col items-center justify-center gap-2">
+                <FrownOutlined style={{ fontSize: 48, color: "currentColor" }} />
+                <span className="text-lg font-semibold text-muted-foreground">No metal purchases found</span>
+              </div>
+            </div>
+          ),
+        }}
+        rowKey={(_, index) => index}
+      />
+    </div>
+  );
+};
+
+export default MetalTransactionDetails;

--- a/mercata/ui/src/lib/metalActivity.ts
+++ b/mercata/ui/src/lib/metalActivity.ts
@@ -1,0 +1,55 @@
+import { api } from '@/lib/axios';
+import type { Event } from '@mercata/shared-types';
+
+export const METAL_ACTIVITY_PAIR = [
+  { contract_name: "MetalForge", event_name: "MetalMinted", filterConfig: { type: "single" as const, attribute: "buyer" } }
+];
+
+export interface MetalTx {
+  block_timestamp: string;
+  payAmount: string;
+  paySymbol: string;
+  metalAmount: string;
+  metalSymbol: string;
+}
+
+export async function resolveTokenSymbols(addresses: string[]): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  if (!addresses.length) return map;
+  const results = await Promise.all(
+    addresses.map(async (addr) => {
+      try {
+        const res = await api.get(`/tokens/${addr}`);
+        const token = Array.isArray(res.data) ? res.data[0] : res.data;
+        return { addr, symbol: token?._symbol || "" };
+      } catch { return { addr, symbol: "" }; }
+    })
+  );
+  for (const { addr, symbol } of results) {
+    if (symbol) { map.set(addr, symbol); map.set(addr.toLowerCase(), symbol); }
+  }
+  return map;
+}
+
+export function collectMetalTokenAddrs(events: Event[]): Set<string> {
+  const addrs = new Set<string>();
+  for (const e of events) {
+    const a = e.attributes || {};
+    if (a.metalToken) addrs.add(a.metalToken);
+    if (a.payToken) addrs.add(a.payToken);
+  }
+  return addrs;
+}
+
+export function mapEventsToMetalTxs(events: Event[], symbolMap: Map<string, string>): MetalTx[] {
+  return events.map((e) => {
+    const a = e.attributes || {};
+    return {
+      block_timestamp: e.block_timestamp || "",
+      payAmount: a.payAmount || "0",
+      paySymbol: symbolMap.get(a.payToken) || symbolMap.get(a.payToken?.toLowerCase()) || "-",
+      metalAmount: a.metalAmount || "0",
+      metalSymbol: symbolMap.get(a.metalToken) || symbolMap.get(a.metalToken?.toLowerCase()) || "-",
+    };
+  });
+}

--- a/mercata/ui/src/pages/DepositsPage.tsx
+++ b/mercata/ui/src/pages/DepositsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DashboardHeader from '../components/dashboard/DashboardHeader';
 import DashboardSidebar from '../components/dashboard/DashboardSidebar';
 import MobileBottomNav from '../components/dashboard/MobileBottomNav';
@@ -11,6 +11,9 @@ import GuestSignInBanner from '@/components/ui/GuestSignInBanner';
 const DepositsPage = () => {
   const { isLoggedIn } = useUser();
   const { loadNetworksAndTokens } = useBridgeContext();
+  const [fundingMode, setFundingMode] = useState<"bridge" | "metals">("bridge");
+  const [metalRefreshKey, setMetalRefreshKey] = useState(0);
+  const handleMetalPurchase = useCallback(() => setMetalRefreshKey(k => k + 1), []);
 
   useEffect(() => {
     loadNetworksAndTokens().catch((error) => {
@@ -25,16 +28,16 @@ const DepositsPage = () => {
 
       <div className="h-screen flex flex-col transition-all duration-300" style={{ paddingLeft: 'var(--sidebar-width, 0px)' }}>
         <DashboardHeader title="Fund" subtitle="Bring assets onto STRATO and start earning" />
-        <main className="flex-1 p-4 md:p-6 pb-16 md:pb-6 overflow-y-auto">
+        <main className="flex-1 p-4 md:p-6 pb-16 md:pb-6 overflow-y-auto" style={{ scrollbarWidth: "none" }}>
           {!isLoggedIn && (
             <GuestSignInBanner message="Sign in to deposit and start earning" />
           )}
           <div className="mb-8 grid grid-cols-1 xl:grid-cols-12 gap-6">
             <div className="xl:col-span-7">
-              <BridgeIn guestMode={!isLoggedIn} />
+              <BridgeIn guestMode={!isLoggedIn} fundingMode={fundingMode} onFundingModeChange={setFundingMode} onMetalPurchase={handleMetalPurchase} />
             </div>
             <div className="xl:col-span-5">
-              <RecentTransactions />
+              <RecentTransactions fundingMode={fundingMode} metalRefreshKey={metalRefreshKey} />
             </div>
           </div>
         </main>

--- a/mercata/ui/src/pages/MetalTransactionsPage.tsx
+++ b/mercata/ui/src/pages/MetalTransactionsPage.tsx
@@ -1,0 +1,21 @@
+import DashboardSidebar from '@/components/dashboard/DashboardSidebar';
+import DashboardHeader from '@/components/dashboard/DashboardHeader';
+import MobileBottomNav from '@/components/dashboard/MobileBottomNav';
+import MetalTransactionDetails from '@/components/dashboard/MetalTransactionDetails';
+
+const MetalTransactionsPage = () => {
+  return (
+    <div className="h-screen bg-background overflow-hidden pb-16 md:pb-0">
+      <DashboardSidebar />
+      <div className="h-screen flex flex-col transition-all duration-300" style={{ paddingLeft: 'var(--sidebar-width, 0px)' }}>
+        <DashboardHeader title="Metal Purchases" />
+        <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6 overflow-y-auto">
+          <MetalTransactionDetails />
+        </main>
+      </div>
+      <MobileBottomNav />
+    </div>
+  );
+};
+
+export default MetalTransactionsPage;


### PR DESCRIPTION
- RecentTransactions shows deposits+withdrawals on Bridge In tab, metal purchases on Buy Metals tab (context-aware via fundingMode prop)
- New /metal-transactions page with paginated MetalMinted history
- Step 3 cards: horizontal scroll carousel with arrows when 4+ cards
- Shared metal activity helpers (metalActivity.ts) for token resolution
- Hidden page scrollbar on Fund page
- No backend changes -- metals use existing /events/activities endpoint
