### PR TITLE
Use pools from SwapContext in SwapPoolsSection

### DIFF
--- a/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
+++ b/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
@@ -19,18 +19,17 @@ const SwapPoolsSection = () => {
   const [selectedPool, setSelectedPool] = useState<Pool | null>(null);
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
-  const [pools, setPools] = useState<Pool[]>([]);
   const [loading, setLoading] = useState(false);
   const poolPollIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const operationInProgressRef = useRef(false);
 
-  const { fetchPools, getPoolByAddress } = useSwapContext();
+  const { pools, poolsLoading, fetchPools, getPoolByAddress } = useSwapContext();
   const { fetchUsdstBalance, usdstBalance, voucherBalance } = useTokenContext();
   const { isLoggedIn } = useUser();
   const { userRewards, loading: rewardsLoading } = useRewardsUserInfo();
 
   useEffect(() => {
-    fetchAndEnrichPools();
+    fetchPools();
   }, [fetchPools]);
 
   useEffect(() => {
@@ -66,20 +65,6 @@ const SwapPoolsSection = () => {
     }
   }, [selectedPool?.address, isDepositModalOpen, getPoolByAddress, fetchUsdstBalance]);
 
-  const fetchAndEnrichPools = async () => {
-    if (operationInProgressRef.current) return;
-    
-    try {
-      setLoading(true);
-      const tempPools = await fetchPools();
-      setPools(tempPools);
-    } catch (err) {
-      console.error("Failed to fetch pools:", err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const handleOpenDepositModal = async (pool: Pool) => {
     if (operationInProgressRef.current) return;
     
@@ -106,13 +91,13 @@ const SwapPoolsSection = () => {
 
   const handleDepositSuccess = async () => {
     // Refresh all data after successful deposit
-    await fetchAndEnrichPools();
+    await fetchPools();
     await fetchUsdstBalance();
   };
 
   const handleWithdrawSuccess = async () => {
     // Refresh all data after successful withdrawal
-    await fetchAndEnrichPools();
+    await fetchPools();
     await fetchUsdstBalance();
   };
 


### PR DESCRIPTION
Instead of fetching them on load in advanced swap tab, use the pools list from the swapContext. The GET /swap-pools takes >5 seconds due to the new APY calculations, and blocking the swap pool table on this call causes poor UX. Instead, when the user navigates to the swap pools tab from elsewhere in the app, the table shows up immediately, and the GET /swap-pools call loads in the background.