### PR TITLE
SaveUSDST implementation

### DIFF
--- a/mercata/backend/src/api/controllers/config.controller.ts
+++ b/mercata/backend/src/api/controllers/config.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { networkId, creditCardTopUp } from "../../config/config";
+import { networkId, creditCardTopUp, featuredEarnOpportunity } from "../../config/config";
 
 class ConfigController {
   static async getConfig(req: Request, res: Response) {
@@ -11,6 +11,7 @@ class ConfigController {
           projectId: process.env.WAGMI_PROJECT_ID || 'PROJECT_ID_UNSET',
           networkId: networkId,
           creditCardTopUpAddress: creditCardTopUp || undefined,
+          featuredEarnOpportunity: featuredEarnOpportunity || undefined,
           stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || null,
         }
       });

--- a/mercata/backend/src/api/controllers/saveUsdst.controller.ts
+++ b/mercata/backend/src/api/controllers/saveUsdst.controller.ts
@@ -1,0 +1,101 @@
+import { Request, Response, NextFunction } from "express";
+import RestStatus from "http-status-codes";
+import {
+  depositSaveUsdst,
+  getSaveUsdstInfo,
+  getSaveUsdstUserInfo,
+  redeemAllSaveUsdst,
+  redeemSaveUsdst,
+} from "../services/saveUsdst.service";
+
+const isPositiveIntegerString = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  if (!/^\d+$/.test(value.trim())) return false;
+
+  try {
+    return BigInt(value) > 0n;
+  } catch {
+    return false;
+  }
+};
+
+class SaveUsdstController {
+  static async getInfo(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const info = await getSaveUsdstInfo(req.accessToken);
+      res.status(RestStatus.OK).json(info);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getUserInfo(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const info = await getSaveUsdstUserInfo(req.accessToken, req.address as string);
+      res.status(RestStatus.OK).json(info);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async deposit(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { amount } = req.body || {};
+      if (!isPositiveIntegerString(amount)) {
+        res.status(RestStatus.BAD_REQUEST).json({ error: "Invalid amount" });
+        return;
+      }
+
+      const result = await depositSaveUsdst(req.accessToken, req.address as string, amount);
+      res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async redeem(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { sharesAmount } = req.body || {};
+      if (!isPositiveIntegerString(sharesAmount)) {
+        res.status(RestStatus.BAD_REQUEST).json({ error: "Invalid shares amount" });
+        return;
+      }
+
+      const result = await redeemSaveUsdst(req.accessToken, req.address as string, sharesAmount);
+      res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async redeemAll(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const result = await redeemAllSaveUsdst(req.accessToken, req.address as string);
+      res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default SaveUsdstController;

--- a/mercata/backend/src/api/routes/earn.routes.ts
+++ b/mercata/backend/src/api/routes/earn.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import authHandler from "../middleware/authHandler";
 import EarnController from "../controllers/earn.controller";
+import SaveUsdstController from "../controllers/saveUsdst.controller";
 
 const router = Router();
 
@@ -19,5 +20,11 @@ const router = Router();
  *         description: Unauthorized
  */
 router.get("/token-apys", authHandler.authorizeRequest(true), EarnController.getTokenApys);
+
+router.get("/save-usdst/info", authHandler.authorizeRequest(true), SaveUsdstController.getInfo);
+router.get("/save-usdst/user", authHandler.authorizeRequest(), SaveUsdstController.getUserInfo);
+router.post("/save-usdst/deposit", authHandler.authorizeRequest(), SaveUsdstController.deposit);
+router.post("/save-usdst/redeem", authHandler.authorizeRequest(), SaveUsdstController.redeem);
+router.post("/save-usdst/redeem-all", authHandler.authorizeRequest(), SaveUsdstController.redeemAll);
 
 export default router;

--- a/mercata/backend/src/api/services/saveUsdst.service.ts
+++ b/mercata/backend/src/api/services/saveUsdst.service.ts
@@ -1,0 +1,395 @@
+import { cirrus, strato } from "../../utils/mercataApiHelper";
+import { buildFunctionTx } from "../../utils/txBuilder";
+import { postAndWaitForTx } from "../../utils/txHelper";
+import { StratoPaths, constants } from "../../config/constants";
+import * as config from "../../config/config";
+import { FunctionInput } from "../../types/types";
+
+const { SaveUSDSTVault, Token, USDST } = constants;
+
+const WAD = 10n ** 18n;
+
+export interface SaveUsdstInfo {
+  configured: boolean;
+  deployed: boolean;
+  vaultAddress: string;
+  assetAddress: string;
+  assetSymbol: string;
+  shareSymbol: string;
+  totalManagedAssets: string;
+  totalAssets: string;
+  pricingAssets: string;
+  totalShares: string;
+  exchangeRate: string;
+  apy: string;
+  paused: boolean;
+}
+
+export interface SaveUsdstUserInfo extends SaveUsdstInfo {
+  walletAssets: string;
+  userShares: string;
+  redeemableAssets: string;
+  maxDeposit: string;
+  maxRedeem: string;
+  maxWithdraw: string;
+  userTotalDepositedAssets: string;
+  userTotalWithdrawnAssets: string;
+  userNetDepositedAssets: string;
+  userAllTimeEarningsAssets: string;
+}
+
+const emptyInfo = (): SaveUsdstInfo => ({
+  configured: Boolean(config.saveUsdstVault),
+  deployed: false,
+  vaultAddress: config.saveUsdstVault || "",
+  assetAddress: USDST,
+  assetSymbol: "USDST",
+  shareSymbol: "saveUSDST",
+  totalManagedAssets: "0",
+  totalAssets: "0",
+  pricingAssets: "0",
+  totalShares: "0",
+  exchangeRate: WAD.toString(),
+  apy: "-",
+  paused: false,
+});
+
+const emptyUserInfo = (): SaveUsdstUserInfo => ({
+  ...emptyInfo(),
+  walletAssets: "0",
+  userShares: "0",
+  redeemableAssets: "0",
+  maxDeposit: "0",
+  maxRedeem: "0",
+  maxWithdraw: "0",
+  userTotalDepositedAssets: "0",
+  userTotalWithdrawnAssets: "0",
+  userNetDepositedAssets: "0",
+  userAllTimeEarningsAssets: "0",
+});
+
+const normalizeAddress = (value: string | undefined | null): string =>
+  (value || "").toLowerCase().replace(/^0x/, "");
+
+const parseBigIntLike = (value: unknown): bigint => {
+  if (value === null || value === undefined) return 0n;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+
+  const raw = String(value).trim();
+  if (!raw) return 0n;
+
+  try {
+    return BigInt(raw);
+  } catch {
+    return 0n;
+  }
+};
+
+const parseEventAttributes = (attributes: unknown): Record<string, any> => {
+  if (!attributes) return {};
+  if (typeof attributes === "string") {
+    try {
+      return JSON.parse(attributes);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof attributes === "object") return attributes as Record<string, any>;
+  return {};
+};
+
+const getExchangeRate = (pricingAssets: bigint, totalShares: bigint): bigint => {
+  if (totalShares <= 0n) return WAD;
+  if (pricingAssets <= 0n) return 0n;
+  return (pricingAssets * WAD) / totalShares;
+};
+
+const requireSaveUsdstVaultAddress = (): string => {
+  const vaultAddress = config.saveUsdstVault || process.env.SAVE_USDST_VAULT || "";
+  if (!vaultAddress) {
+    throw new Error("SAVE_USDST_VAULT is not configured");
+  }
+  return vaultAddress;
+};
+
+const getAssetBalance = async (
+  accessToken: string,
+  tokenAddress: string,
+  ownerAddress: string
+): Promise<string> => {
+  const { data } = await cirrus.get(accessToken, `/${Token}-_balances`, {
+    params: {
+      address: `eq.${tokenAddress}`,
+      key: `eq.${ownerAddress}`,
+      select: "value::text",
+    },
+  });
+
+  return data?.[0]?.value || "0";
+};
+
+const getVaultShareBalance = async (
+  accessToken: string,
+  vaultAddress: string,
+  ownerAddress: string
+): Promise<string> => {
+  const { data } = await cirrus.get(accessToken, `/${SaveUSDSTVault}-_balances`, {
+    params: {
+      address: `eq.${vaultAddress}`,
+      key: `eq.${ownerAddress}`,
+      select: "value::text",
+    },
+  });
+
+  if (data?.[0]?.value) {
+    return data[0].value;
+  }
+
+  return await getAssetBalance(accessToken, vaultAddress, ownerAddress);
+};
+
+const getVaultState = async (accessToken: string): Promise<Record<string, any> | null> => {
+  if (!config.saveUsdstVault) {
+    return null;
+  }
+
+  const { data } = await cirrus.get(accessToken, `/${SaveUSDSTVault}`, {
+    params: {
+      address: `eq.${config.saveUsdstVault}`,
+      select: "address,assetToken,_managedAssets::text,_paused,_symbol,_totalSupply::text",
+    },
+  });
+
+  return data?.[0] || null;
+};
+
+const getUserFlowTotals = async (
+  accessToken: string,
+  vaultAddress: string,
+  userAddress: string
+): Promise<{ totalDepositedAssets: bigint; totalWithdrawnAssets: bigint }> => {
+  const normalizedUser = normalizeAddress(userAddress);
+  if (!vaultAddress || !normalizedUser) {
+    return { totalDepositedAssets: 0n, totalWithdrawnAssets: 0n };
+  }
+
+  const pageSize = 1000;
+  let offset = 0;
+  let totalDepositedAssets = 0n;
+  let totalWithdrawnAssets = 0n;
+
+  try {
+    while (true) {
+      const response = await cirrus.get(accessToken, "/event", {
+        params: {
+          address: `eq.${vaultAddress}`,
+          event_name: "in.(Deposit,Withdraw)",
+          select: "event_name,attributes,transaction_sender,block_timestamp",
+          order: "block_timestamp.asc",
+          limit: `${pageSize}`,
+          offset: `${offset}`,
+        },
+      });
+
+      const events = response?.data || [];
+      if (!Array.isArray(events) || events.length === 0) break;
+
+      for (const event of events) {
+        const attrs = parseEventAttributes(event.attributes);
+        const actor = normalizeAddress(
+          attrs.owner ||
+            attrs.ownerAddress ||
+            attrs.receiver ||
+            attrs.caller ||
+            event.transaction_sender
+        );
+
+        if (!actor || actor !== normalizedUser) continue;
+
+        if (event.event_name === "Deposit") {
+          totalDepositedAssets += parseBigIntLike(attrs.assets);
+        } else if (event.event_name === "Withdraw") {
+          totalWithdrawnAssets += parseBigIntLike(attrs.assets);
+        }
+      }
+
+      if (events.length < pageSize) break;
+      offset += pageSize;
+    }
+  } catch (error) {
+    console.warn("Failed to compute saveUSDST flow totals:", error);
+  }
+
+  return { totalDepositedAssets, totalWithdrawnAssets };
+};
+
+export const getSaveUsdstInfo = async (accessToken: string): Promise<SaveUsdstInfo> => {
+  const fallback = emptyInfo();
+  const vaultState = await getVaultState(accessToken);
+
+  if (!vaultState) {
+    return fallback;
+  }
+
+  const vaultAddress = vaultState.address || config.saveUsdstVault;
+  const assetAddress = vaultState.assetToken || USDST;
+  const [assetToken, liveAssetBalance] = await Promise.all([
+    cirrus.get(accessToken, `/${Token}`, {
+      params: {
+        address: `eq.${assetAddress}`,
+        select: "_symbol",
+      },
+    }),
+    getAssetBalance(accessToken, assetAddress, vaultAddress),
+  ]);
+
+  const totalManagedAssets = parseBigIntLike(vaultState._managedAssets);
+  const totalAssets = parseBigIntLike(liveAssetBalance);
+  const pricingAssets = totalAssets < totalManagedAssets ? totalAssets : totalManagedAssets;
+  const totalShares = parseBigIntLike(vaultState._totalSupply);
+  const exchangeRate = getExchangeRate(pricingAssets, totalShares);
+
+  return {
+    configured: true,
+    deployed: true,
+    vaultAddress,
+    assetAddress,
+    assetSymbol: assetToken?.data?.[0]?._symbol || "USDST",
+    shareSymbol: vaultState._symbol || "saveUSDST",
+    totalManagedAssets: totalManagedAssets.toString(),
+    totalAssets: totalAssets.toString(),
+    pricingAssets: pricingAssets.toString(),
+    totalShares: totalShares.toString(),
+    exchangeRate: exchangeRate.toString(),
+    apy: "-",
+    paused: Boolean(vaultState._paused),
+  };
+};
+
+export const getSaveUsdstUserInfo = async (
+  accessToken: string,
+  userAddress: string
+): Promise<SaveUsdstUserInfo> => {
+  const info = await getSaveUsdstInfo(accessToken);
+  if (!info.deployed) {
+    return {
+      ...emptyUserInfo(),
+      configured: info.configured,
+      vaultAddress: info.vaultAddress,
+    };
+  }
+
+  const [walletAssetsRaw, userSharesRaw, flows] = await Promise.all([
+    getAssetBalance(accessToken, info.assetAddress, userAddress),
+    getVaultShareBalance(accessToken, info.vaultAddress, userAddress),
+    getUserFlowTotals(accessToken, info.vaultAddress, userAddress),
+  ]);
+
+  const walletAssets = parseBigIntLike(walletAssetsRaw);
+  const userShares = parseBigIntLike(userSharesRaw);
+  const pricingAssets = parseBigIntLike(info.pricingAssets);
+  const totalShares = parseBigIntLike(info.totalShares);
+  const redeemableAssets =
+    userShares > 0n && totalShares > 0n && pricingAssets > 0n
+      ? (userShares * pricingAssets) / totalShares
+      : 0n;
+
+  const userNetDepositedAssets = flows.totalDepositedAssets - flows.totalWithdrawnAssets;
+  const userAllTimeEarningsAssets = redeemableAssets - userNetDepositedAssets;
+
+  return {
+    ...info,
+    walletAssets: walletAssets.toString(),
+    userShares: userShares.toString(),
+    redeemableAssets: redeemableAssets.toString(),
+    maxDeposit: info.paused ? "0" : walletAssets.toString(),
+    maxRedeem: info.paused ? "0" : userShares.toString(),
+    maxWithdraw: info.paused ? "0" : redeemableAssets.toString(),
+    userTotalDepositedAssets: flows.totalDepositedAssets.toString(),
+    userTotalWithdrawnAssets: flows.totalWithdrawnAssets.toString(),
+    userNetDepositedAssets: userNetDepositedAssets.toString(),
+    userAllTimeEarningsAssets: userAllTimeEarningsAssets.toString(),
+  };
+};
+
+export const depositSaveUsdst = async (
+  accessToken: string,
+  userAddress: string,
+  amount: string
+): Promise<{ status: string; hash: string }> => {
+  const info = await getSaveUsdstInfo(accessToken);
+  const vaultAddress = requireSaveUsdstVaultAddress();
+  if (!info.deployed) {
+    throw new Error("saveUSDST vault is not deployed");
+  }
+
+  const txs: FunctionInput[] = [
+    {
+      contractName: "Token",
+      contractAddress: info.assetAddress || USDST,
+      method: "approve",
+      args: {
+        spender: vaultAddress,
+        value: amount,
+      },
+    },
+    {
+      contractName: "SaveUSDSTVault",
+      contractAddress: vaultAddress,
+      method: "deposit",
+      args: {
+        assets: amount,
+        receiver: userAddress,
+      },
+    },
+  ];
+
+  const builtTx = await buildFunctionTx(txs, userAddress, accessToken);
+  return await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, builtTx)
+  );
+};
+
+export const redeemSaveUsdst = async (
+  accessToken: string,
+  userAddress: string,
+  sharesAmount: string
+): Promise<{ status: string; hash: string }> => {
+  const info = await getSaveUsdstInfo(accessToken);
+  const vaultAddress = requireSaveUsdstVaultAddress();
+  if (!info.deployed) {
+    throw new Error("saveUSDST vault is not deployed");
+  }
+
+  const builtTx = await buildFunctionTx(
+    {
+      contractName: "SaveUSDSTVault",
+      contractAddress: vaultAddress,
+      method: "redeem",
+      args: {
+        shares: sharesAmount,
+        receiver: userAddress,
+        ownerAddress: userAddress,
+      },
+    },
+    userAddress,
+    accessToken
+  );
+
+  return await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, builtTx)
+  );
+};
+
+export const redeemAllSaveUsdst = async (
+  accessToken: string,
+  userAddress: string
+): Promise<{ status: string; hash: string }> => {
+  const userInfo = await getSaveUsdstUserInfo(accessToken, userAddress);
+  if (parseBigIntLike(userInfo.userShares) <= 0n) {
+    throw new Error("No saveUSDST shares to redeem");
+  }
+
+  return await redeemSaveUsdst(accessToken, userAddress, userInfo.userShares);
+};

--- a/mercata/backend/src/api/services/tokens.v2.service.ts
+++ b/mercata/backend/src/api/services/tokens.v2.service.ts
@@ -2,12 +2,46 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { getCompletePriceMap } from "../helpers/oracle.helper";
 import { getVaultShareTokenAddress, getVaultHistoryConfig } from "./vault.service";
+import { getSaveUsdstInfo, getSaveUsdstUserInfo } from "./saveUsdst.service";
 import { Token, EarningAsset, BalanceSnapshot } from "@mercata/shared-types";
 import { buildTokenSelectFields } from "../../config/tokensConstants";
 import { getHistory, HistoryParams, HistorySnapshot, MappingHistoryElement, StorageHistoryElement } from "../helpers/history.helper";
 import { calculateLPTokenPrice } from "../helpers/swapping.helper";
 
 const { Token, CollateralVault, CDPEngine, DECIMALS } = constants;
+
+const buildSaveUsdstEarningAsset = (
+  info: Awaited<ReturnType<typeof getSaveUsdstInfo>>,
+  userInfo?: Awaited<ReturnType<typeof getSaveUsdstUserInfo>>
+): EarningAsset | null => {
+  if (!info.deployed || !info.vaultAddress) return null;
+
+  const balance = userInfo?.userShares || "0";
+  const totalBalance = balance;
+  const price = info.exchangeRate || "0";
+  const redeemableValueUsd = userInfo?.redeemableAssets || "0";
+  const value = (Number(BigInt(redeemableValueUsd || "0")) / 1e18).toFixed(2);
+
+  return {
+    address: info.vaultAddress,
+    _name: "Save USDST",
+    _symbol: info.shareSymbol || "saveUSDST",
+    _owner: "",
+    _totalSupply: info.totalShares || "0",
+    customDecimals: 18,
+    description: "Native USDST savings token",
+    status: "2",
+    _paused: info.paused,
+    balance,
+    images: [],
+    attributes: [],
+    price,
+    collateralBalance: "0",
+    totalBalance,
+    isPoolToken: false,
+    value,
+  };
+};
 
 export const getTokens = async (
   accessToken: string,
@@ -47,7 +81,7 @@ export const getEarningAssets = async (
   accessToken: string,
   userAddress: string
 ): Promise<EarningAsset[]> => {
-  const [tokens, collaterals, cdps, rawPrices, vaultShareToken] = await Promise.all([
+  const [tokens, collaterals, cdps, rawPrices, vaultShareToken, saveUsdstInfo, saveUsdstUserInfo] = await Promise.all([
     cirrus.get(accessToken, "/" + Token, {
       params: {
         "balances.key": `eq.${userAddress}`,
@@ -75,6 +109,8 @@ export const getEarningAssets = async (
     }),
     getCompletePriceMap(accessToken),
     getVaultShareTokenAddress(accessToken),
+    getSaveUsdstInfo(accessToken).catch(() => null),
+    getSaveUsdstUserInfo(accessToken, userAddress).catch(() => null),
   ]);
 
   const collateralMap = new Map<string, bigint>();
@@ -85,7 +121,7 @@ export const getEarningAssets = async (
     )
   );
 
-  return (tokens.data || []).map((t: any) => {
+  const earningAssets = (tokens.data || []).map((t: any) => {
     const balance = t.balances?.[0]?.balance || "0";
     const price = rawPrices.get(t.address) || "0";
     const collateralBalance = (collateralMap.get(t.address) || 0n).toString();
@@ -112,6 +148,20 @@ export const getEarningAssets = async (
       value,
     };
   });
+
+  const saveUsdstAsset =
+    saveUsdstInfo && saveUsdstUserInfo && BigInt(saveUsdstUserInfo.userShares || "0") > 0n
+      ? buildSaveUsdstEarningAsset(saveUsdstInfo, saveUsdstUserInfo)
+      : null;
+
+  if (
+    saveUsdstAsset &&
+    !earningAssets.some((asset: EarningAsset) => asset.address.toLowerCase() === saveUsdstAsset.address.toLowerCase())
+  ) {
+    earningAssets.push(saveUsdstAsset);
+  }
+
+  return earningAssets;
 };
 
 export const getPublicEarningAssets = async (
@@ -128,13 +178,14 @@ export const getPublicEarningAssets = async (
   };
 
   // Fetch only tokens and prices (skip user-specific collateral data)
-  const [tokens, rawPrices, vaultShareToken] = await Promise.all([
+  const [tokens, rawPrices, vaultShareToken, saveUsdstInfo] = await Promise.all([
     cirrus.get(accessToken, "/" + Token, { params: tokenParams }),
     getCompletePriceMap(accessToken),
     getVaultShareTokenAddress(accessToken),
+    getSaveUsdstInfo(accessToken).catch(() => null),
   ]);
 
-  return (tokens.data || []).map((t: any) => {
+  const earningAssets = (tokens.data || []).map((t: any) => {
     const balance = "0";
     const price = rawPrices.get(t.address) || "0";
     const collateralBalance = "0";
@@ -156,6 +207,16 @@ export const getPublicEarningAssets = async (
       value,
     };
   });
+
+  const saveUsdstAsset = saveUsdstInfo ? buildSaveUsdstEarningAsset(saveUsdstInfo) : null;
+  if (
+    saveUsdstAsset &&
+    !earningAssets.some((asset: EarningAsset) => asset.address.toLowerCase() === saveUsdstAsset.address.toLowerCase())
+  ) {
+    earningAssets.push(saveUsdstAsset);
+  }
+
+  return earningAssets;
 };
 
 function updatePortfolioInfoStorage(portfolioInfo: any, newInfo: StorageHistoryElement): any {

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -53,6 +53,8 @@ export const cdpRegistry = process.env.CDP_REGISTRY || "000000000000000000000000
 
 export const safetyModule = process.env.SAFETY_MODULE || "0000000000000000000000000000000000001015";
 export const sToken = process.env.SUSDST_ADDRESS || "0000000000000000000000000000000000001016";
+export const saveUsdstVault = process.env.SAVE_USDST_VAULT || "eee43786dfefc01add3dfddfc21e36df6350cf65";
+export const featuredEarnOpportunity = process.env.FEATURED_EARN_OPPORTUNITY || "save-usdst";
 
 // Hidden swap pools - these pools are filtered out from API responses
 export const hiddenSwapPools: Set<string> = new Set([

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -53,7 +53,7 @@ export const cdpRegistry = process.env.CDP_REGISTRY || "000000000000000000000000
 
 export const safetyModule = process.env.SAFETY_MODULE || "0000000000000000000000000000000000001015";
 export const sToken = process.env.SUSDST_ADDRESS || "0000000000000000000000000000000000001016";
-export const saveUsdstVault = process.env.SAVE_USDST_VAULT || "eee43786dfefc01add3dfddfc21e36df6350cf65";
+export const saveUsdstVault = process.env.SAVE_USDST_VAULT || "ceeb982f671b4ee2b4471e5b49f3126739537f15";
 export const featuredEarnOpportunity = process.env.FEATURED_EARN_OPPORTUNITY || "save-usdst";
 
 // Hidden swap pools - these pools are filtered out from API responses

--- a/mercata/backend/src/config/constants.ts
+++ b/mercata/backend/src/config/constants.ts
@@ -37,6 +37,7 @@ export const constants = (() => {
   const Voucher = `${CONTRACT_PREFIX}Voucher`;
   const Vault = `${CONTRACT_PREFIX}Vault`;
   const VaultFactory = `${CONTRACT_PREFIX}VaultFactory`;
+  const SaveUSDSTVault = `${CONTRACT_PREFIX}SaveUSDSTVault`;
   const MetalForge = `${CONTRACT_PREFIX}MetalForge`;
   const SafetyModule = `${CONTRACT_PREFIX}SafetyModule`;
   const Event = "event";
@@ -147,6 +148,7 @@ export const constants = (() => {
     Voucher,
     Vault,
     VaultFactory,
+    SaveUSDSTVault,
     MetalForge,
     SafetyModule,
     get metalForge() { return config.metalForge; },

--- a/mercata/contracts/concrete/BaseCodeCollection.sol
+++ b/mercata/contracts/concrete/BaseCodeCollection.sol
@@ -35,6 +35,9 @@ import "Lending/PriceOracle.sol";
 import "Lending/RateStrategy.sol";
 import "Lending/SafetyModule.sol";
 
+//Savings
+import "Savings/SaveUSDSTVault.sol";
+
 //Bridging
 import "./Bridge/MercataBridge.sol";
 
@@ -72,6 +75,7 @@ contract record Mercata is Authorizable {
     CDPRegistry public cdpRegistry;
     CDPReserve public cdpReserve;
     SafetyModule public safetyModule;
+    SaveUSDSTVault public saveUSDSTVault;
     Rewards public rewards;
     Token public cataToken;
     Escrow public escrow;
@@ -163,6 +167,12 @@ contract record Mercata is Authorizable {
         rewards = Rewards(address(new Proxy(rewardsImpl, this)));
         rewards.initialize(address(cataToken));
         Ownable(rewards).transferOwnership(address(0x000000000000000000000000000000000000100c));
+
+        // Create native USDST savings vault
+        address saveUSDSTVaultImpl = address(new SaveUSDSTVault(implOwnerIgnored));
+        saveUSDSTVault = SaveUSDSTVault(address(new Proxy(saveUSDSTVaultImpl, this)));
+        saveUSDSTVault.initialize(address(0x937efa7e3a77e20bbdbd7c0d32b6514f368c1010), "Save USDST", "saveUSDST");
+        Ownable(saveUSDSTVault).transferOwnership(address(adminRegistry));
 
         // Deploy CDP registry, vault, and engine
         address cdpRegistryImpl = address(new CDPRegistry(implOwnerIgnored));

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -77,13 +77,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
 
     function maxWithdraw(address ownerAddress) public view returns (uint256) {
         if (!vaultInitialized || paused()) return 0;
-        uint256 assets = _convertToAssets(balanceOf(ownerAddress), false);
-        uint256 available = _managedAssets;
-        uint256 liveBalance = IERC20(assetToken).balanceOf(address(this));
-        if (liveBalance < available) {
-            available = liveBalance;
-        }
-        return assets < available ? assets : available;
+        return _convertToAssets(balanceOf(ownerAddress), false);
     }
 
     function maxRedeem(address ownerAddress) public view returns (uint256) {
@@ -142,7 +136,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function exchangeRate() external view returns (uint256) {
         _requireInitialized();
         if (totalSupply() == 0) return 1e18;
-        return (totalAssets() * 1e18) / totalSupply();
+        return (_pricingAssets() * 1e18) / totalSupply();
     }
 
     /// @notice Pull USDST from the owner and credit it as savings rewards.
@@ -189,6 +183,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal {
         require(assets > 0, "SaveUSDST: zero assets");
         require(shares > 0, "SaveUSDST: zero shares");
+        require(totalSupply() == 0 || _pricingAssets() > 0, "SaveUSDST: insolvent");
 
         uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
         require(IERC20(assetToken).transferFrom(caller, address(this), assets), "SaveUSDST: deposit transfer failed");
@@ -219,6 +214,8 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
             _spendAllowance(ownerAddress, caller, shares);
         }
 
+        uint256 supplyBeforeBurn = totalSupply();
+        uint256 managedAssetsBefore = _managedAssets;
         _burn(ownerAddress, shares);
 
         uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
@@ -227,7 +224,14 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
         require(delta > 0, "SaveUSDST: no withdraw delta");
 
         require(delta <= _managedAssets, "SaveUSDST: managed underflow");
-        _managedAssets -= delta;
+        if (totalSupply() == 0) {
+            _managedAssets = 0;
+        } else {
+            uint256 managedReduction = _mulDiv(shares, managedAssetsBefore, supplyBeforeBurn, false);
+            require(managedReduction > 0, "SaveUSDST: zero managed reduction");
+            require(managedReduction <= _managedAssets, "SaveUSDST: managed underflow");
+            _managedAssets -= managedReduction;
+        }
 
         emit Withdraw(caller, receiver, ownerAddress, delta, shares);
     }
@@ -235,17 +239,19 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function _convertToShares(uint256 assets, bool roundUp) internal view returns (uint256) {
         _requireInitialized();
         uint256 supply = totalSupply();
+        uint256 pricingAssets = _pricingAssets();
         if (assets == 0) return 0;
-        if (supply == 0 || _managedAssets == 0) return assets;
-        return _mulDiv(assets, supply, _managedAssets, roundUp);
+        if (supply == 0 || pricingAssets == 0) return assets;
+        return _mulDiv(assets, supply, pricingAssets, roundUp);
     }
 
     function _convertToAssets(uint256 shares, bool roundUp) internal view returns (uint256) {
         _requireInitialized();
         uint256 supply = totalSupply();
+        uint256 pricingAssets = _pricingAssets();
         if (shares == 0) return 0;
-        if (supply == 0 || _managedAssets == 0) return shares;
-        return _mulDiv(shares, _managedAssets, supply, roundUp);
+        if (supply == 0 || pricingAssets == 0) return 0;
+        return _mulDiv(shares, pricingAssets, supply, roundUp);
     }
 
     function _mulDiv(uint256 x, uint256 y, uint256 denominator, bool roundUp) internal pure returns (uint256) {
@@ -259,6 +265,15 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
 
     function _requireInitialized() internal view {
         require(vaultInitialized, "SaveUSDST: not initialized");
+    }
+
+    function _pricingAssets() internal view returns (uint256) {
+        uint256 pricingAssets = _managedAssets;
+        uint256 liveBalance = IERC20(assetToken).balanceOf(address(this));
+        if (liveBalance < pricingAssets) {
+            pricingAssets = liveBalance;
+        }
+        return pricingAssets;
     }
 
     function _tryGetAssetDecimals(address token) internal view returns (uint8) {

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -79,6 +79,10 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
         if (!vaultInitialized || paused()) return 0;
         uint256 assets = _convertToAssets(balanceOf(ownerAddress), false);
         uint256 available = _managedAssets;
+        uint256 liveBalance = IERC20(assetToken).balanceOf(address(this));
+        if (liveBalance < available) {
+            available = liveBalance;
+        }
         return assets < available ? assets : available;
     }
 
@@ -145,6 +149,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function notifyReward(uint256 amount) external onlyOwner {
         _requireInitialized();
         require(amount > 0, "SaveUSDST: zero reward");
+        require(totalSupply() > 0, "SaveUSDST: no shares");
 
         uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
         require(IERC20(assetToken).transferFrom(_msgSender(), address(this), amount), "SaveUSDST: reward transfer failed");

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -1,0 +1,266 @@
+import "../../abstract/ERC20/ERC20.sol";
+import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Ownable.sol";
+import "../../abstract/ERC20/extensions/IERC20Metadata.sol";
+import "../../abstract/ERC20/utils/Pausable.sol";
+
+/// @title SaveUSDSTVault
+/// @notice A standalone USDST savings vault with ERC-4626-style accounting.
+/// @dev The vault itself is the ERC-20 share token. Yield is added explicitly
+///      through reward notifications rather than lending-pool utilization.
+contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
+    address public assetToken;
+    bool public vaultInitialized;
+    uint8 private _underlyingDecimals;
+    uint256 private _managedAssets;
+
+    event VaultInitialized(address indexed assetToken, string name, string symbol);
+    event RewardNotified(address indexed sender, uint256 amount);
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
+
+    constructor(address initialOwner)
+        Ownable(initialOwner)
+        ERC20("", "")
+    {}
+
+    function initialize(address _assetToken, string name_, string symbol_) external onlyOwner {
+        require(!vaultInitialized, "SaveUSDST: already initialized");
+        require(_assetToken != address(0), "SaveUSDST: asset=0");
+        require(_assetToken != address(this), "SaveUSDST: invalid asset");
+
+        __ERC20_init(name_, symbol_);
+
+        assetToken = _assetToken;
+        _underlyingDecimals = _tryGetAssetDecimals(_assetToken);
+        vaultInitialized = true;
+
+        emit VaultInitialized(_assetToken, name_, symbol_);
+    }
+
+    function decimals() public view override returns (uint8) {
+        if (!vaultInitialized) return 18;
+        return _underlyingDecimals;
+    }
+
+    function asset() public view returns (address) {
+        _requireInitialized();
+        return assetToken;
+    }
+
+    function totalAssets() public view returns (uint256) {
+        _requireInitialized();
+        return _managedAssets;
+    }
+
+    function managedAssets() external view returns (uint256) {
+        return totalAssets();
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, false);
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, false);
+    }
+
+    function maxDeposit(address) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return 2 ** 256 - 1;
+    }
+
+    function maxMint(address) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return 2 ** 256 - 1;
+    }
+
+    function maxWithdraw(address ownerAddress) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        uint256 assets = _convertToAssets(balanceOf(ownerAddress), false);
+        uint256 available = _managedAssets;
+        return assets < available ? assets : available;
+    }
+
+    function maxRedeem(address ownerAddress) public view returns (uint256) {
+        if (!vaultInitialized || paused()) return 0;
+        return balanceOf(ownerAddress);
+    }
+
+    function previewDeposit(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, false);
+    }
+
+    function previewMint(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, true);
+    }
+
+    function previewWithdraw(uint256 assets) public view returns (uint256) {
+        return _convertToShares(assets, true);
+    }
+
+    function previewRedeem(uint256 shares) public view returns (uint256) {
+        return _convertToAssets(shares, false);
+    }
+
+    function deposit(uint256 assets, address receiver) external whenNotPaused returns (uint256 shares) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        shares = previewDeposit(assets);
+        _deposit(_msgSender(), receiver, assets, shares);
+    }
+
+    function mint(uint256 shares, address receiver) external whenNotPaused returns (uint256 assets) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        assets = previewMint(shares);
+        _deposit(_msgSender(), receiver, assets, shares);
+    }
+
+    function withdraw(uint256 assets, address receiver, address ownerAddress) external whenNotPaused returns (uint256 shares) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        require(assets <= maxWithdraw(ownerAddress), "SaveUSDST: withdraw exceeds max");
+
+        shares = previewWithdraw(assets);
+        _withdraw(_msgSender(), receiver, ownerAddress, assets, shares);
+    }
+
+    function redeem(uint256 shares, address receiver, address ownerAddress) external whenNotPaused returns (uint256 assets) {
+        _requireInitialized();
+        require(receiver != address(0), "SaveUSDST: receiver=0");
+        require(shares <= maxRedeem(ownerAddress), "SaveUSDST: redeem exceeds max");
+
+        assets = previewRedeem(shares);
+        _withdraw(_msgSender(), receiver, ownerAddress, assets, shares);
+    }
+
+    function exchangeRate() external view returns (uint256) {
+        _requireInitialized();
+        if (totalSupply() == 0) return 1e18;
+        return (totalAssets() * 1e18) / totalSupply();
+    }
+
+    /// @notice Pull USDST from the owner and credit it as savings rewards.
+    function notifyReward(uint256 amount) external onlyOwner {
+        _requireInitialized();
+        require(amount > 0, "SaveUSDST: zero reward");
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transferFrom(_msgSender(), address(this), amount), "SaveUSDST: reward transfer failed");
+        uint256 delta = IERC20(assetToken).balanceOf(address(this)) - beforeBalance;
+        require(delta > 0, "SaveUSDST: no reward delta");
+
+        _managedAssets += delta;
+        emit RewardNotified(_msgSender(), delta);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function recoverStrayAssets(address to) external onlyOwner {
+        _requireInitialized();
+        require(to != address(0), "SaveUSDST: bad recipient");
+
+        uint256 balance = IERC20(assetToken).balanceOf(address(this));
+        require(balance >= _managedAssets, "SaveUSDST: balance underflow");
+        uint256 stray = balance - _managedAssets;
+        require(stray > 0, "SaveUSDST: no stray");
+
+        require(IERC20(assetToken).transfer(to, stray), "SaveUSDST: stray transfer failed");
+    }
+
+    function rescueToken(address token, address to, uint256 amount) external onlyOwner {
+        require(token != assetToken, "SaveUSDST: no asset rescue");
+        require(to != address(0), "SaveUSDST: bad recipient");
+        require(IERC20(token).transfer(to, amount), "SaveUSDST: rescue transfer failed");
+    }
+
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal {
+        require(assets > 0, "SaveUSDST: zero assets");
+        require(shares > 0, "SaveUSDST: zero shares");
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transferFrom(caller, address(this), assets), "SaveUSDST: deposit transfer failed");
+        uint256 delta = IERC20(assetToken).balanceOf(address(this)) - beforeBalance;
+        require(delta > 0, "SaveUSDST: no deposit delta");
+
+        if (totalSupply() == 0) {
+            require(_managedAssets == 0, "SaveUSDST: bad init state");
+        }
+
+        // If the underlying ever becomes fee-on-transfer, mint against actual assets received.
+        if (delta != assets) {
+            shares = _convertToShares(delta, false);
+            require(shares > 0, "SaveUSDST: fee-on-transfer dust");
+        }
+
+        _managedAssets += delta;
+        _mint(receiver, shares);
+
+        emit Deposit(caller, receiver, delta, shares);
+    }
+
+    function _withdraw(address caller, address receiver, address ownerAddress, uint256 assets, uint256 shares) internal {
+        require(assets > 0, "SaveUSDST: zero assets");
+        require(shares > 0, "SaveUSDST: zero shares");
+
+        if (caller != ownerAddress) {
+            _spendAllowance(ownerAddress, caller, shares);
+        }
+
+        _burn(ownerAddress, shares);
+
+        uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
+        require(IERC20(assetToken).transfer(receiver, assets), "SaveUSDST: withdraw transfer failed");
+        uint256 delta = beforeBalance - IERC20(assetToken).balanceOf(address(this));
+        require(delta > 0, "SaveUSDST: no withdraw delta");
+
+        require(delta <= _managedAssets, "SaveUSDST: managed underflow");
+        _managedAssets -= delta;
+
+        emit Withdraw(caller, receiver, ownerAddress, delta, shares);
+    }
+
+    function _convertToShares(uint256 assets, bool roundUp) internal view returns (uint256) {
+        _requireInitialized();
+        uint256 supply = totalSupply();
+        if (assets == 0) return 0;
+        if (supply == 0 || _managedAssets == 0) return assets;
+        return _mulDiv(assets, supply, _managedAssets, roundUp);
+    }
+
+    function _convertToAssets(uint256 shares, bool roundUp) internal view returns (uint256) {
+        _requireInitialized();
+        uint256 supply = totalSupply();
+        if (shares == 0) return 0;
+        if (supply == 0 || _managedAssets == 0) return shares;
+        return _mulDiv(shares, _managedAssets, supply, roundUp);
+    }
+
+    function _mulDiv(uint256 x, uint256 y, uint256 denominator, bool roundUp) internal pure returns (uint256) {
+        require(denominator > 0, "SaveUSDST: div by zero");
+        uint256 z = (x * y) / denominator;
+        if (roundUp && ((x * y) % denominator) > 0) {
+            z += 1;
+        }
+        return z;
+    }
+
+    function _requireInitialized() internal view {
+        require(vaultInitialized, "SaveUSDST: not initialized");
+    }
+
+    function _tryGetAssetDecimals(address token) internal view returns (uint8) {
+        try IERC20Metadata(token).decimals() returns (uint8 tokenDecimals) {
+            return tokenDecimals;
+        } catch {
+            return 18;
+        }
+    }
+}

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -254,7 +254,8 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
         uint256 supply = totalSupply();
         uint256 pricingAssets = _pricingAssets();
         if (shares == 0) return 0;
-        if (supply == 0 || pricingAssets == 0) return 0;
+        if (supply == 0) return shares;
+        if (pricingAssets == 0) return 0;
         return _mulDiv(shares, pricingAssets, supply, roundUp);
     }
 

--- a/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
+++ b/mercata/contracts/concrete/Savings/SaveUSDSTVault.sol
@@ -50,6 +50,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
 
     function totalAssets() public view returns (uint256) {
         _requireInitialized();
+        // Raw managed accounting is exposed separately from redeemable pricing.
         return _managedAssets;
     }
 
@@ -183,6 +184,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal {
         require(assets > 0, "SaveUSDST: zero assets");
         require(shares > 0, "SaveUSDST: zero shares");
+        // Do not let new deposits recapitalize an outstanding share supply at a misleading 1:1 price.
         require(totalSupply() == 0 || _pricingAssets() > 0, "SaveUSDST: insolvent");
 
         uint256 beforeBalance = IERC20(assetToken).balanceOf(address(this));
@@ -225,8 +227,10 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
 
         require(delta <= _managedAssets, "SaveUSDST: managed underflow");
         if (totalSupply() == 0) {
+            // Last redeemer clears the vault's accounting state.
             _managedAssets = 0;
         } else {
+            // In an impaired state, socialize losses by burning the same fraction of managed accounting as shares.
             uint256 managedReduction = _mulDiv(shares, managedAssetsBefore, supplyBeforeBurn, false);
             require(managedReduction > 0, "SaveUSDST: zero managed reduction");
             require(managedReduction <= _managedAssets, "SaveUSDST: managed underflow");
@@ -270,6 +274,7 @@ contract record SaveUSDSTVault is ERC20, Ownable, Pausable {
     function _pricingAssets() internal view returns (uint256) {
         uint256 pricingAssets = _managedAssets;
         uint256 liveBalance = IERC20(assetToken).balanceOf(address(this));
+        // Price shares against what the vault can actually redeem, not just internal accounting.
         if (liveBalance < pricingAssets) {
             pricingAssets = liveBalance;
         }

--- a/mercata/contracts/deploy/README.md
+++ b/mercata/contracts/deploy/README.md
@@ -30,7 +30,7 @@ npm run deploy
 - `OAUTH_CLIENT_ID` - OAuth client ID
 - `OAUTH_CLIENT_SECRET` - OAuth client secret
 
-**Output**: Prints all deployed contract addresses and provides ready-to-paste `.env` snippets.
+**Output**: Prints all deployed contract addresses, including `SaveUSDSTVault`, and provides ready-to-paste `.env` snippets.
 
 #### `upgrade.js`
 Script for upgrading existing proxy contracts to new implementations.

--- a/mercata/contracts/deploy/deploy.js
+++ b/mercata/contracts/deploy/deploy.js
@@ -63,6 +63,7 @@ async function main() {
     console.log(`CDP Engine: ${deployedContract.managers.cdpEngine}`);
     console.log(`CDP Vault: ${deployedContract.managers.cdpVault}`);
     console.log(`Safety Module: ${deployedContract.managers.safetyModule}`);
+    console.log(`Save USDST Vault: ${deployedContract.managers.saveUSDSTVault}`);
     console.log(`Rewards: ${deployedContract.managers.rewards}`);
     console.log(`Escrow: ${deployedContract.managers.escrow}`);
     console.log(`Metal Forge: ${deployedContract.managers.metalForge}`);
@@ -92,6 +93,7 @@ async function main() {
       CDP_ENGINE: deployedContract.managers.cdpEngine,
       CDP_VAULT: deployedContract.managers.cdpVault,
       SAFETY_MODULE: deployedContract.managers.safetyModule,
+      SAVE_USDST_VAULT: deployedContract.managers.saveUSDSTVault,
       REWARDS: deployedContract.managers.rewards,
       ESCROW: deployedContract.managers.escrow,
       METAL_FORGE: deployedContract.managers.metalForge,

--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -35,6 +35,11 @@ contract Describe_Mercata is Authorizable {
         require(address(m.liquidityPool().registry().lendingPool()) != address(0), "LiquidityPool's LendingPool address is 0");
     }
 
+    function it_deploys_save_usdst_vault() {
+        require(address(m.saveUSDSTVault()) != address(0), "SaveUSDSTVault address is 0");
+        require(m.saveUSDSTVault().asset() == address(0x937efa7e3a77e20bbdbd7c0d32b6514f368c1010), "SaveUSDSTVault asset mismatch");
+    }
+
     function it_can_create_tokens() {
         address t = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
         require(t != address(0), "Failed to create Token");

--- a/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
+++ b/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
@@ -41,6 +41,15 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(vault.previewMint(1e18) == 1e18, "initial mint should be 1:1");
     }
 
+    function it_cannot_be_initialized_twice() public {
+        bool reverted = false;
+        try vault.initialize(USDST, "Save USDST 2", "saveUSDST2") {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "second initialize should revert");
+    }
+
     function it_prevents_donation_attacks_from_changing_total_assets() public {
         User attacker = new User();
         User victim = new User();
@@ -83,6 +92,20 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(vault.previewDeposit(10e18) < 10e18, "post-reward deposits should mint fewer shares");
     }
 
+    function it_reverts_reward_notification_when_no_shares_exist() public {
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+
+        bool reverted = false;
+        try vault.notifyReward(20e18) {
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "notifyReward should revert when no shares exist");
+        require(vault.totalAssets() == 0, "managed assets should remain zero");
+    }
+
     function it_allows_withdrawal_of_principal_plus_rewards() public {
         User saver = new User();
 
@@ -101,6 +124,28 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(saverBalanceAfter == saverBalanceBefore + 60e18, "redeem should return principal plus rewards");
         require(vault.totalSupply() == 0, "all shares should be burned");
         require(vault.totalAssets() == 0, "managed assets should be empty");
+    }
+
+    function it_reverts_reward_notification_after_vault_has_been_fully_redeemed() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 50e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 50e18, address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 50e18, address(saver), address(saver));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+
+        bool reverted = false;
+        try vault.notifyReward(10e18) {
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "notifyReward should revert after full redeem");
+        require(vault.totalSupply() == 0, "supply should remain zero");
+        require(vault.totalAssets() == 0, "managed assets should remain zero");
     }
 
     function it_distributes_rewards_proportionally_to_multiple_users() public {
@@ -260,10 +305,35 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(saverGot == 100e18, "saver gets full principal after recovery");
     }
 
+    function it_caps_max_withdraw_by_live_balance_when_balance_drops_below_managed_assets() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        // Simulate unexpected live-balance loss while internal accounting stays unchanged.
+        Token(USDST).burn(address(vault), 40e18);
+
+        require(vault.totalAssets() == 100e18, "managed assets unchanged");
+        require(IERC20(USDST).balanceOf(address(vault)) == 60e18, "live balance reduced");
+        require(vault.maxWithdraw(address(saver)) == 60e18, "maxWithdraw should cap to live balance");
+    }
+
+    function it_blocks_underlying_rescue() public {
+        bool reverted = false;
+        try vault.rescueToken(USDST, address(this), 1) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "underlying rescue should revert");
+    }
+
     function it_blocks_operations_when_paused() public {
         User saver = new User();
         Token(USDST).mint(address(saver), 100e18);
         saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
 
         vault.pause();
 
@@ -279,10 +349,16 @@ contract Describe_SaveUSDSTVault is Authorizable {
         }
         require(reverted, "deposit should revert when paused");
 
-        vault.unpause();
+        reverted = false;
+        try saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "redeem should revert when paused");
 
-        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
-        require(IERC20(address(vault)).balanceOf(address(saver)) == 100e18, "deposit works after unpause");
+        vault.unpause();
+        saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver));
+        require(IERC20(address(vault)).balanceOf(address(saver)) == 0, "redeem works after unpause");
     }
 
     function it_supports_allowance_based_redeem() public {
@@ -392,5 +468,33 @@ contract Describe_SaveUSDSTVault is Authorizable {
         u2.do(address(vault), "deposit(uint256,address)", dep2, address(u2));
         uint rate3 = vault.exchangeRate();
         require(rate3 >= rate2 - 1, "rate must not decrease after deposit (within 1 wei rounding)");
+    }
+
+    /// @notice maxWithdraw should never exceed both live balance and the owner's economic claim.
+    function property_max_withdraw_is_bounded(uint seedDeposit, uint seedReward, uint seedBurn) public {
+        uint dep = ((seedDeposit % 500000) + 1) * 1e12;
+        uint rew = ((seedReward % 200000) + 1) * 1e12;
+
+        User u = new User();
+        Token(USDST).mint(address(u), dep);
+        u.do(USDST, "approve", address(vault), INFINITY);
+        u.do(address(vault), "deposit(uint256,address)", dep, address(u));
+
+        Token(USDST).mint(address(this), rew);
+        Token(USDST).approve(address(vault), rew);
+        vault.notifyReward(rew);
+
+        uint liveBalanceBeforeBurn = IERC20(USDST).balanceOf(address(vault));
+        uint burnAmt = seedBurn % (liveBalanceBeforeBurn + 1);
+        if (burnAmt > 0) {
+            Token(USDST).burn(address(vault), burnAmt);
+        }
+
+        uint maxW = vault.maxWithdraw(address(u));
+        uint liveBalance = IERC20(USDST).balanceOf(address(vault));
+        uint claim = vault.convertToAssets(IERC20(address(vault)).balanceOf(address(u)));
+
+        require(maxW <= liveBalance, "maxWithdraw exceeds live balance");
+        require(maxW <= claim, "maxWithdraw exceeds economic claim");
     }
 }

--- a/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
+++ b/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
@@ -1,0 +1,396 @@
+import "../../concrete/BaseCodeCollection.sol";
+import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
+import "../../concrete/Tokens/Token.sol";
+import "../../concrete/Savings/SaveUSDSTVault.sol";
+
+contract User {
+    function do(address a, string f, variadic args) public returns (variadic) {
+        variadic result = address(a).call(f, args);
+        return result;
+    }
+}
+
+contract Describe_SaveUSDSTVault is Authorizable {
+    uint public INFINITY = 2 ** 256 - 1;
+
+    Mercata m;
+    SaveUSDSTVault vault;
+    address USDST;
+
+    function beforeAll() public {
+        bypassAuthorizations = true;
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
+    }
+
+    function beforeEach() public {
+        vault = new SaveUSDSTVault(address(this));
+
+        USDST = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        Token(USDST).setStatus(2);
+
+        vault.initialize(USDST, "Save USDST", "saveUSDST");
+    }
+
+    function it_initializes_as_an_exchange_rate_vault() public {
+        require(vault.asset() == USDST, "asset not set");
+        require(vault.totalSupply() == 0, "unexpected initial supply");
+        require(vault.totalAssets() == 0, "unexpected initial assets");
+        require(vault.previewDeposit(1e18) == 1e18, "initial deposit should be 1:1");
+        require(vault.previewMint(1e18) == 1e18, "initial mint should be 1:1");
+    }
+
+    function it_prevents_donation_attacks_from_changing_total_assets() public {
+        User attacker = new User();
+        User victim = new User();
+
+        Token(USDST).mint(address(attacker), 10000e18 + 1);
+        attacker.do(USDST, "approve", address(vault), INFINITY);
+        attacker.do(address(vault), "deposit(uint256,address)", 1, address(attacker));
+
+        uint attackerShares = IERC20(address(vault)).balanceOf(address(attacker));
+        require(attackerShares == 1, "attacker share mismatch");
+
+        attacker.do(USDST, "transfer", address(vault), 10000e18);
+        require(vault.totalAssets() == 1, "donation should not change managed assets");
+        require(vault.totalSupply() == 1, "supply should remain unchanged");
+
+        Token(USDST).mint(address(victim), 1000e18);
+        victim.do(USDST, "approve", address(vault), INFINITY);
+        victim.do(address(vault), "deposit(uint256,address)", 1000e18, address(victim));
+
+        uint victimShares = IERC20(address(vault)).balanceOf(address(victim));
+        require(victimShares == 1000e18, "victim should receive fair shares");
+        require(vault.totalAssets() == 1000e18 + 1, "managed assets incorrect");
+    }
+
+    function it_increases_exchange_rate_when_rewards_are_notified() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        require(vault.convertToAssets(100e18) == 100e18, "initial assets mismatch");
+
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+        vault.notifyReward(20e18);
+
+        require(vault.totalAssets() == 120e18, "reward should raise assets");
+        require(vault.convertToAssets(100e18) == 120e18, "share value should increase");
+        require(vault.previewDeposit(10e18) < 10e18, "post-reward deposits should mint fewer shares");
+    }
+
+    function it_allows_withdrawal_of_principal_plus_rewards() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 50e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 50e18, address(saver));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+        vault.notifyReward(10e18);
+
+        uint saverBalanceBefore = IERC20(USDST).balanceOf(address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 50e18, address(saver), address(saver));
+        uint saverBalanceAfter = IERC20(USDST).balanceOf(address(saver));
+
+        require(saverBalanceAfter == saverBalanceBefore + 60e18, "redeem should return principal plus rewards");
+        require(vault.totalSupply() == 0, "all shares should be burned");
+        require(vault.totalAssets() == 0, "managed assets should be empty");
+    }
+
+    function it_distributes_rewards_proportionally_to_multiple_users() public {
+        User alice = new User();
+        User bob = new User();
+
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        Token(USDST).mint(address(bob), 100e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 100e18, address(bob));
+
+        Token(USDST).mint(address(this), 20e18);
+        Token(USDST).approve(address(vault), 20e18);
+        vault.notifyReward(20e18);
+
+        // 220 managed, 200 shares. Each user has 100 shares = 110 USDST.
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", 100e18, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+        require(aliceGot == 110e18, "alice should get 110");
+
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", 100e18, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+        require(bobGot == 110e18, "bob should get 110");
+
+        require(vault.totalSupply() == 0, "all shares burned");
+        require(vault.totalAssets() == 0, "vault fully drained");
+    }
+
+    function it_prices_deposits_correctly_after_reward() public {
+        User alice = new User();
+        User bob = new User();
+
+        // Alice deposits 100 at 1:1, gets 100 shares
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        // Reward of 100 doubles the rate to 2:1
+        Token(USDST).mint(address(this), 100e18);
+        Token(USDST).approve(address(vault), 100e18);
+        vault.notifyReward(100e18);
+
+        // Bob deposits 100 at 2:1, gets 50 shares
+        Token(USDST).mint(address(bob), 100e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 100e18, address(bob));
+
+        uint bobShares = IERC20(address(vault)).balanceOf(address(bob));
+        require(bobShares == 50e18, "bob should get 50 shares at 2:1 rate");
+
+        // Another reward of 30. Total managed = 330, total shares = 150.
+        Token(USDST).mint(address(this), 30e18);
+        Token(USDST).approve(address(vault), 30e18);
+        vault.notifyReward(30e18);
+
+        // Alice: 100/150 * 330 = 220. Bob: 50/150 * 330 = 110.
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", 100e18, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+        require(aliceGot == 220e18, "alice should get 220");
+
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", 50e18, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+        require(bobGot == 110e18, "bob should get 110");
+
+        require(vault.totalAssets() == 0, "vault empty");
+    }
+
+    function it_lets_last_user_drain_vault_cleanly() public {
+        User alice = new User();
+        User bob = new User();
+        User charlie = new User();
+
+        Token(USDST).mint(address(alice), 50e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 50e18, address(alice));
+
+        Token(USDST).mint(address(bob), 30e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 30e18, address(bob));
+
+        Token(USDST).mint(address(charlie), 20e18);
+        charlie.do(USDST, "approve", address(vault), INFINITY);
+        charlie.do(address(vault), "deposit(uint256,address)", 20e18, address(charlie));
+
+        Token(USDST).mint(address(this), 10e18);
+        Token(USDST).approve(address(vault), 10e18);
+        vault.notifyReward(10e18);
+
+        // Alice and bob withdraw. Charlie is last.
+        alice.do(address(vault), "redeem(uint256,address,address)", 50e18, address(alice), address(alice));
+        bob.do(address(vault), "redeem(uint256,address,address)", 30e18, address(bob), address(bob));
+
+        uint charlieShares = IERC20(address(vault)).balanceOf(address(charlie));
+        uint charlieBefore = IERC20(USDST).balanceOf(address(charlie));
+        charlie.do(address(vault), "redeem(uint256,address,address)", charlieShares, address(charlie), address(charlie));
+        uint charlieGot = IERC20(USDST).balanceOf(address(charlie)) - charlieBefore;
+
+        require(charlieGot > 0, "charlie should get something");
+        require(vault.totalSupply() == 0, "all shares burned");
+        require(vault.totalAssets() == 0, "vault fully drained");
+    }
+
+    function it_reverts_deposit_of_1_wei_when_rate_is_above_1() public {
+        User alice = new User();
+
+        Token(USDST).mint(address(alice), 100e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 100e18, address(alice));
+
+        Token(USDST).mint(address(this), 100e18);
+        Token(USDST).approve(address(vault), 100e18);
+        vault.notifyReward(100e18);
+
+        // Rate is now 2:1. Depositing 1 wei should yield 0 shares and revert.
+        User dust = new User();
+        Token(USDST).mint(address(dust), 1);
+        dust.do(USDST, "approve", address(vault), INFINITY);
+
+        bool reverted = false;
+        try dust.do(address(vault), "deposit(uint256,address)", 1, address(dust)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "1 wei deposit should revert at 2:1 rate");
+    }
+
+    function it_recovers_stray_assets_without_affecting_accounting() public {
+        User saver = new User();
+
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+
+        // Donate 500 USDST directly
+        Token(USDST).mint(address(this), 500e18);
+        Token(USDST).transfer(address(vault), 500e18);
+
+        require(vault.totalAssets() == 100e18, "managed assets unchanged by donation");
+
+        uint recoveryBefore = IERC20(USDST).balanceOf(address(this));
+        vault.recoverStrayAssets(address(this));
+        uint recovered = IERC20(USDST).balanceOf(address(this)) - recoveryBefore;
+        require(recovered == 500e18, "should recover exactly 500");
+        require(vault.totalAssets() == 100e18, "managed assets still unchanged");
+
+        // Saver can still redeem normally
+        uint saverBefore = IERC20(USDST).balanceOf(address(saver));
+        saver.do(address(vault), "redeem(uint256,address,address)", 100e18, address(saver), address(saver));
+        uint saverGot = IERC20(USDST).balanceOf(address(saver)) - saverBefore;
+        require(saverGot == 100e18, "saver gets full principal after recovery");
+    }
+
+    function it_blocks_operations_when_paused() public {
+        User saver = new User();
+        Token(USDST).mint(address(saver), 100e18);
+        saver.do(USDST, "approve", address(vault), INFINITY);
+
+        vault.pause();
+
+        require(vault.maxDeposit(address(saver)) == 0, "maxDeposit should be 0 when paused");
+        require(vault.maxMint(address(saver)) == 0, "maxMint should be 0 when paused");
+        require(vault.maxWithdraw(address(saver)) == 0, "maxWithdraw should be 0 when paused");
+        require(vault.maxRedeem(address(saver)) == 0, "maxRedeem should be 0 when paused");
+
+        bool reverted = false;
+        try saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver)) {
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "deposit should revert when paused");
+
+        vault.unpause();
+
+        saver.do(address(vault), "deposit(uint256,address)", 100e18, address(saver));
+        require(IERC20(address(vault)).balanceOf(address(saver)) == 100e18, "deposit works after unpause");
+    }
+
+    function it_supports_allowance_based_redeem() public {
+        User owner = new User();
+        User spender = new User();
+
+        Token(USDST).mint(address(owner), 100e18);
+        owner.do(USDST, "approve", address(vault), INFINITY);
+        owner.do(address(vault), "deposit(uint256,address)", 100e18, address(owner));
+
+        // Owner approves spender to spend vault shares
+        owner.do(address(vault), "approve", address(spender), 100e18);
+
+        // Spender redeems on behalf of owner, receives the USDST
+        uint spenderBefore = IERC20(USDST).balanceOf(address(spender));
+        spender.do(address(vault), "redeem(uint256,address,address)", 100e18, address(spender), address(owner));
+        uint spenderGot = IERC20(USDST).balanceOf(address(spender)) - spenderBefore;
+
+        require(spenderGot == 100e18, "spender should receive the USDST");
+        require(IERC20(address(vault)).balanceOf(address(owner)) == 0, "owner shares burned");
+        require(vault.totalSupply() == 0, "all shares burned");
+    }
+
+    /// @notice For any deposit amount, deposit then full redeem returns the original amount (within 1 wei rounding).
+    function property_deposit_redeem_round_trip_conserves_value(uint seed) public {
+        uint amount = (seed % 1000000) + 1;
+        amount = amount * 1e12;
+
+        User u = new User();
+        Token(USDST).mint(address(u), amount);
+        u.do(USDST, "approve", address(vault), INFINITY);
+        u.do(address(vault), "deposit(uint256,address)", amount, address(u));
+
+        uint shares = IERC20(address(vault)).balanceOf(address(u));
+        require(shares > 0, "should have shares");
+
+        uint balBefore = IERC20(USDST).balanceOf(address(u));
+        u.do(address(vault), "redeem(uint256,address,address)", shares, address(u), address(u));
+        uint got = IERC20(USDST).balanceOf(address(u)) - balBefore;
+
+        require(got >= amount - 1 && got <= amount, "round trip should conserve value within 1 wei");
+        require(vault.totalSupply() == 0, "no shares left");
+        require(vault.totalAssets() == 0, "no assets left");
+    }
+
+    /// @notice Two users deposit random amounts, a random reward arrives. Total redeemed == total deposited + reward (within rounding).
+    function property_rewards_conserve_total_value(uint seedA, uint seedB, uint seedR) public {
+        uint amountA = ((seedA % 500000) + 1) * 1e12;
+        uint amountB = ((seedB % 500000) + 1) * 1e12;
+        uint reward  = ((seedR % 100000) + 1) * 1e12;
+
+        User alice = new User();
+        User bob = new User();
+
+        Token(USDST).mint(address(alice), amountA);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", amountA, address(alice));
+
+        Token(USDST).mint(address(bob), amountB);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", amountB, address(bob));
+
+        Token(USDST).mint(address(this), reward);
+        Token(USDST).approve(address(vault), reward);
+        vault.notifyReward(reward);
+
+        uint aliceShares = IERC20(address(vault)).balanceOf(address(alice));
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", aliceShares, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+
+        uint bobShares = IERC20(address(vault)).balanceOf(address(bob));
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", bobShares, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+
+        uint totalIn = amountA + amountB + reward;
+        uint totalOut = aliceGot + bobGot;
+
+        require(totalOut >= totalIn - 2 && totalOut <= totalIn, "total value must be conserved within 2 wei rounding");
+        require(vault.totalSupply() == 0, "no shares left");
+        require(vault.totalAssets() <= 2, "vault should be empty within rounding");
+    }
+
+    /// @notice Exchange rate must never decrease after a deposit or reward.
+    function property_exchange_rate_never_decreases(uint seedDeposit, uint seedReward, uint seedDeposit2) public {
+        uint dep1 = ((seedDeposit % 500000) + 1) * 1e12;
+        uint rew  = ((seedReward % 200000) + 1) * 1e12;
+        uint dep2 = ((seedDeposit2 % 500000) + 1) * 1e12;
+
+        User u1 = new User();
+        User u2 = new User();
+
+        Token(USDST).mint(address(u1), dep1);
+        u1.do(USDST, "approve", address(vault), INFINITY);
+        u1.do(address(vault), "deposit(uint256,address)", dep1, address(u1));
+        uint rate1 = vault.exchangeRate();
+
+        Token(USDST).mint(address(this), rew);
+        Token(USDST).approve(address(vault), rew);
+        vault.notifyReward(rew);
+        uint rate2 = vault.exchangeRate();
+        require(rate2 >= rate1, "rate must not decrease after reward");
+
+        Token(USDST).mint(address(u2), dep2);
+        u2.do(USDST, "approve", address(vault), INFINITY);
+        u2.do(address(vault), "deposit(uint256,address)", dep2, address(u2));
+        uint rate3 = vault.exchangeRate();
+        require(rate3 >= rate2 - 1, "rate must not decrease after deposit (within 1 wei rounding)");
+    }
+}

--- a/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
+++ b/mercata/contracts/tests/Savings/SaveUSDSTVault.test.sol
@@ -320,6 +320,68 @@ contract Describe_SaveUSDSTVault is Authorizable {
         require(vault.maxWithdraw(address(saver)) == 60e18, "maxWithdraw should cap to live balance");
     }
 
+    function it_socializes_live_balance_loss_pro_rata_across_redeemers() public {
+        User alice = new User();
+        User bob = new User();
+
+        Token(USDST).mint(address(alice), 50e18);
+        alice.do(USDST, "approve", address(vault), INFINITY);
+        alice.do(address(vault), "deposit(uint256,address)", 50e18, address(alice));
+
+        Token(USDST).mint(address(bob), 50e18);
+        bob.do(USDST, "approve", address(vault), INFINITY);
+        bob.do(address(vault), "deposit(uint256,address)", 50e18, address(bob));
+
+        Token(USDST).burn(address(vault), 40e18);
+
+        require(vault.totalAssets() == 100e18, "managed assets unchanged after loss");
+        require(IERC20(USDST).balanceOf(address(vault)) == 60e18, "live balance should reflect loss");
+        require(vault.exchangeRate() == 6e17, "exchange rate should use redeemable assets");
+        require(vault.previewRedeem(50e18) == 30e18, "half the shares should redeem half the live balance");
+        require(vault.previewWithdraw(30e18) == 50e18, "withdrawing redeemable assets should burn a fair share amount");
+        require(vault.maxWithdraw(address(alice)) == 30e18, "single user should only withdraw their pro-rata share");
+        require(vault.maxRedeem(address(alice)) == 50e18, "full share redemption should remain available");
+
+        uint aliceBefore = IERC20(USDST).balanceOf(address(alice));
+        alice.do(address(vault), "redeem(uint256,address,address)", 50e18, address(alice), address(alice));
+        uint aliceGot = IERC20(USDST).balanceOf(address(alice)) - aliceBefore;
+        require(aliceGot == 30e18, "alice should absorb her pro-rata loss");
+
+        uint bobBefore = IERC20(USDST).balanceOf(address(bob));
+        bob.do(address(vault), "redeem(uint256,address,address)", 50e18, address(bob), address(bob));
+        uint bobGot = IERC20(USDST).balanceOf(address(bob)) - bobBefore;
+        require(bobGot == 30e18, "bob should absorb the same pro-rata loss");
+
+        require(vault.totalSupply() == 0, "all shares should be burned");
+        require(vault.totalAssets() == 0, "managed assets should reset when the vault is emptied");
+        require(IERC20(USDST).balanceOf(address(vault)) == 0, "live balance should be empty after final redeem");
+    }
+
+    function it_blocks_new_deposits_when_existing_shares_are_fully_insolvent() public {
+        User incumbent = new User();
+        User newcomer = new User();
+
+        Token(USDST).mint(address(incumbent), 100e18);
+        incumbent.do(USDST, "approve", address(vault), INFINITY);
+        incumbent.do(address(vault), "deposit(uint256,address)", 100e18, address(incumbent));
+
+        Token(USDST).burn(address(vault), 100e18);
+
+        Token(USDST).mint(address(newcomer), 10e18);
+        newcomer.do(USDST, "approve", address(vault), INFINITY);
+
+        bool reverted = false;
+        try newcomer.do(address(vault), "deposit(uint256,address)", 10e18, address(newcomer)) {
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "deposit should revert when outstanding shares have no redeemable assets");
+        require(vault.totalSupply() == 100e18, "existing shares should remain outstanding");
+        require(vault.totalAssets() == 100e18, "managed accounting should remain unchanged");
+        require(IERC20(USDST).balanceOf(address(vault)) == 0, "live balance should remain zero");
+    }
+
     function it_blocks_underlying_rescue() public {
         bool reverted = false;
         try vault.rescueToken(USDST, address(this), 1) {

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -33,6 +33,7 @@ import ReferralsManagement from "./pages/ReferralsManagement";
 import PriceTracking from "./pages/PriceTracking";
 import Vault from "./pages/Vault";
 import Earn from "./pages/Earn";
+import EarnSave from "./pages/EarnSave";
 import EarnVault from "./pages/EarnVault";
 import EarnLending from "./pages/EarnLending";
 import EarnPools from "./pages/EarnPools";
@@ -267,6 +268,14 @@ const App = () => {
                                             element={
                                               <GuestAccessibleRoute>
                                                 <Earn />
+                                              </GuestAccessibleRoute>
+                                            }
+                                          />
+                                          <Route
+                                            path="/dashboard/earn-save"
+                                            element={
+                                              <GuestAccessibleRoute>
+                                                <EarnSave />
                                               </GuestAccessibleRoute>
                                             }
                                           />

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -6,6 +6,20 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/
 import { Token as TokenType, EarningAsset } from "@mercata/shared-types";
 import { formatBalance } from "@/utils/numberUtils";
 
+const isSaveUsdstAsset = (asset: { _symbol?: string; _name?: string } | null | undefined): boolean => {
+  const symbol = asset?._symbol?.toLowerCase?.() || "";
+  const name = asset?._name?.toLowerCase?.() || "";
+  return symbol === "saveusdst" || name.includes("save usdst") || name.includes("saveusdst");
+};
+
+const getAssetDetailHref = (asset: { address?: string; _symbol?: string; _name?: string } | null | undefined): string => {
+  if (isSaveUsdstAsset(asset)) {
+    return "/dashboard/earn-save";
+  }
+
+  return `/dashboard/deposits/${asset?.address || ""}`;
+};
+
 interface AssetsProps {
   loading: boolean;
   tokens: EarningAsset[];
@@ -139,7 +153,7 @@ const AssetsList = ({
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <Link
-                                    to={`/dashboard/deposits/${asset?.address || ''}`}
+                                    to={getAssetDetailHref(asset)}
                                     className="font-medium text-sm md:text-base text-blue-600 truncate hover:text-blue-800 underline transition-colors"
                                   >
                                     {asset?._symbol || asset?._name || ""}
@@ -284,7 +298,7 @@ const AssetsList = ({
                             )}
                             <div className="ml-2 md:ml-3 min-w-0 flex-1">
                               <Link
-                                to={`/dashboard/deposits/${asset?.address || ''}`}
+                                to={getAssetDetailHref(asset)}
                                 className="font-medium text-sm md:text-base text-blue-600 hover:text-blue-800 underline transition-colors block truncate"
                               >
                                 {asset?._symbol || asset?._name || ""}

--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -53,26 +53,26 @@ const NAV_CATEGORIES: NavCategory[] = [
     ],
   },
   {
+    label: 'EARN',
+    items: [
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
+    ],
+  },
+  {
     label: 'SPEND',
     items: [
       { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
     ],
   },
   {
-    label: 'EARN',
-    items: [
-      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-    ],
-  },
-  {
     label: 'PRO',
     items: [
       { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
-      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
-      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
-      { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
       { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
-      { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
+      { icon: UserPlus, label: 'Referrals', path: '/dashboard/referrals' },
+      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+      { icon: BarChart3, label: 'Analytics', path: '/dashboard/stats' },
       { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
     ],
   },

--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -53,26 +53,26 @@ const MORE_CATEGORIES: MoreNavCategory[] = [
     ],
   },
   {
+    label: 'EARN',
+    items: [
+      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
+      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
+    ],
+  },
+  {
     label: 'SPEND',
     items: [
       { icon: CreditCard, label: 'Card', path: '/dashboard/credit-card' },
     ],
   },
   {
-    label: 'EARN',
-    items: [
-      { icon: HandCoins, label: 'Earn', path: '/dashboard/earn' },
-    ],
-  },
-  {
     label: 'PRO',
     items: [
       { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
-      { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
-      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
-      { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
       { icon: Droplets, label: 'Advanced', path: '/dashboard/advanced' },
-      { icon: UserPlus, label: 'My Referrals', path: '/dashboard/referrals' },
+      { icon: UserPlus, label: 'Referrals', path: '/dashboard/referrals' },
+      { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
+      { icon: BarChart3, label: 'Analytics', path: '/dashboard/stats' },
       { icon: Shield, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
     ],
   },
@@ -129,9 +129,9 @@ const MobileBottomNav = () => {
 
       {/* More Drawer */}
       <Drawer open={isMoreOpen} onOpenChange={setIsMoreOpen}>
-        <DrawerContent className="max-h-[70vh] pb-7">
+        <DrawerContent className="max-h-[calc(100svh-1rem)] overflow-hidden pb-[calc(env(safe-area-inset-bottom)+1rem)]">
           {/* Close Button */}
-          <div className="flex justify-end px-4 pt-3">
+          <div className="flex justify-end px-4 pt-2">
             <DrawerClose asChild>
               <button className="p-1.5 rounded-md hover:bg-muted transition-colors">
                 <X size={18} className="text-muted-foreground" />
@@ -140,14 +140,14 @@ const MobileBottomNav = () => {
           </div>
 
           {/* Menu Items */}
-          <div className="px-3 pb-4">
+          <div className="min-h-0 overflow-y-auto overscroll-contain px-3 pb-3">
             {MORE_CATEGORIES.map((category, idx) => {
               const visibleItems = category.items.filter(item => !item.adminOnly || isAdmin);
               if (visibleItems.length === 0) return null;
               return (
-                <div key={idx} className={idx > 0 ? 'mt-3' : ''}>
+                <div key={idx} className={idx > 0 ? 'mt-2' : ''}>
                   {category.label && (
-                    <div className="px-4 py-1.5 text-[11px] font-semibold tracking-wider text-gray-400 dark:text-gray-500 uppercase">
+                    <div className="px-4 py-1 text-[10px] font-semibold tracking-wider text-gray-400 dark:text-gray-500 uppercase">
                       {category.label}
                     </div>
                   )}
@@ -155,13 +155,13 @@ const MobileBottomNav = () => {
                     <button
                       key={path}
                       onClick={() => handleMoreItemClick(path)}
-                      className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg transition-colors ${isActive(path)
+                      className={`flex items-center gap-3 w-full px-4 py-2.5 rounded-lg transition-colors ${isActive(path)
                           ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
                           : 'text-foreground hover:bg-muted'
                         }`}
                     >
-                      <Icon size={20} />
-                      <span className="text-sm font-medium">{label}</span>
+                      <Icon size={18} />
+                      <span className="text-[13px] font-medium">{label}</span>
                     </button>
                   ))}
                 </div>

--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -46,26 +46,26 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
       ],
     },
     {
+      label: 'EARN',
+      items: [
+        { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
+        { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
+      ],
+    },
+    {
       label: 'SPEND',
       items: [
         { icon: <CreditCard size={20} />, label: 'Card', path: '/dashboard/credit-card' },
       ],
     },
     {
-      label: 'EARN',
-      items: [
-        { icon: <HandCoins size={20} />, label: 'Earn', path: '/dashboard/earn' },
-      ],
-    },
-    {
       label: 'PRO',
       items: [
         { icon: <Vault size={20} />, label: 'Vault', path: '/dashboard/vault' },
-        { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
-        { icon: <Activity size={20} />, label: 'Activity Feed', path: '/dashboard/activity' },
-        { icon: <BarChart3 size={20} />, label: 'STRATO Stats', path: '/dashboard/stats' },
         { icon: <Droplets size={20} />, label: 'Advanced', path: '/dashboard/advanced' },
-        { icon: <UserPlus size={20} />, label: 'My Referrals', path: '/dashboard/referrals' },
+        { icon: <UserPlus size={20} />, label: 'Referrals', path: '/dashboard/referrals' },
+        { icon: <Activity size={20} />, label: 'Activity Feed', path: '/dashboard/activity' },
+        { icon: <BarChart3 size={20} />, label: 'Analytics', path: '/dashboard/stats' },
         { icon: <Shield size={20} />, label: 'Admin', path: '/dashboard/admin', adminOnly: true },
       ],
     },

--- a/mercata/ui/src/lib/axios.ts
+++ b/mercata/ui/src/lib/axios.ts
@@ -104,6 +104,7 @@ const GUEST_SAFE_URLS = [
   // Rewards page
   '/rewards/overview',
   '/rewards/activities',
+  '/earn/save-usdst/info',
   // ActivityFeed page
   '/events',
   // Transfer page

--- a/mercata/ui/src/lib/config.ts
+++ b/mercata/ui/src/lib/config.ts
@@ -4,6 +4,7 @@ export interface ConfigData {
   projectId: string;
   networkId?: string;
   creditCardTopUpAddress?: string;
+  featuredEarnOpportunity?: string;
   stripePublishableKey: string | null;
 }
 

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -1,8 +1,10 @@
-import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import MobileSidebar from "@/components/dashboard/MobileSidebar";
 import MobileBottomNav from "@/components/dashboard/MobileBottomNav";
+import { api } from "@/lib/axios";
+import { getConfig } from "@/lib/config";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -30,7 +32,7 @@ import VaultDepositModal from "@/components/vault/VaultDepositModal";
 import type { Pool } from "@/interface";
 import { formatUnits } from "ethers";
 import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
-import { CircleArrowDown, Star, Vault as VaultIcon } from "lucide-react";
+import { CircleArrowDown, PiggyBank, Star } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import stratoVaultLogo from "@/assets/strato-vault-logo.png";
 import {
@@ -40,6 +42,7 @@ import {
 } from "@/lib/constants";
 
 const WAD = BigInt(10) ** BigInt(18);
+const TOP_OPPORTUNITY_MIN_POOL_TVL = 100000n * WAD;
 
 const safeBigInt = (value: string | undefined | null): bigint => {
   if (!value) return BigInt(0);
@@ -72,64 +75,59 @@ const formatTokenAmount = (value: string): string => {
   }
 };
 
-const formatSignedUsd = (value: string): string => {
-  try {
-    const raw = Number(formatUnits(value, 18));
-    const abs = Math.abs(raw).toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
-    if (Math.abs(raw) < 0.005) return "+$0.00";
-    return raw >= 0 ? `+$${abs}` : `-$${abs}`;
-  } catch {
-    return "+$0.00";
-  }
-};
-
-const formatSignedUsdFromWei = (weiValue: bigint): string => {
-  try {
-    const isPositive = weiValue >= 0n;
-    const absWei = isPositive ? weiValue : -weiValue;
-    const abs = Number(formatUnits(absWei, 18)).toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
-    if (absWei < 5000000000000000n) return isPositive ? "+$0.00" : "-$0.00";
-    return isPositive ? `+$${abs}` : `-$${abs}`;
-  } catch {
-    return "+$0.00";
-  }
-};
+const normalizeAddress = (value?: string | null): string =>
+  (value || "").toLowerCase().replace(/^0x/, "");
 
 const parseApy = (value: string | number | undefined): number => {
   if (!value || value === "-") return Number.NEGATIVE_INFINITY;
   const apy = Number(value);
-  return Number.isFinite(apy) ? apy : Number.NEGATIVE_INFINITY;
+  if (!Number.isFinite(apy)) return Number.NEGATIVE_INFINITY;
+  if (apy <= 0 || Math.abs(apy) < 0.005) return Number.NEGATIVE_INFINITY;
+  return apy;
 };
 
 const isPoolPaused = (pool: Pool): boolean => Boolean((pool as any).isPaused);
 const isPoolDisabled = (pool: Pool): boolean => Boolean((pool as any).isDisabled);
 
-const formatApyDisplay = (value: string | undefined): { label: string; className: string } => {
+const formatApyDisplay = (value: string | number | undefined): { label: string; className: string } => {
   if (!value || value === "-") {
-    return { label: "-", className: "text-foreground" };
+    return { label: "--", className: "text-foreground" };
   }
 
   const apy = Number(value);
   if (!Number.isFinite(apy)) {
-    return { label: "-", className: "text-foreground" };
+    return { label: "--", className: "text-foreground" };
   }
 
-  if (Math.abs(apy) < 0.005) {
-    return { label: "0.00%", className: "text-foreground" };
+  if (apy <= 0 || Math.abs(apy) < 0.005) {
+    return { label: "--", className: "text-foreground" };
   }
 
   const sign = apy >= 0 ? "+" : "-";
   const className = apy >= 0
     ? "text-green-600 dark:text-green-400"
-    : "text-red-600 dark:text-red-400";
+    : "text-foreground";
 
   return { label: `${sign}${Math.abs(apy).toFixed(2)}%`, className };
+};
+
+const getEstimatedIncentiveApy = (
+  emissionRate?: string,
+  totalStakeUsd?: string | null
+): number => {
+  try {
+    if (!emissionRate || !totalStakeUsd) return Number.NEGATIVE_INFINITY;
+
+    const tvlUsd = Number(BigInt(totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return Number.NEGATIVE_INFINITY;
+
+    const annualCata = (Number(BigInt(emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata < 0) return Number.NEGATIVE_INFINITY;
+
+    return ((annualCata * 0.25) / tvlUsd) * 100;
+  } catch {
+    return Number.NEGATIVE_INFINITY;
+  }
 };
 
 const formatPointsMultiplier = (scaledTenths: bigint): string => {
@@ -144,47 +142,10 @@ const formatMaxAmount = (weiAmount: bigint): string => {
   return `${whole}.${frac.slice(0, 18)}`.replace(/\.?0+$/, "");
 };
 
-const PositionCard = ({
-  title,
-  icon,
-  deposited,
-  earnings,
-  rateLabel,
-  rateValue,
-}: {
-  title: string;
-  icon: ReactNode;
-  deposited: string;
-  earnings: { label: string; className: string };
-  rateLabel: "APY" | "APR";
-  rateValue: string;
-}) => {
-  return (
-    <Card className="border border-border/70 dark:border-white/15 bg-card dark:bg-gradient-to-br dark:from-[#0f1a33] dark:to-[#111c3a] shadow-sm">
-      <CardContent className="pt-4 space-y-4">
-        <div className="flex items-center gap-3">
-          <div className="w-9 h-9 rounded-full bg-blue-500/15 dark:bg-blue-400/15 flex items-center justify-center">
-            {icon}
-          </div>
-          <p className="text-lg md:text-xl font-medium tracking-tight">{title}</p>
-        </div>
-        <div className="grid grid-cols-3 gap-3">
-          <div>
-            <p className="text-[11px] md:text-xs text-muted-foreground">Your Shares</p>
-            <p className="text-lg md:text-xl font-medium leading-tight">{deposited}</p>
-          </div>
-          <div>
-            <p className="text-[11px] md:text-xs text-muted-foreground">Earnings</p>
-            <p className={`text-lg md:text-xl font-medium leading-tight ${earnings.className}`}>{earnings.label}</p>
-          </div>
-          <div>
-            <p className="text-[11px] md:text-xs text-muted-foreground">{rateLabel}</p>
-            <p className="text-lg md:text-xl font-medium leading-tight">{rateValue}</p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
+type SaveUsdstInfo = {
+  configured: boolean;
+  deployed: boolean;
+  totalAssets: string;
 };
 
 const TokenPairIcon = ({ pool, size = "sm" }: { pool: Pool; size?: "sm" | "lg" }) => {
@@ -221,6 +182,7 @@ const TokenPairIcon = ({ pool, size = "sm" }: { pool: Pool; size?: "sm" | "lg" }
 
 const Earn = () => {
   type OpportunityRow =
+    | { kind: "saveUsdst"; apySortValue: number }
     | { kind: "vault"; apySortValue: number }
     | { kind: "lending"; apySortValue: number }
     | { kind: "pool"; apySortValue: number; pool: Pool };
@@ -235,12 +197,14 @@ const Earn = () => {
   const [lendingDepositAmount, setLendingDepositAmount] = useState("");
   const [stakeLendingRewards, setStakeLendingRewards] = useState<boolean>(rewardsEnabled);
   const [isLendingSubmitting, setIsLendingSubmitting] = useState(false);
+  const [featuredOpportunityKey, setFeaturedOpportunityKey] = useState("");
+  const [saveUsdstInfo, setSaveUsdstInfo] = useState<SaveUsdstInfo | null>(null);
   const operationInProgressRef = useRef(false);
 
   const { vaultState, refreshVault } = useVaultContext();
   const { pools, fetchPools, poolsLoading } = useSwapContext();
   const { liquidityInfo, loadingLiquidity, refreshLiquidity, depositLiquidity } = useLendingContext();
-  const { usdstBalance, voucherBalance, fetchUsdstBalance } = useTokenContext();
+  const { earningAssets, usdstBalance, voucherBalance, fetchUsdstBalance } = useTokenContext();
   const { activities: rewardsActivities } = useRewardsActivities();
   const { isLoggedIn } = useUser();
   const { toast } = useToast();
@@ -250,6 +214,49 @@ const Earn = () => {
   useEffect(() => {
     document.title = "STRATO Vault | STRATO";
     window.scrollTo(0, 0);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadConfig = async () => {
+      try {
+        const config = await getConfig();
+        if (!cancelled) {
+          setFeaturedOpportunityKey(config.featuredEarnOpportunity || "");
+        }
+      } catch {
+        if (!cancelled) {
+          setFeaturedOpportunityKey("");
+        }
+      }
+    };
+
+    loadConfig();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadSaveUsdstInfo = async () => {
+      try {
+        const response = await api.get<SaveUsdstInfo>("/earn/save-usdst/info", {
+          signal: controller.signal,
+        });
+        setSaveUsdstInfo(response.data);
+      } catch {
+        setSaveUsdstInfo(null);
+      }
+    };
+
+    loadSaveUsdstInfo();
+
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   useEffect(() => {
@@ -338,7 +345,6 @@ const Earn = () => {
       });
       await Promise.all([refreshLiquidity(), fetchPools(), fetchUsdstBalance()]);
     } catch {
-      // Error toast is handled globally.
     } finally {
       setIsLendingSubmitting(false);
     }
@@ -350,17 +356,107 @@ const Earn = () => {
       .sort((a, b) => parseApy(b.apy) - parseApy(a.apy));
   }, [pools]);
 
-  const poolsWithUserPosition = useMemo(() => {
-    return [...(pools || [])].filter((pool) => safeBigInt(pool.lpToken?.totalBalance) > BigInt(0));
-  }, [pools]);
+  const saveUsdstAsset = useMemo(() => {
+    return earningAssets.find((asset) => {
+      const symbol = asset._symbol?.toLowerCase?.() || "";
+      const name = asset._name?.toLowerCase?.() || "";
+      return symbol === "saveusdst" || name.includes("save usdst") || name.includes("saveusdst");
+    });
+  }, [earningAssets]);
 
-  const userHasVaultPosition = safeBigInt(vaultState.userShares) > BigInt(0);
-  const userHasLendingPosition = safeBigInt(liquidityInfo?.withdrawable?.userBalanceTotal) > BigInt(0);
+  const saveUsdstRewardsActivity = useMemo(() => {
+    return rewardsActivities.find((activity) => {
+      const source = activity.sourceContract?.toLowerCase?.() || "";
+      const name = activity.name?.toLowerCase?.() || "";
+      const saveAddress = saveUsdstAsset?.address?.toLowerCase?.() || "";
+
+      if (saveAddress && source === saveAddress) {
+        return true;
+      }
+
+      return name.includes("save usdst") || name.includes("saveusdst");
+    }) || null;
+  }, [rewardsActivities, saveUsdstAsset?.address]);
+
+  const saveUsdstEstimatedApy = useMemo(() => {
+    return getEstimatedIncentiveApy(
+      saveUsdstRewardsActivity?.emissionRate,
+      saveUsdstRewardsActivity?.totalStakeUsd ?? null
+    );
+  }, [saveUsdstRewardsActivity]);
+
+  const saveUsdstTvl = useMemo(() => {
+    if (saveUsdstInfo?.deployed && saveUsdstInfo.totalAssets) {
+      return saveUsdstInfo.totalAssets;
+    }
+
+    return saveUsdstRewardsActivity?.totalStakeUsd || "0";
+  }, [saveUsdstInfo, saveUsdstRewardsActivity]);
+
+  const getOpportunityTvl = (opportunity: OpportunityRow): bigint => {
+    if (opportunity.kind === "saveUsdst") return safeBigInt(saveUsdstTvl);
+    if (opportunity.kind === "vault") return safeBigInt(vaultState.totalEquity);
+    if (opportunity.kind === "lending") return safeBigInt(liquidityInfo?.totalUSDSTSupplied?.toString());
+    return safeBigInt(opportunity.pool.totalLiquidityUSD);
+  };
+
+  const getOpportunitySimplicityRank = (opportunity: OpportunityRow): number => {
+    if (opportunity.kind === "saveUsdst") return 0;
+    if (opportunity.kind === "vault") return 1;
+    if (opportunity.kind === "lending") return 2;
+    return 3;
+  };
+
+  const compareOpportunities = (a: OpportunityRow, b: OpportunityRow): number => {
+    if (b.apySortValue !== a.apySortValue) {
+      return b.apySortValue - a.apySortValue;
+    }
+
+    const simplicityDiff = getOpportunitySimplicityRank(a) - getOpportunitySimplicityRank(b);
+    if (simplicityDiff !== 0) {
+      return simplicityDiff;
+    }
+
+    const tvlA = getOpportunityTvl(a);
+    const tvlB = getOpportunityTvl(b);
+    if (tvlA !== tvlB) {
+      return tvlA > tvlB ? -1 : 1;
+    }
+
+    return 0;
+  };
+
+  const isEligibleForTopOpportunity = (opportunity: OpportunityRow): boolean => {
+    if (opportunity.kind !== "pool") return true;
+    return getOpportunityTvl(opportunity) >= TOP_OPPORTUNITY_MIN_POOL_TVL;
+  };
+
+  const getOpportunityPositionValue = (opportunity: OpportunityRow): string => {
+    if (guestMode) return "--";
+
+    if (opportunity.kind === "saveUsdst") {
+      return `$${saveUsdstAsset?.value || "0.00"}`;
+    }
+
+    if (opportunity.kind === "vault") {
+      return `$${formatUsd(vaultState.userValueUsd || "0")}`;
+    }
+
+    if (opportunity.kind === "lending") {
+      return `$${formatUsd(liquidityInfo?.withdrawable?.userBalance || "0")}`;
+    }
+
+    const lpBalance = safeBigInt(opportunity.pool.lpToken?.totalBalance);
+    const lpPrice = safeBigInt(opportunity.pool.lpToken?.price);
+    const depositedUsd = lpPrice > 0n ? (lpBalance * lpPrice) / WAD : 0n;
+    return `$${formatUsd(depositedUsd.toString())}`;
+  };
 
   const allOpportunities = useMemo<OpportunityRow[]>(() => {
     const rows: OpportunityRow[] = [];
 
     if (activeFilter === "all" || activeFilter === "vaults") {
+      rows.push({ kind: "saveUsdst", apySortValue: saveUsdstEstimatedApy });
       rows.push({ kind: "vault", apySortValue: parseApy(vaultState.apy) });
     }
 
@@ -371,12 +467,13 @@ const Earn = () => {
       }
     }
 
-    return rows.sort((a, b) => b.apySortValue - a.apySortValue);
-  }, [activeFilter, liquidityInfo?.supplyAPY, sortedPools, vaultState.apy]);
+    return rows.sort(compareOpportunities);
+  }, [activeFilter, liquidityInfo?.supplyAPY, saveUsdstEstimatedApy, saveUsdstTvl, sortedPools, vaultState.apy, vaultState.totalEquity, liquidityInfo?.totalUSDSTSupplied]);
 
   const topApy = formatApyDisplay(vaultState.apy);
   const topOpportunity = useMemo<OpportunityRow>(() => {
     const candidates: OpportunityRow[] = [
+      { kind: "saveUsdst", apySortValue: saveUsdstEstimatedApy },
       { kind: "vault", apySortValue: parseApy(vaultState.apy) },
       { kind: "lending", apySortValue: parseApy(liquidityInfo?.supplyAPY) },
       ...sortedPools.map((pool) => ({
@@ -385,13 +482,16 @@ const Earn = () => {
         pool,
       })),
     ];
+    const rankedCandidates = [...candidates].sort(compareOpportunities);
+    const eligibleCandidates = rankedCandidates.filter(isEligibleForTopOpportunity);
     return (
-      candidates.sort((a, b) => b.apySortValue - a.apySortValue)[0] ?? {
-        kind: "vault",
+      eligibleCandidates[0] ??
+      rankedCandidates[0] ?? {
+        kind: "saveUsdst",
         apySortValue: Number.NEGATIVE_INFINITY,
       }
     );
-  }, [liquidityInfo?.supplyAPY, sortedPools, vaultState.apy]);
+  }, [liquidityInfo?.supplyAPY, liquidityInfo?.totalUSDSTSupplied, saveUsdstEstimatedApy, saveUsdstTvl, sortedPools, vaultState.apy, vaultState.totalEquity]);
 
   const rewardActivityByContract = useMemo(() => {
     const map = new Map<string, { emissionRate: bigint }>();
@@ -447,137 +547,119 @@ const Earn = () => {
 
   const vaultRewardMeta = getRewardMeta(vaultState.shareTokenAddress);
   const lendingRewardMeta = getRewardMeta(mUsdstAddress);
-  const topOpportunityMeta = useMemo(() => {
-    if (topOpportunity.kind === "vault") {
+  const saveUsdstRewardMeta = getRewardMeta(saveUsdstRewardsActivity?.sourceContract || saveUsdstAsset?.address);
+  const getOpportunityMeta = (opportunity: OpportunityRow) => {
+    if (opportunity.kind === "saveUsdst") {
       return {
-        title: "STRATO Vault",
+        title: "Savings Vault",
+        subtitle: "Stable USD savings with rewards-based yield today",
+        apyRaw: saveUsdstEstimatedApy,
+        tvl: saveUsdstTvl,
+        badge: "Savings Vault",
+        rateLabel: "Est. Yield",
+        actionLabel: "Deposit",
+        onCardClick: () => navigate("/dashboard/earn-save"),
+        onActionClick: () => navigate("/dashboard/earn-save"),
+      };
+    }
+
+    if (opportunity.kind === "vault") {
+      return {
+        title: "Diversified Vault",
         subtitle: "Diversified real assets: gold, silver, ETH, BTC, stables - actively managed",
         apyRaw: vaultState.apy,
         tvl: vaultState.totalEquity,
-        badge: "Vault",
+        badge: "Diversified Vault",
+        rateLabel: "APY",
+        actionLabel: "Deposit",
         onCardClick: () => navigate("/dashboard/earn-vault"),
         onActionClick: () => handleVaultDepositClick(),
       };
     }
 
-    if (topOpportunity.kind === "lending") {
+    if (opportunity.kind === "lending") {
       return {
         title: "USDST Lending Pool",
         subtitle: "Earn yield by supplying USDST liquidity",
         apyRaw: liquidityInfo?.supplyAPY?.toString(),
         tvl: liquidityInfo?.totalUSDSTSupplied?.toString() || "0",
         badge: "Lending",
+        rateLabel: "APY",
+        actionLabel: "Deposit",
         onCardClick: () => navigate("/dashboard/earn-lending"),
         onActionClick: () => handleLendingDepositClick(),
       };
     }
 
-    const pool = topOpportunity.pool;
+    const pool = opportunity.pool;
     return {
       title: pool.poolName,
       subtitle: `Earn fees on ${pool.poolName.replace(" Pool", "")} swaps`,
       apyRaw: pool.apy,
       tvl: pool.totalLiquidityUSD,
       badge: "Pool",
+      rateLabel: "APY",
+      actionLabel: "Deposit",
       onCardClick: () => navigateToPoolDetails(pool),
       onActionClick: () => handlePoolDeposit(pool),
       pool,
     };
+  };
+
+  const configuredFeaturedOpportunity = useMemo<OpportunityRow | null>(() => {
+    const key = featuredOpportunityKey.trim().toLowerCase();
+    if (!key) return null;
+
+    if (key === "save-usdst" || key === "saveusdst") {
+      return { kind: "saveUsdst", apySortValue: saveUsdstEstimatedApy };
+    }
+
+    if (key === "vault") {
+      return { kind: "vault", apySortValue: parseApy(vaultState.apy) };
+    }
+
+    if (key === "lending") {
+      return { kind: "lending", apySortValue: parseApy(liquidityInfo?.supplyAPY) };
+    }
+
+    if (key.startsWith("pool:")) {
+      const targetAddress = normalizeAddress(key.slice(5));
+      const pool = sortedPools.find((candidate) => normalizeAddress(candidate.address) === targetAddress);
+      if (pool) {
+        return { kind: "pool", apySortValue: parseApy(pool.apy), pool };
+      }
+    }
+
+    return null;
   }, [
-    topOpportunity,
-    vaultState.apy,
-    vaultState.totalEquity,
+    featuredOpportunityKey,
     liquidityInfo?.supplyAPY,
-    liquidityInfo?.totalUSDSTSupplied,
-    navigate,
+    saveUsdstEstimatedApy,
+    sortedPools,
+    vaultState.apy,
   ]);
+
+  const topOpportunityMeta = useMemo(() => getOpportunityMeta(topOpportunity), [topOpportunity, saveUsdstEstimatedApy, saveUsdstTvl, vaultState.apy, vaultState.totalEquity, liquidityInfo?.supplyAPY, liquidityInfo?.totalUSDSTSupplied, navigate]);
   const topOpportunityApy = formatApyDisplay(topOpportunityMeta.apyRaw);
+  const featuredOpportunityMeta = useMemo(
+    () => (configuredFeaturedOpportunity ? getOpportunityMeta(configuredFeaturedOpportunity) : null),
+    [
+      configuredFeaturedOpportunity,
+      saveUsdstEstimatedApy,
+      saveUsdstTvl,
+      vaultState.apy,
+      vaultState.totalEquity,
+      liquidityInfo?.supplyAPY,
+      liquidityInfo?.totalUSDSTSupplied,
+      navigate,
+    ]
+  );
+  const featuredOpportunityApy = formatApyDisplay(featuredOpportunityMeta?.apyRaw);
 
   const pageLoading =
     vaultState.loading ||
     (isLoggedIn && vaultState.loadingUser) ||
     (poolsLoading && (pools?.length || 0) === 0);
-
-  const sortedUserPositionCards = (() => {
-    const positions: Array<{ key: string; apySortValue: number; card: ReactNode }> = [];
-
-    if (userHasVaultPosition) {
-      positions.push({
-        key: "position-vault",
-        apySortValue: parseApy(vaultState.apy),
-        card: (
-          <PositionCard
-            title="STRATO Vault"
-            icon={<VaultIcon className="h-4 w-4 text-blue-600 dark:text-blue-400" />}
-            deposited={`$${formatUsd(vaultState.userValueUsd)}`}
-            earnings={{
-              label: formatSignedUsd(vaultState.allTimeEarnings),
-              className:
-                safeBigInt(vaultState.allTimeEarnings) >= BigInt(0)
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-red-600 dark:text-red-400",
-            }}
-            rateLabel="APY"
-            rateValue={vaultState.apy === "-" ? "-" : `${vaultState.apy}%`}
-          />
-        ),
-      });
-    }
-
-    if (userHasLendingPosition) {
-      const lendingEarningsWei = safeBigInt(liquidityInfo?.userAllTimeEarningsUsd);
-      positions.push({
-        key: "position-lending",
-        apySortValue: parseApy(liquidityInfo?.supplyAPY),
-        card: (
-          <PositionCard
-            title="USDST Lending Pool"
-            icon={<CircleArrowDown className="h-4 w-4 text-blue-600 dark:text-blue-400" />}
-            deposited={`$${formatUsd(liquidityInfo?.withdrawable?.userBalance || "0")}`}
-            earnings={{
-              label: formatSignedUsdFromWei(lendingEarningsWei),
-              className: lendingEarningsWei >= 0n
-                ? "text-green-600 dark:text-green-400"
-                : "text-red-600 dark:text-red-400",
-            }}
-            rateLabel="APY"
-            rateValue={liquidityInfo?.supplyAPY ? `${liquidityInfo.supplyAPY}%` : "N/A"}
-          />
-        ),
-      });
-    }
-
-    for (const pool of poolsWithUserPosition) {
-      const lpBalance = safeBigInt(pool.lpToken?.totalBalance);
-      const lpPrice = safeBigInt(pool.lpToken?.price);
-      const depositedUsd = lpPrice > BigInt(0) ? (lpBalance * lpPrice) / WAD : BigInt(0);
-      const poolEarningsWei = safeBigInt((pool as any).userAllTimeEarningsUsd);
-      const poolEarningsLabel = formatSignedUsdFromWei(poolEarningsWei);
-      const poolEarningsClass = poolEarningsWei >= 0n
-        ? "text-green-600 dark:text-green-400"
-        : "text-red-600 dark:text-red-400";
-
-      positions.push({
-        key: `position-pool-${pool.address}`,
-        apySortValue: parseApy(pool.apy),
-        card: (
-          <PositionCard
-            title={pool.poolName}
-            icon={<TokenPairIcon pool={pool} />}
-            deposited={`$${formatUsd(depositedUsd.toString())}`}
-            earnings={{
-              label: poolEarningsLabel,
-              className: poolEarningsClass,
-            }}
-            rateLabel="APY"
-            rateValue={pool.apy ? `${pool.apy}%` : "N/A"}
-          />
-        ),
-      });
-    }
-
-    return positions.sort((a, b) => b.apySortValue - a.apySortValue);
-  })();
 
   if (pageLoading) {
     return (
@@ -605,10 +687,6 @@ const Earn = () => {
               </div>
             </div>
             <Skeleton className="h-40 w-full rounded-lg" />
-            <div className="space-y-3">
-              <Skeleton className="h-6 w-40" />
-              <Skeleton className="h-72 w-full rounded-lg" />
-            </div>
           </main>
         </div>
 
@@ -636,111 +714,173 @@ const Earn = () => {
             <GuestSignInBanner message="Sign in to view your positions and manage pool deposits or withdrawals" />
           )}
 
-          {/* Your Positions */}
-          <section className="space-y-3">
-            <h2 className="text-lg font-semibold">Your Positions</h2>
-            {guestMode ? (
-              <Card>
-                <CardContent className="pt-6 text-sm text-muted-foreground">
-                  Sign in to see your vault and pool positions.
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {sortedUserPositionCards.map((position) => (
-                  <Fragment key={position.key}>{position.card}</Fragment>
-                ))}
-
-                {sortedUserPositionCards.length === 0 && (
-                  <Card>
-                    <CardContent className="pt-6 text-sm text-muted-foreground">
-                      No active positions yet.
+          <section>
+            <div className={`grid grid-cols-1 gap-4 ${configuredFeaturedOpportunity && featuredOpportunityMeta ? "xl:grid-cols-2" : ""}`}>
+              {configuredFeaturedOpportunity && featuredOpportunityMeta && (
+                <div>
+                  <Card
+                    className="border border-amber-500/40 dark:border-amber-400/35 bg-gradient-to-br from-[#fffaf0] to-[#fff4db] dark:from-[#24190a] dark:to-[#2b1d0c] shadow-sm cursor-pointer h-full"
+                    role="button"
+                    tabIndex={0}
+                    onClick={featuredOpportunityMeta.onCardClick}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        featuredOpportunityMeta.onCardClick();
+                      }
+                    }}
+                  >
+                    <CardContent className="pt-3 pb-3 px-4 md:px-4 space-y-2">
+                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5 w-fit rounded-md bg-background/70 dark:bg-white/10">
+                        Featured Opportunity
+                      </Badge>
+                      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-3">
+                            {configuredFeaturedOpportunity.kind === "saveUsdst" ? (
+                              <div className="w-12 h-12 rounded-full bg-emerald-500/15 dark:bg-emerald-400/15 flex items-center justify-center shrink-0">
+                                <PiggyBank className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                              </div>
+                            ) : configuredFeaturedOpportunity.kind === "vault" ? (
+                              <img
+                                src={stratoVaultLogo}
+                                alt="STRATO Vault"
+                                className="w-12 h-12 rounded-full object-cover shrink-0"
+                              />
+                            ) : configuredFeaturedOpportunity.kind === "lending" ? (
+                              <div className="w-12 h-12 rounded-full bg-blue-500/15 dark:bg-blue-400/15 flex items-center justify-center shrink-0">
+                                <CircleArrowDown className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                              </div>
+                            ) : (
+                              <TokenPairIcon pool={configuredFeaturedOpportunity.pool} size="lg" />
+                            )}
+                            <div className="min-w-0">
+                              <h3 className="text-2xl md:text-[26px] leading-none font-semibold tracking-tight">{featuredOpportunityMeta.title}</h3>
+                              <p className="mt-0.5 text-xs md:text-sm text-muted-foreground">
+                                {featuredOpportunityMeta.subtitle}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="text-left md:text-right shrink-0">
+                          <p className="text-xs md:text-sm uppercase tracking-wide text-muted-foreground">
+                            {featuredOpportunityMeta.rateLabel}
+                          </p>
+                          <p className={`text-2xl md:text-[32px] leading-none font-semibold ${featuredOpportunityApy.className}`}>
+                            {featuredOpportunityApy.label === "-" ? "-" : featuredOpportunityApy.label}
+                          </p>
+                          <p className="mt-0.5 text-xs md:text-sm text-muted-foreground">
+                            TVL ${formatUsd(featuredOpportunityMeta.tvl)}
+                          </p>
+                          <div className="mt-1 flex items-center gap-2 md:justify-end">
+                            <Badge variant="secondary" className="text-[10px] px-2 py-0.5 rounded-md">{featuredOpportunityMeta.badge}</Badge>
+                            <Badge className="text-[10px] px-2 py-0.5 rounded-md bg-amber-600 hover:bg-amber-600 text-white">Featured</Badge>
+                          </div>
+                        </div>
+                      </div>
+                      <Button
+                        className="w-full h-8 rounded-lg bg-amber-600 hover:bg-amber-600 text-white font-medium"
+                        variant="default"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          featuredOpportunityMeta.onActionClick();
+                        }}
+                        disabled={
+                          (featuredOpportunityMeta.actionLabel === "Deposit" && guestMode) ||
+                          (configuredFeaturedOpportunity.kind === "pool" &&
+                            (isPoolPaused(configuredFeaturedOpportunity.pool) || Boolean((configuredFeaturedOpportunity.pool as any).isDisabled)))
+                        }
+                      >
+                        {featuredOpportunityMeta.actionLabel === "View" ? "Deposit" : featuredOpportunityMeta.actionLabel}
+                      </Button>
                     </CardContent>
                   </Card>
-                )}
-              </div>
-            )}
-          </section>
+                </div>
+              )}
 
-          {/* Top Opportunity */}
-          <section className="space-y-2">
-            <Card
-              className="border border-blue-500/40 dark:border-blue-400/35 bg-gradient-to-br from-[#f8fbff] to-[#edf3ff] dark:from-[#0f1a33] dark:to-[#111c3a] shadow-sm cursor-pointer"
-              role="button"
-              tabIndex={0}
-              onClick={topOpportunityMeta.onCardClick}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  topOpportunityMeta.onCardClick();
-                }
-              }}
-            >
-              <CardContent className="pt-3 pb-3 px-4 md:px-5 space-y-3">
-                <Badge variant="secondary" className="text-[10px] px-2 py-0.5 w-fit rounded-md bg-background/70 dark:bg-white/10">
-                  Top Opportunity
-                </Badge>
-                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-3">
-                      {topOpportunity.kind === "vault" ? (
-                        <img
-                          src={stratoVaultLogo}
-                          alt="STRATO Vault"
-                          className="w-16 h-16 rounded-full object-cover shrink-0"
-                        />
-                      ) : topOpportunity.kind === "lending" ? (
-                        <div className="w-16 h-16 rounded-full bg-blue-500/15 dark:bg-blue-400/15 flex items-center justify-center shrink-0">
-                          <CircleArrowDown className="h-7 w-7 text-blue-600 dark:text-blue-400" />
-                        </div>
-                      ) : (
-                          <TokenPairIcon pool={topOpportunity.pool} size="lg" />
-                      )}
+                <div>
+                <Card
+                  className="border border-blue-500/40 dark:border-blue-400/35 bg-gradient-to-br from-[#f8fbff] to-[#edf3ff] dark:from-[#0f1a33] dark:to-[#111c3a] shadow-sm cursor-pointer h-full"
+                  role="button"
+                  tabIndex={0}
+                  onClick={topOpportunityMeta.onCardClick}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      topOpportunityMeta.onCardClick();
+                    }
+                  }}
+                >
+                  <CardContent className="pt-3 pb-3 px-4 md:px-4 space-y-2">
+                    <Badge variant="secondary" className="text-[10px] px-2 py-0.5 w-fit rounded-md bg-background/70 dark:bg-white/10">
+                      Top Opportunity
+                    </Badge>
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
                       <div className="min-w-0">
-                        <h3 className="text-[30px] leading-none font-semibold tracking-tight">{topOpportunityMeta.title}</h3>
-                        <p className="mt-1 text-xs md:text-sm text-muted-foreground">
-                          {topOpportunityMeta.subtitle}
+                        <div className="flex items-center gap-3">
+                          {topOpportunity.kind === "saveUsdst" ? (
+                          <div className="w-12 h-12 rounded-full bg-emerald-500/15 dark:bg-emerald-400/15 flex items-center justify-center shrink-0">
+                            <PiggyBank className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                            </div>
+                          ) : topOpportunity.kind === "vault" ? (
+                            <img
+                              src={stratoVaultLogo}
+                              alt="STRATO Vault"
+                            className="w-12 h-12 rounded-full object-cover shrink-0"
+                            />
+                          ) : topOpportunity.kind === "lending" ? (
+                          <div className="w-12 h-12 rounded-full bg-blue-500/15 dark:bg-blue-400/15 flex items-center justify-center shrink-0">
+                            <CircleArrowDown className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                            </div>
+                          ) : (
+                            <TokenPairIcon pool={topOpportunity.pool} size="lg" />
+                          )}
+                          <div className="min-w-0">
+                          <h3 className="text-2xl md:text-[26px] leading-none font-semibold tracking-tight">{topOpportunityMeta.title}</h3>
+                          <p className="mt-0.5 text-xs md:text-sm text-muted-foreground">
+                              {topOpportunityMeta.subtitle}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="text-left md:text-right shrink-0">
+                        <p className="text-xs md:text-sm uppercase tracking-wide text-muted-foreground">
+                          {topOpportunityMeta.rateLabel}
                         </p>
+                      <p className={`text-2xl md:text-[32px] leading-none font-semibold ${topOpportunityApy.className}`}>
+                          {topOpportunityApy.label === "-" ? "-" : topOpportunityApy.label}
+                        </p>
+                      <p className="mt-0.5 text-xs md:text-sm text-muted-foreground">
+                          TVL ${formatUsd(topOpportunityMeta.tvl)}
+                        </p>
+                      <div className="mt-1 flex items-center gap-2 md:justify-end">
+                          <Badge variant="secondary" className="text-[10px] px-2 py-0.5 rounded-md">{topOpportunityMeta.badge}</Badge>
+                          <Badge className="text-[10px] px-2 py-0.5 rounded-md bg-blue-600 hover:bg-blue-600 text-white">Featured</Badge>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="text-left md:text-right shrink-0">
-                    <p className="text-3xl md:text-[40px] leading-none font-semibold text-foreground">
-                      <span>APY </span>
-                      <span className={topOpportunityApy.className}>
-                        {topOpportunityApy.label === "-" ? "-" : topOpportunityApy.label}
-                      </span>
-                    </p>
-                    <p className="mt-1 text-xs md:text-sm text-muted-foreground">
-                      TVL ${formatUsd(topOpportunityMeta.tvl)}
-                    </p>
-                    <div className="mt-1.5 flex items-center gap-2 md:justify-end">
-                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5 rounded-md">{topOpportunityMeta.badge}</Badge>
-                      <Badge className="text-[10px] px-2 py-0.5 rounded-md bg-blue-600 hover:bg-blue-600 text-white">Featured</Badge>
-                    </div>
-                  </div>
-                </div>
-                <Button
-                  className="w-full h-9 rounded-lg bg-blue-600 hover:bg-blue-600 text-white font-medium"
-                  variant="default"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    topOpportunityMeta.onActionClick();
-                  }}
-                  disabled={
-                    guestMode ||
-                    (topOpportunity.kind === "pool" &&
-                      (isPoolPaused(topOpportunity.pool) || Boolean((topOpportunity.pool as any).isDisabled)))
-                  }
-                >
-                  Deposit
-                </Button>
-              </CardContent>
-            </Card>
+                    <Button
+                    className="w-full h-8 rounded-lg bg-blue-600 hover:bg-blue-600 text-white font-medium"
+                      variant="default"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        topOpportunityMeta.onActionClick();
+                      }}
+                      disabled={
+                        (topOpportunityMeta.actionLabel === "Deposit" && guestMode) ||
+                        (topOpportunity.kind === "pool" &&
+                          (isPoolPaused(topOpportunity.pool) || Boolean((topOpportunity.pool as any).isDisabled)))
+                      }
+                    >
+                      {topOpportunityMeta.actionLabel}
+                    </Button>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
           </section>
 
-          {/* All Opportunities */}
-          <section className="space-y-3">
+          <section className="mt-2 space-y-3 border-t border-border/60 pt-5">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <h2 className="text-lg font-semibold">All Opportunities</h2>
               <div className="w-full sm:w-auto overflow-x-auto">
@@ -788,9 +928,96 @@ const Earn = () => {
             <Card className="border border-border/70 overflow-hidden">
               <CardContent className="p-0">
                 <div className="w-full max-w-full overflow-x-auto">
-                  <table className="w-full min-w-[980px]">
+                  <table className="w-full min-w-[1260px]">
+                    <thead className="bg-muted/40">
+                      <tr className="border-b border-border/50">
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Opportunity</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Yield</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Rewards</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">TVL</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Your Position</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Type</th>
+                        <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">Action</th>
+                      </tr>
+                    </thead>
                     <tbody>
                       {allOpportunities.map((opportunity) => {
+                        if (opportunity.kind === "saveUsdst") {
+                          const saveUsdstApyDisplay = formatApyDisplay(saveUsdstEstimatedApy);
+                          return (
+                            <tr
+                              key="save-usdst"
+                              className="border-b border-border/40 cursor-pointer hover:bg-muted/20"
+                              role="button"
+                              tabIndex={0}
+                              onClick={() => navigate("/dashboard/earn-save")}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  navigate("/dashboard/earn-save");
+                                }
+                              }}
+                            >
+                              <td className="px-4 py-3">
+                                <div className="flex items-center gap-2.5 min-w-0">
+                                  <div className="w-8 h-8 rounded-full bg-emerald-500/15 dark:bg-emerald-400/15 flex items-center justify-center shrink-0">
+                                    <PiggyBank className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                                  </div>
+                                  <p className="font-medium truncate">Savings Vault</p>
+                                  <Badge variant="secondary" className="text-[10px]">Savings Vault</Badge>
+                                </div>
+                              </td>
+                              <td className="px-4 py-3">
+                                <p className={`text-sm font-semibold ${saveUsdstApyDisplay.className}`}>
+                                  {saveUsdstApyDisplay.label}
+                                </p>
+                                <p className="text-xs text-muted-foreground">Est. Yield</p>
+                              </td>
+                              <td className="px-4 py-3">
+                                {saveUsdstRewardMeta.pointsLabel !== "-" ? (
+                                  <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                                    <Star className="h-4 w-4 text-amber-500" />
+                                    <span className="font-medium text-foreground">{saveUsdstRewardMeta.pointsLabel}</span>
+                                    {saveUsdstRewardMeta.featured && (
+                                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Boosted</Badge>
+                                    )}
+                                  </div>
+                                ) : (
+                                  <span className="text-sm text-muted-foreground">--</span>
+                                )}
+                              </td>
+                              <td className="px-4 py-3">
+                                <p className="text-sm font-semibold">
+                                  ${formatUsd(saveUsdstTvl)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">TVL</p>
+                              </td>
+                              <td className="px-4 py-3">
+                                <p className="text-sm font-semibold">{getOpportunityPositionValue(opportunity)}</p>
+                                <p className="text-xs text-muted-foreground">Your Position</p>
+                              </td>
+                              <td className="px-4 py-3 text-sm text-muted-foreground">
+                                Savings Vault
+                              </td>
+                              <td className="px-4 py-3">
+                                <div className="flex items-center justify-end gap-2">
+                                  <Button
+                                    className="h-9 min-w-[108px] justify-center"
+                                    size="sm"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      navigate("/dashboard/earn-save");
+                                    }}
+                                  >
+                                    <CircleArrowDown className="h-4 w-4 mr-1 shrink-0" />
+                                    Deposit
+                                  </Button>
+                                </div>
+                              </td>
+                            </tr>
+                          );
+                        }
+
                         if (opportunity.kind === "vault") {
                           return (
                             <tr
@@ -813,33 +1040,44 @@ const Earn = () => {
                                     alt="STRATO Vault"
                                     className="w-8 h-8 rounded-full object-cover shrink-0"
                                   />
-                                  <p className="font-medium truncate">STRATO Vault</p>
-                                  <Badge variant="secondary" className="text-[10px]">Vault</Badge>
+                                  <p className="font-medium truncate">Diversified Vault</p>
+                                  <Badge variant="secondary" className="text-[10px]">Diversified Vault</Badge>
                                 </div>
                               </td>
                               <td className="px-4 py-3">
                                 <p className={`text-sm font-semibold ${topApy.className}`}>
-                                  {topApy.label === "-" ? "-" : topApy.label}
+                                  {topApy.label}
                                 </p>
                                 <p className="text-xs text-muted-foreground">APY</p>
+                              </td>
+                              <td className="px-4 py-3">
+                                {vaultRewardMeta.pointsLabel !== "-" ? (
+                                  <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                                    <Star className="h-4 w-4 text-amber-500" />
+                                    <span className="font-medium text-foreground">{vaultRewardMeta.pointsLabel}</span>
+                                    {vaultRewardMeta.featured && (
+                                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Boosted</Badge>
+                                    )}
+                                  </div>
+                                ) : (
+                                  <span className="text-sm text-muted-foreground">--</span>
+                                )}
                               </td>
                               <td className="px-4 py-3">
                                 <p className="text-sm font-semibold">${formatUsd(vaultState.totalEquity)}</p>
                                 <p className="text-xs text-muted-foreground">TVL</p>
                               </td>
+                              <td className="px-4 py-3">
+                                <p className="text-sm font-semibold">{getOpportunityPositionValue(opportunity)}</p>
+                                <p className="text-xs text-muted-foreground">Your Position</p>
+                              </td>
                               <td className="px-4 py-3 text-sm text-muted-foreground">
-                                Diversified real assets
+                                Diversified Vault
                               </td>
                               <td className="px-4 py-3">
                                 <div className="flex items-center justify-end gap-3">
                                   {vaultRewardMeta.pointsLabel !== "-" && (
-                                    <div className="hidden md:flex items-center gap-1 text-sm text-muted-foreground">
-                                      <Star className="h-4 w-4 text-amber-500" />
-                                      <span className="font-medium text-foreground">{vaultRewardMeta.pointsLabel}</span>
-                                      {vaultRewardMeta.featured && (
-                                        <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Featured</Badge>
-                                      )}
-                                    </div>
+                                    <div className="hidden" />
                                   )}
                                   <Button
                                     className="h-9 min-w-[108px] justify-center"
@@ -884,9 +1122,22 @@ const Earn = () => {
                               </td>
                               <td className="px-4 py-3">
                                 <p className="text-sm font-semibold">
-                                  {liquidityInfo?.supplyAPY ? `${liquidityInfo.supplyAPY}%` : "N/A"}
+                                  {formatApyDisplay(liquidityInfo?.supplyAPY).label}
                                 </p>
                                 <p className="text-xs text-muted-foreground">APY</p>
+                              </td>
+                              <td className="px-4 py-3">
+                                {lendingRewardMeta.pointsLabel !== "-" ? (
+                                  <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                                    <Star className="h-4 w-4 text-amber-500" />
+                                    <span className="font-medium text-foreground">{lendingRewardMeta.pointsLabel}</span>
+                                    {lendingRewardMeta.featured && (
+                                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Boosted</Badge>
+                                    )}
+                                  </div>
+                                ) : (
+                                  <span className="text-sm text-muted-foreground">--</span>
+                                )}
                               </td>
                               <td className="px-4 py-3">
                                 <p className="text-sm font-semibold">
@@ -896,19 +1147,17 @@ const Earn = () => {
                                 </p>
                                 <p className="text-xs text-muted-foreground">TVL</p>
                               </td>
+                              <td className="px-4 py-3">
+                                <p className="text-sm font-semibold">{getOpportunityPositionValue(opportunity)}</p>
+                                <p className="text-xs text-muted-foreground">Your Position</p>
+                              </td>
                               <td className="px-4 py-3 text-sm text-muted-foreground">
-                                Earn yield by supplying USDST liquidity
+                                Lending pool
                               </td>
                               <td className="px-4 py-3">
                                 <div className="flex items-center justify-end gap-2">
                                   {lendingRewardMeta.pointsLabel !== "-" && (
-                                    <div className="hidden md:flex items-center gap-1 text-sm text-muted-foreground mr-1">
-                                      <Star className="h-4 w-4 text-amber-500" />
-                                      <span className="font-medium text-foreground">{lendingRewardMeta.pointsLabel}</span>
-                                      {lendingRewardMeta.featured && (
-                                        <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Featured</Badge>
-                                      )}
-                                    </div>
+                                    <div className="hidden" />
                                   )}
                                   <Button
                                     className="h-9 min-w-[108px] justify-center"
@@ -953,27 +1202,38 @@ const Earn = () => {
                               </td>
                               <td className="px-4 py-3">
                                 <p className="text-sm font-semibold">
-                                  {pool.apy ? `${pool.apy}%` : "N/A"}
+                                  {formatApyDisplay(pool.apy).label}
                                 </p>
                                 <p className="text-xs text-muted-foreground">APY</p>
+                              </td>
+                              <td className="px-4 py-3">
+                                {poolRewardMeta.pointsLabel !== "-" ? (
+                                  <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                                    <Star className="h-4 w-4 text-amber-500" />
+                                    <span className="font-medium text-foreground">{poolRewardMeta.pointsLabel}</span>
+                                    {poolRewardMeta.featured && (
+                                      <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Boosted</Badge>
+                                    )}
+                                  </div>
+                                ) : (
+                                  <span className="text-sm text-muted-foreground">--</span>
+                                )}
                               </td>
                               <td className="px-4 py-3">
                                 <p className="text-sm font-semibold">${formatUsd(pool.totalLiquidityUSD)}</p>
                                 <p className="text-xs text-muted-foreground">TVL</p>
                               </td>
+                              <td className="px-4 py-3">
+                                <p className="text-sm font-semibold">{getOpportunityPositionValue(opportunity)}</p>
+                                <p className="text-xs text-muted-foreground">Your Position</p>
+                              </td>
                               <td className="px-4 py-3 text-sm text-muted-foreground">
-                                {`Earn fees on ${pool.poolName.replace(" Pool", "")} swaps`}
+                                Swap fees
                               </td>
                               <td className="px-4 py-3">
                                 <div className="flex items-center justify-end gap-2">
                                   {poolRewardMeta.pointsLabel !== "-" && (
-                                    <div className="hidden md:flex items-center gap-1 text-sm text-muted-foreground mr-1">
-                                      <Star className="h-4 w-4 text-amber-500" />
-                                      <span className="font-medium text-foreground">{poolRewardMeta.pointsLabel}</span>
-                                      {poolRewardMeta.featured && (
-                                        <Badge variant="secondary" className="text-[10px] px-2 py-0.5">Featured</Badge>
-                                      )}
-                                    </div>
+                                    <div className="hidden" />
                                   )}
                                   <Button
                                     className="h-9 min-w-[108px] justify-center"
@@ -996,7 +1256,7 @@ const Earn = () => {
 
                       {(activeFilter === "pools" && !poolsLoading && sortedPools.length === 0) && (
                         <tr>
-                          <td className="px-4 py-6 text-sm text-muted-foreground" colSpan={5}>
+                          <td className="px-4 py-6 text-sm text-muted-foreground" colSpan={7}>
                             No pool opportunities available.
                           </td>
                         </tr>
@@ -1007,6 +1267,7 @@ const Earn = () => {
               </CardContent>
             </Card>
           </section>
+
         </main>
       </div>
 

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -552,7 +552,7 @@ const Earn = () => {
     if (opportunity.kind === "saveUsdst") {
       return {
         title: "Savings Vault",
-        subtitle: "Stable USD savings with rewards-based yield today",
+        subtitle: "Stable USD savings with rewards-based yield",
         apyRaw: saveUsdstEstimatedApy,
         tvl: saveUsdstTvl,
         badge: "Savings Vault",
@@ -855,7 +855,7 @@ const Earn = () => {
                         </p>
                       <div className="mt-1 flex items-center gap-2 md:justify-end">
                           <Badge variant="secondary" className="text-[10px] px-2 py-0.5 rounded-md">{topOpportunityMeta.badge}</Badge>
-                          <Badge className="text-[10px] px-2 py-0.5 rounded-md bg-blue-600 hover:bg-blue-600 text-white">Featured</Badge>
+                          <Badge className="text-[10px] px-2 py-0.5 rounded-md bg-blue-600 hover:bg-blue-600 text-white">Top Ranked</Badge>
                         </div>
                       </div>
                     </div>
@@ -1008,6 +1008,7 @@ const Earn = () => {
                                       e.stopPropagation();
                                       navigate("/dashboard/earn-save");
                                     }}
+                                    disabled={guestMode}
                                   >
                                     <CircleArrowDown className="h-4 w-4 mr-1 shrink-0" />
                                     Deposit
@@ -1086,6 +1087,7 @@ const Earn = () => {
                                       e.stopPropagation();
                                       handleVaultDepositClick();
                                     }}
+                                    disabled={guestMode}
                                   >
                                     <CircleArrowDown className="h-4 w-4 mr-1 shrink-0" />
                                     Deposit

--- a/mercata/ui/src/pages/EarnSave.tsx
+++ b/mercata/ui/src/pages/EarnSave.tsx
@@ -1,0 +1,593 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { formatUnits } from "ethers";
+import { ArrowLeft, CircleDollarSign, PiggyBank, Sparkles, Wallet } from "lucide-react";
+import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import MobileBottomNav from "@/components/dashboard/MobileBottomNav";
+import GuestSignInBanner from "@/components/ui/GuestSignInBanner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useUser } from "@/context/UserContext";
+import { api } from "@/lib/axios";
+import { useToast } from "@/hooks/use-toast";
+import { safeParseUnits } from "@/utils/numberUtils";
+import { useRewardsActivities } from "@/hooks/useRewardsActivities";
+import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
+import { RewardsWidget } from "@/components/rewards/RewardsWidget";
+import {
+  calculateRealTimePendingRewards,
+  formatRoundedWithCommas,
+  roundByMagnitude,
+} from "@/services/rewardsService";
+
+const formatTokenAmount = (value: string, maxFractionDigits: number = 4): string => {
+  try {
+    const num = Number(formatUnits(value || "0", 18));
+    if (!Number.isFinite(num) || Math.abs(num) < 0.000001) return "0";
+    return num.toLocaleString("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
+    });
+  } catch {
+    return "0";
+  }
+};
+
+const formatExchangeRate = (exchangeRate: string): string => {
+  try {
+    const num = Number(formatUnits(exchangeRate || "0", 18));
+    if (!Number.isFinite(num)) return "-";
+    return `${num.toFixed(4)} USDST`;
+  } catch {
+    return "-";
+  }
+};
+
+const formatPercent = (value: string): string => {
+  if (!value || value === "-") return "-";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "-";
+  return `${num.toFixed(2)}%`;
+};
+
+type SaveUsdstInfo = {
+  configured: boolean;
+  deployed: boolean;
+  vaultAddress: string;
+  assetAddress: string;
+  assetSymbol: string;
+  shareSymbol: string;
+  totalManagedAssets: string;
+  totalAssets: string;
+  pricingAssets: string;
+  totalShares: string;
+  exchangeRate: string;
+  apy: string;
+  paused: boolean;
+};
+
+type SaveUsdstUserInfo = SaveUsdstInfo & {
+  walletAssets: string;
+  userShares: string;
+  redeemableAssets: string;
+  maxDeposit: string;
+  maxRedeem: string;
+  maxWithdraw: string;
+  userTotalDepositedAssets: string;
+  userTotalWithdrawnAssets: string;
+  userNetDepositedAssets: string;
+  userAllTimeEarningsAssets: string;
+};
+
+type ActionMode = "deposit" | "redeem" | null;
+
+const getEstimatedIncentiveApyPercent = (
+  emissionRate?: string,
+  totalStakeUsd?: string | null
+): string => {
+  try {
+    if (!emissionRate || !totalStakeUsd) return "-";
+
+    const tvlUsd = Number(BigInt(totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return "-";
+
+    const annualCata = (Number(BigInt(emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata < 0) return "-";
+
+    return ((annualCata * 0.25) / tvlUsd * 100).toFixed(2);
+  } catch {
+    return "-";
+  }
+};
+
+const EarnSave = () => {
+  const navigate = useNavigate();
+  const { isLoggedIn } = useUser();
+  const { toast } = useToast();
+  const { activities: rewardsActivities, loading: rewardsActivitiesLoading } = useRewardsActivities();
+  const { userRewards, loading: rewardsUserLoading } = useRewardsUserInfo();
+  const [saveInfo, setSaveInfo] = useState<SaveUsdstInfo | null>(null);
+  const [userInfo, setUserInfo] = useState<SaveUsdstUserInfo | null>(null);
+  const [loadingInfo, setLoadingInfo] = useState(true);
+  const [actionMode, setActionMode] = useState<ActionMode>(null);
+  const [actionAmount, setActionAmount] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    document.title = "Save USDST | STRATO";
+    window.scrollTo(0, 0);
+  }, []);
+
+  const refreshData = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        setLoadingInfo(true);
+        const [infoResponse, userResponse] = await Promise.all([
+          api.get<SaveUsdstInfo>("/earn/save-usdst/info", { signal }),
+          isLoggedIn
+            ? api.get<SaveUsdstUserInfo>("/earn/save-usdst/user", { signal })
+            : Promise.resolve({ data: null } as { data: null }),
+        ]);
+
+        if (signal?.aborted) return;
+
+        setSaveInfo(infoResponse.data);
+        setUserInfo(userResponse.data);
+      } catch (error: any) {
+        if (signal?.aborted || error?.name === "AbortError" || error?.code === "ERR_CANCELED") {
+          return;
+        }
+
+        setSaveInfo(null);
+        setUserInfo(null);
+      } finally {
+        if (!signal?.aborted) {
+          setLoadingInfo(false);
+        }
+      }
+    },
+    [isLoggedIn]
+  );
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    refreshData(abortController.signal);
+    return () => abortController.abort();
+  }, [refreshData]);
+
+  useEffect(() => {
+    if (!actionMode) {
+      setActionAmount("");
+    }
+  }, [actionMode]);
+
+  const effectiveInfo = userInfo || saveInfo;
+  const exchangeRate = formatExchangeRate(effectiveInfo?.exchangeRate || "0");
+  const walletAssets = userInfo?.walletAssets || "0";
+  const userShares = userInfo?.userShares || "0";
+  const redeemableAssets = userInfo?.redeemableAssets || "0";
+  const isConfigured = Boolean(effectiveInfo?.configured);
+  const isDeployed = Boolean(effectiveInfo?.deployed);
+  const isPaused = Boolean(effectiveInfo?.paused);
+  const normalizedVaultAddress = effectiveInfo?.vaultAddress?.toLowerCase?.() || "";
+  const saveRewardsActivity = useMemo(() => {
+    return rewardsActivities.find((activity) => {
+      const source = activity.sourceContract?.toLowerCase?.() || "";
+      const name = activity.name?.toLowerCase?.() || "";
+
+      if (normalizedVaultAddress && source === normalizedVaultAddress) {
+        return true;
+      }
+
+      return name.includes("save usdst") || name.includes("saveusdst");
+    }) || null;
+  }, [normalizedVaultAddress, rewardsActivities]);
+  const saveRewardEntries = useMemo(() => {
+    return userRewards?.activities.filter(({ activity }) => {
+      const source = activity.sourceContract?.toLowerCase?.() || "";
+      const name = activity.name?.toLowerCase?.() || "";
+
+      if (normalizedVaultAddress && source === normalizedVaultAddress) {
+        return true;
+      }
+
+      return name.includes("save usdst") || name.includes("saveusdst");
+    }) || [];
+  }, [normalizedVaultAddress, userRewards]);
+  const incentiveYield = formatPercent(
+    getEstimatedIncentiveApyPercent(
+      saveRewardsActivity?.emissionRate,
+      saveRewardsActivity?.totalStakeUsd ?? null
+    )
+  );
+  const saveRewardPointsEarned = useMemo(() => {
+    if (saveRewardEntries.length === 0) return "0";
+
+    const currentTime = Math.floor(Date.now() / 1000);
+    const pendingRewards = saveRewardEntries.reduce((total, { activity, userInfo }) => (
+      total + BigInt(calculateRealTimePendingRewards(
+        userInfo?.stake || "0",
+        activity.accRewardPerStake || "0",
+        userInfo?.userIndex || "0",
+        activity.emissionRate || "0",
+        activity.totalStake || "0",
+        activity.lastUpdateTime || "0",
+        currentTime
+      ))
+    ), 0n);
+
+    return formatRoundedWithCommas(roundByMagnitude(formatUnits(pendingRewards, 18)));
+  }, [saveRewardEntries]);
+  const isInsolvent = BigInt(effectiveInfo?.totalShares || "0") > 0n && BigInt(effectiveInfo?.pricingAssets || "0") === 0n;
+  const depositDisabled = !isLoggedIn || !isConfigured || !isDeployed || isPaused || isInsolvent;
+  const redeemDisabled = !isLoggedIn || !isConfigured || !isDeployed || isPaused;
+
+  const amountWei = actionAmount ? safeParseUnits(actionAmount, 18) : 0n;
+  const actionMaxWei = useMemo(() => {
+    if (actionMode === "deposit") return BigInt(userInfo?.maxDeposit || "0");
+    if (actionMode === "redeem") return BigInt(userInfo?.maxRedeem || "0");
+    return 0n;
+  }, [actionMode, userInfo?.maxDeposit, userInfo?.maxRedeem]);
+
+  const previewValueWei = useMemo(() => {
+    const pricingAssets = BigInt(effectiveInfo?.pricingAssets || "0");
+    const totalShares = BigInt(effectiveInfo?.totalShares || "0");
+
+    if (amountWei <= 0n) return 0n;
+
+    if (actionMode === "deposit") {
+      if (pricingAssets <= 0n || totalShares <= 0n) return amountWei;
+      return (amountWei * totalShares) / pricingAssets;
+    }
+
+    if (actionMode === "redeem") {
+      if (pricingAssets <= 0n || totalShares <= 0n) return 0n;
+      return (amountWei * pricingAssets) / totalShares;
+    }
+
+    return 0n;
+  }, [actionMode, amountWei, effectiveInfo?.pricingAssets, effectiveInfo?.totalShares]);
+
+  const isActionAmountValid = amountWei > 0n && amountWei <= actionMaxWei;
+
+  const metrics = [
+    {
+      label: "USDST Balance",
+      value: loadingInfo ? "..." : isLoggedIn ? formatTokenAmount(walletAssets) : "--",
+      hint: "Available to save",
+      icon: <Wallet className="h-4 w-4 text-blue-600 dark:text-blue-400" />,
+    },
+    {
+      label: "Your saveUSDST",
+      value: loadingInfo ? "..." : isLoggedIn ? formatTokenAmount(userShares) : "--",
+      hint: "Savings shares held",
+      icon: <PiggyBank className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />,
+    },
+    {
+      label: "Position Value",
+      value: loadingInfo ? "..." : isLoggedIn ? `${formatTokenAmount(redeemableAssets)} USDST` : "--",
+      hint: "Current redeemable value",
+      icon: <CircleDollarSign className="h-4 w-4 text-violet-600 dark:text-violet-400" />,
+    },
+    {
+      label: "Reward Points Earned",
+      value: loadingInfo || rewardsUserLoading ? "..." : isLoggedIn ? `${saveRewardPointsEarned} Points` : "--",
+      hint: "Points you've earned so far",
+      icon: <Sparkles className="h-4 w-4 text-amber-600 dark:text-amber-400" />,
+    },
+  ];
+
+  const handleActionRequest = (mode: Exclude<ActionMode, null>) => {
+    if (!isLoggedIn) {
+      toast({
+        title: "Sign in required",
+        description: "Connect your account to deposit or redeem saveUSDST.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setActionMode(mode);
+  };
+
+  const handleSubmit = async () => {
+    if (!actionMode || !isActionAmountValid || isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      if (actionMode === "deposit") {
+        await api.post("/earn/save-usdst/deposit", { amount: amountWei.toString() });
+        toast({
+          title: "Deposit submitted",
+          description: `Depositing ${actionAmount} USDST into saveUSDST.`,
+          variant: "success",
+        });
+      } else {
+        await api.post("/earn/save-usdst/redeem", { sharesAmount: amountWei.toString() });
+        toast({
+          title: "Redeem submitted",
+          description: `Redeeming ${actionAmount} saveUSDST back to USDST.`,
+          variant: "success",
+        });
+      }
+
+      setActionMode(null);
+      await refreshData();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRedeemAll = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+      await api.post("/earn/save-usdst/redeem-all");
+      toast({
+        title: "Redeem submitted",
+        description: "Redeeming your full saveUSDST balance back to USDST.",
+        variant: "success",
+      });
+      setActionMode(null);
+      await refreshData();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const actionPrimaryLabel = actionMode === "deposit" ? "Deposit USDST" : "Redeem saveUSDST";
+  const actionSecondaryLabel = actionMode === "deposit" ? "You receive" : "You receive";
+  const actionPreviewSymbol = actionMode === "deposit"
+    ? (effectiveInfo?.shareSymbol || "saveUSDST")
+    : (effectiveInfo?.assetSymbol || "USDST");
+  const actionMaxInputValue = actionMode === "deposit"
+    ? formatUnits(userInfo?.maxDeposit || "0", 18)
+    : formatUnits(userInfo?.maxRedeem || "0", 18);
+  const actionMaxLabel = actionMode === "deposit"
+    ? formatTokenAmount(userInfo?.maxDeposit || "0")
+    : formatTokenAmount(userInfo?.maxRedeem || "0");
+  const actionDisabledReason = !isConfigured
+    ? "Set SAVE_USDST_VAULT to enable transactions."
+    : !isDeployed
+      ? "The saveUSDST vault is not deployed on this network yet."
+      : isPaused
+        ? "The saveUSDST vault is currently paused."
+        : isInsolvent
+          ? "New deposits are blocked while the vault is fully insolvent."
+        : null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <DashboardSidebar />
+
+      <div
+        className="transition-all duration-300 md:pl-64"
+        style={{ paddingLeft: "var(--sidebar-width, 0rem)" }}
+      >
+        <DashboardHeader title="Save USDST" />
+
+        <main className="pb-16 md:pb-6">
+          {!isLoggedIn && (
+            <GuestSignInBanner message="Sign in to view your USDST and saveUSDST balances." />
+          )}
+
+          <div className="w-full">
+            <Card className="bg-card border-0 rounded-none">
+              <CardContent className="p-4 md:p-6 space-y-8">
+                <button
+                  className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => navigate("/dashboard/earn")}
+                  type="button"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back to Earn
+                </button>
+
+                <section className="space-y-5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                      Native Savings
+                    </Badge>
+                    <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                      USDST Only
+                    </Badge>
+                    {!isConfigured && (
+                      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                        Needs Config
+                      </Badge>
+                    )}
+                    {isConfigured && !isDeployed && (
+                      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                        Not Deployed
+                      </Badge>
+                    )}
+                    {isPaused && (
+                      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                        Paused
+                      </Badge>
+                    )}
+                  </div>
+
+                  <Card className="border border-blue-500/25 dark:border-blue-400/25 bg-gradient-to-br from-[#f8fbff] to-[#edf3ff] dark:from-[#0f1a33] dark:to-[#111c3a]">
+                    <CardContent className="pt-5 space-y-5">
+                      <div className="space-y-3">
+                        <div className="flex items-center gap-3">
+                          <div className="w-12 h-12 rounded-full bg-blue-500/15 dark:bg-blue-400/15 flex items-center justify-center">
+                            <PiggyBank className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+                          </div>
+                          <div>
+                            <h1 className="text-2xl md:text-4xl font-semibold tracking-tight">Save USDST</h1>
+                            <p className="text-sm md:text-base text-muted-foreground">
+                              Simple USD savings, natively on STRATO. Stay liquid. Earn rewards.
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                        <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                          <p className="text-muted-foreground">Exchange Rate</p>
+                          <p className="mt-1 text-lg font-semibold">{exchangeRate}</p>
+                          <p className="text-xs text-muted-foreground mt-1">
+                            USDST redeemable per saveUSDST
+                          </p>
+                        </div>
+                        <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                          <p className="text-muted-foreground">Yield</p>
+                          <p className="mt-1 text-lg font-semibold">
+                            {loadingInfo || rewardsActivitiesLoading ? "..." : incentiveYield}
+                          </p>
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Estimated annualized rewards incentive yield
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col sm:flex-row gap-3">
+                        <Button
+                          className="sm:min-w-[180px]"
+                          onClick={() => handleActionRequest("deposit")}
+                          disabled={depositDisabled}
+                        >
+                          Deposit USDST
+                        </Button>
+                        <Button
+                          variant="outline"
+                          className="sm:min-w-[180px]"
+                          onClick={() => handleActionRequest("redeem")}
+                          disabled={redeemDisabled}
+                        >
+                          Redeem saveUSDST
+                        </Button>
+                      </div>
+                      {actionDisabledReason && (
+                        <p className="text-xs text-muted-foreground">{actionDisabledReason}</p>
+                      )}
+                    </CardContent>
+                  </Card>
+                </section>
+
+                <section className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+                  {metrics.map((metric) => (
+                    <Card key={metric.label} className="border border-border/70">
+                      <CardContent className="pt-4 space-y-3">
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs text-muted-foreground">{metric.label}</p>
+                          {metric.icon}
+                        </div>
+                        <p className="text-2xl font-semibold leading-none">{metric.value}</p>
+                        <p className="text-xs text-muted-foreground">{metric.hint}</p>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </section>
+
+              </CardContent>
+            </Card>
+          </div>
+        </main>
+      </div>
+
+      <MobileBottomNav />
+
+      <Dialog open={actionMode !== null} onOpenChange={(open) => (!open ? setActionMode(null) : undefined)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{actionPrimaryLabel}</DialogTitle>
+            <DialogDescription>
+              {actionMode === "deposit"
+                ? "Deposit USDST into the native savings vault and receive saveUSDST shares."
+                : "Redeem saveUSDST shares back into the underlying USDST asset."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs">
+                <span>Available</span>
+                <button
+                  type="button"
+                  className="font-medium text-foreground hover:underline"
+                  onClick={() => setActionAmount(actionMaxInputValue === "0.0" || actionMaxInputValue === "0" ? "" : actionMaxInputValue)}
+                >
+                  Max: {actionMaxLabel}
+                </button>
+              </div>
+              <Input
+                type="number"
+                min="0"
+                step="any"
+                placeholder="0.00"
+                value={actionAmount}
+                onChange={(event) => setActionAmount(event.target.value)}
+              />
+            </div>
+            <div className="rounded-lg border border-border/70 bg-muted/40 p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <span>USDST Balance</span>
+                <span className="font-medium text-foreground">{formatTokenAmount(walletAssets)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>saveUSDST Balance</span>
+                <span className="font-medium text-foreground">{formatTokenAmount(userShares)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>{actionSecondaryLabel}</span>
+                <span className="font-medium text-foreground">
+                  {formatTokenAmount(previewValueWei.toString())} {actionPreviewSymbol}
+                </span>
+              </div>
+            </div>
+            {actionMode === "redeem" && (
+              <div className="rounded-lg border border-border/70 bg-background/60 p-3 text-xs">
+                Current redeemable value: {formatTokenAmount(redeemableAssets)} USDST
+              </div>
+            )}
+            {saveRewardsActivity?.name && !rewardsUserLoading && (
+              <RewardsWidget
+                userRewards={userRewards}
+                activityName={saveRewardsActivity.name}
+                inputAmount={actionAmount}
+                isWithdrawal={actionMode === "redeem"}
+                actionLabel={actionMode === "redeem" ? "Redeem" : "Deposit"}
+              />
+            )}
+            <div className="flex flex-col gap-2">
+              <Button
+                className="w-full"
+                disabled={!isActionAmountValid || isSubmitting}
+                onClick={handleSubmit}
+              >
+                {isSubmitting ? "Submitting..." : actionPrimaryLabel}
+              </Button>
+              {actionMode === "redeem" && (
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  disabled={BigInt(userInfo?.maxRedeem || "0") <= 0n || isSubmitting}
+                  onClick={handleRedeemAll}
+                >
+                  Redeem All
+                </Button>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default EarnSave;

--- a/techdocs/design-docs/save-usdst.md
+++ b/techdocs/design-docs/save-usdst.md
@@ -1,0 +1,459 @@
+# saveUSDST Technical Spec
+
+Draft: 2026-03-18
+
+## Business Context
+
+The protocol needs `USDST` to do three things well:
+
+1. circulate
+2. trade at size
+3. be worth holding
+
+The first comes from CDP minting. The second comes from stable liquidity. `saveUSDST` is the third leg: the native hold asset for `USDST`.
+
+This matches the current internal framing:
+
+- mint `USDST` against collateral
+- LP in the metastable stable surface
+- hold `saveUSDST`
+
+The point of `saveUSDST` is not to replace lending or external yieldcoins. It is to give Mercata a simple native savings product for `USDST` and a clean path from bootstrap incentives to fee-funded savings yield.
+
+## Current Protocol Context
+
+This spec assumes the current Mercata / STRATO product stack has four relevant pieces:
+
+1. `USDST`
+   - the protocol stablecoin
+   - the unit users mint, borrow, swap, spend, and save
+
+2. `CDP`
+   - the lower-cost path for minting new `USDST` against collateral
+   - intended to be the primary supply engine for `USDST`
+
+3. Lending pool
+   - a separate money market for supplying and borrowing `USDST`
+   - yield for suppliers depends on borrow demand and utilization
+
+4. Stable liquidity surface
+   - pools that let users move between `USDST` and external stable or yield-bearing assets such as `syrupUSDC`, `sUSDS`, and `sUSDe`
+
+The current strategic picture is:
+
+- CDP grows `USDST` supply
+- stable liquidity makes `USDST` usable
+- `saveUSDST` creates hold demand
+
+## Definitions
+
+### USDST
+
+The protocol stablecoin. It is the base asset for this spec.
+
+### saveUSDST
+
+The proposed native savings token for `USDST`. Users deposit `USDST` and receive a non-rebasing claim whose value rises over time.
+
+### CDP
+
+Collateralized debt position system. Users lock collateral and mint new `USDST` against it. In current protocol economics, this is the cheaper borrowing path and the main source of new `USDST` circulation.
+
+### Lending pool
+
+Separate from the CDP. Users supply `USDST` or supported collateral to a money market. Supplier yield comes from borrower demand, not from a protocol savings rate.
+
+### safetyUSDST
+
+The safety-module token. It exists for protocol backstop and bad-debt handling. It is not the savings product described here.
+
+### Metastable pool
+
+The main stable liquidity surface for `USDST` against other stable or yield-bearing stable assets. Its job is to keep `USDST` easy to move into and out of at size.
+
+### PSM
+
+Peg stability mechanism. A backstop convertibility path, typically against `USDC` or `USDT`, used to anchor the peg and support arbitrage during larger deviations. It is not intended to be the normal day-to-day user route.
+
+### External yield assets
+
+Stable or dollar-like assets outside the native `saveUSDST` product that already earn yield, such as `syrupUSDC`, `sUSDS`, and `sUSDe`.
+
+## Scope Assumptions
+
+This document assumes:
+
+- `saveUSDST` is a new product, not a rename of an existing token
+- the lending pool remains in place
+- `safetyUSDST` remains in place
+- launch support comes from explicit rewards first
+- fee-share support comes later
+- collateral use is out of scope for launch
+
+## Product Definition
+
+`saveUSDST` is a non-rebasing, exchange-rate token backed by deposited `USDST`.
+
+User flow:
+
+1. deposit `USDST`
+2. receive `saveUSDST`
+3. hold while the exchange rate rises
+4. redeem back to `USDST`
+
+`saveUSDST` is:
+
+- the savings product for `USDST`
+- separate from the lending pool
+- separate from `safetyUSDST`
+- intended to look and behave like an `sDAI` / `sUSDS` style asset
+
+`saveUSDST` is not:
+
+- a lending-pool receipt token
+- a bad-debt recovery token
+- a CDP position
+- a rebasing balance token
+
+## Goals
+
+- Create a simple reason to hold `USDST`
+- Increase sticky `USDST` balances in the system
+- Give the protocol a native savings-rate outlet
+- Make the asset easy to explain and integrate
+- Start with explicit support, then transition to fee share
+
+## Non-Goals
+
+- Do not use `saveUSDST` for protocol safety
+- Do not tie core yield to lending-pool utilization
+- Do not allow collateral use at launch
+- Do not rely on permanent token emissions
+
+## System Model
+
+### Underlying and share asset
+
+- underlying: `USDST`
+- share token: `saveUSDST`
+
+### Accounting model
+
+The vault tracks:
+
+- total managed `USDST`
+- total `saveUSDST` shares
+- user share balances
+
+Economic identity:
+
+- `exchangeRate = totalManagedUSDST / totalSaveUSDSTShares`
+
+User value:
+
+- `userUnderlyingValue = userShares * exchangeRate`
+
+When rewards are added:
+
+- managed `USDST` increases
+- share supply stays unchanged
+- exchange rate rises
+
+This is the right model for the product because it is simple, non-rebasing, and familiar to users who know `sDAI` or `sUSDS`.
+
+### Accounting requirement
+
+The implementation should account against managed assets, not blindly against raw token balance. Reward injections must be explicit. Unexpected direct transfers should not silently distort the exchange rate.
+
+## Functional Requirements
+
+### User actions
+
+- deposit `USDST`
+- mint shares
+- withdraw `USDST`
+- redeem shares
+- view exchange rate
+- view current redeemable value
+
+### Protocol / governance actions
+
+- configure or approve any fee-share routing into the product
+- pause / unpause if needed
+- recover stray assets without affecting core accounting
+
+### Interface shape
+
+The interface should be ERC-4626-shaped:
+
+- `deposit`
+- `mint`
+- `withdraw`
+- `redeem`
+- `totalAssets`
+- `convertToShares`
+- `convertToAssets`
+- preview functions
+
+The important point is standard savings-vault semantics, even if the implementation uses repo-specific accounting patterns internally.
+
+## Product Positioning Relative To Existing Components
+
+### Lending pool
+
+The lending pool remains the money-market layer for `USDST`. It is not being replaced.
+
+The reason not to make it the primary savings product is that supplier yield depends on borrow demand in a venue where users already have cheaper ways to borrow through the CDP path. If utilization has to be subsidized to make the savings story work, it is cleaner to support `saveUSDST` directly.
+
+### safetyUSDST
+
+`safetyUSDST` is the safety layer. It exists for bad-debt recovery and protocol backstop functions.
+
+`saveUSDST` is the savings layer. It should not inherit cooldown, slashing, or backstop semantics.
+
+### External yield assets
+
+`saveUSDST` does not need to outyield every external asset in every regime. It does need to be the best native destination for `USDST`.
+
+## Funding Model
+
+### Phase 1: bootstrap incentives
+
+At launch, `saveUSDST` should not use a hard `USDST` cash subsidy as the main incentive.
+
+Reason:
+
+- cheap internal borrow paths make a hard-cash savings subsidy mechanically loopable
+- if users can mint or borrow `USDST` below the headline `saveUSDST` rate, the protocol is just paying for a carry trade
+- that is especially unattractive before fee-funded yield is real
+
+The launch posture should therefore be:
+
+- no hard-cash `USDST` base subsidy
+- use the floating token for temporary promotional incentives if needed
+- reserve direct exchange-rate growth for real fee-funded cash flows or very deliberate governance decisions
+
+This keeps early incentives softer, reduces obvious carry extraction, and preserves the long-run meaning of `saveUSDST` as a savings product rather than a farm.
+
+At launch, the exchange rate starts at 1:1 and remains flat. Exchange-rate growth begins when fee-share routing is activated.
+
+### Phase 2: fee-share transition
+
+As protocol revenues grow, part of protocol revenue should be routed to `saveUSDST`.
+
+Candidate sources:
+
+- stability fees
+- lending fees
+- swap fees
+- other protocol revenues, subject to governance choice
+
+### Phase 3: steady state
+
+Long-term target:
+
+- fee-funded base savings rate
+- market-level stability fees over time
+- temporary token incentives only when strategically justified
+
+The product should move from "promotion-supported" to "fee-supported", not remain a perpetual emissions sink.
+
+## Economics
+
+### Strategic target
+
+The current internal materials imply a working `saveUSDST` hold-demand target around `$20M`.
+
+That is a useful planning target because it is large enough to matter for `USDST` retention, but still small enough to bootstrap deliberately.
+
+### Implied fee-funded base rate
+
+The useful thing about `saveUSDST` is that the long-run exchange-rate growth is modelable before fee share is turned on.
+
+Very roughly:
+
+- `saveUSDST base rate ~= (USDST debt outstanding * stability fee * allocation to saveUSDST) / saveUSDST TVL`
+
+This should be the anchor for the product.
+
+It allows the team to estimate:
+
+- the fee-funded rate the product can support later
+- the gap between that rate and the headline launch rate
+- how much temporary promotion is actually needed
+
+If the protocol becomes widely used and stability fees rise toward market, the fee-funded base rate should rise with it.
+
+### Launch yield range
+
+The current internal materials point to a visible launch rate in the mid-single digits. That is still the right qualitative range for the headline number.
+
+Recommended working range:
+
+- `5-8%` headline launch APY, assuming the floating token launches and incentives are active
+
+This should be understood as a combined number, not a pure fee-funded rate.
+
+Why:
+
+- below that, the product may not feel different enough from idle `USDST`
+- far above that, it starts to look like a short-lived subsidy rather than a real savings product
+
+## Yield Presentation
+
+Users should see one headline yield number.
+
+That is how vault products are understood in practice.
+
+Recommended presentation:
+
+- headline APY: one combined current rate
+- below the fold: breakdown by source
+
+The breakdown should separate:
+
+- modeled or actual fee-funded base rate
+- temporary floating-token incentive rate
+- any other temporary promotional components
+
+The product should not expect users to parse the decomposition before deciding whether the vault is attractive.
+
+At the same time, the protocol must track the decomposition internally so it is always clear which part of the yield is durable and which part is promotional.
+
+## Launch Policy
+
+### Scope
+
+Launch `saveUSDST` as:
+
+- deposit
+- hold
+- redeem
+
+Only.
+
+### Collateral policy
+
+Do not allow `saveUSDST` as collateral anywhere at launch.
+
+That means:
+
+- no CDP collateral
+- no lending-pool collateral
+
+### Rationale
+
+CDP collateral is too reflexive:
+
+- mint `USDST`
+- wrap into `saveUSDST`
+- use a claim on `USDST` to mint more `USDST`
+
+Lending collateral is more defensible because there is a financing cost and actual pool liquidity constraints. Even so, launch exclusion is still preferable because bootstrap rewards would distort the loop and complicate the rollout.
+
+Future lending-collateral eligibility can be revisited once:
+
+- fee share is the dominant yield source
+- bootstrap support is no longer the main APY driver
+- haircut, cap, and monitoring policy are defined
+
+CDP collateral should remain out of scope.
+
+## Integrations
+
+The system needs to support:
+
+- wallet / portfolio visibility for `saveUSDST`
+- exchange-rate and redeemable-value display
+- API endpoints for public and user-specific vault state
+- standard preview functions for integrators
+- clear labeling distinct from lending and safety
+
+User-facing copy should consistently frame:
+
+- `USDST` as the routing and transaction asset
+- `saveUSDST` as the native savings asset
+
+## KPIs
+
+Primary KPIs:
+
+- `saveUSDST` TVL
+- share of circulating `USDST` held in `saveUSDST`
+- average holding duration
+- retention after incentives taper
+- share of newly minted / borrowed `USDST` that ends up saved
+- fee-share coverage ratio over time
+
+## Risks
+
+- If launch support is too low, users route directly into external yield assets
+- If launch support is too high, TVL can become mercenary
+- If taper is too sharp, retention will be poor
+- If product boundaries are blurry, users will confuse savings, lending, and safety
+- If collateral is enabled too early, recursive loops complicate risk before the savings product is proven
+
+## Recommendation
+
+Launch `saveUSDST` as the native savings-rate product for `USDST`.
+
+Keep the story simple:
+
+- mint `USDST`
+- use `USDST`
+- save `USDST`
+
+Keep the first version simple too:
+
+- exchange-rate token
+- no hard-cash `USDST` launch subsidy
+- optional floating-token promotional incentives
+- later fee share
+- no collateral at launch
+
+That is the cleanest way to create durable hold demand for `USDST` without mixing savings, leverage, and safety into one product.
+
+## Implementation Notes
+
+### Existing contract
+
+`SaveUSDSTVault.sol` in `mercata/contracts/concrete/Savings/` already implements the core vault. It is the share token itself (ERC-20), with ERC-4626-shaped deposit / mint / withdraw / redeem and managed-asset accounting.
+
+### Contract interactions at launch
+
+The vault's only runtime dependency is the `USDST` ERC-20 token. It does not interact with the CDP, lending pool, safety module, or any rewards system.
+
+This is the key architectural difference from `SafetyModule` (safetyUSDST), which imports and calls `LendingPool`, `LiquidityPool`, and `LendingRegistry`. `SaveUSDSTVault` is standalone.
+
+At launch:
+
+- `deposit` / `mint`: pull `USDST` from user via `transferFrom`, mint shares
+- `withdraw` / `redeem`: burn shares, transfer `USDST` to user
+- `exchangeRate`: read-only, returns `totalAssets * 1e18 / totalSupply`
+
+No other contract calls. No external state reads. The vault holds `USDST` and tracks `_managedAssets` internally.
+
+### What `notifyReward` is and when it matters
+
+The current contract has a `notifyReward` method that pulls `USDST` from the owner and adds it to `_managedAssets`, raising the exchange rate for all holders.
+
+At launch, this is unused. The exchange rate is flat at 1:1. Promotional incentives use the floating token through a separate system that does not touch the vault.
+
+When fee-share routing activates (Phase 2), the vault will need a mechanism to receive protocol revenue and credit it as managed assets. Whether that mechanism is the existing `notifyReward` (pull from owner), a push-style `recordTransfer` (like SafetyModule uses for LendingPool), or a continuous drip is a Phase 2 design decision. The launch contract does not need to commit to one.
+
+### Deployment sequence
+
+1. Deploy `SaveUSDSTVault` behind proxy (via `BaseCodeCollection`)
+2. Call `initialize(USDST, "Save USDST", "saveUSDST")`
+3. Set pause authority
+4. Register in UI and API as a first-class product
+
+### UI and API
+
+The system needs:
+
+- public vault state (total assets, total supply, exchange rate)
+- user share balance and redeemable value
+- deposit and redeem actions
+
+Present `saveUSDST` as its own product, not as a tab inside lending or safety.


### PR DESCRIPTION
**Summary**
Add saveUSDST as a first-class earn product across backend, contracts, and UI, including dedicated earn endpoints, portfolio integration, and deployment wiring.
Add a dedicated Save USDST experience and streamline the main Earn page so users can compare opportunities by yield, rewards, TVL, and position value in one place.
Reorganize navigation and product labeling to make Earn, Rewards, Savings Vault, and Diversified Vault clearer and more discoverable.

**Key Changes**
Backend:
Added saveUSDST controller/service and /earn/save-usdst/* routes.
Exposed featured earn configuration and saveUSDST constants/config.
Included saveUSDST in earning-assets responses so it appears in portfolio and earn flows.

Contracts / deployment:
Integrated SaveUSDSTVault into BaseCodeCollection.
Updated deploy scripts and related contract test coverage for base collection wiring.

UI:
Added dedicated EarnSave page for saveUSDST.
Routed portfolio saveUSDST links to the dedicated save page.
Refactored Earn page table and ranking logic to emphasize effective yield, rewards, TVL, and user position.
Replaced the separate bottom position cards with inline Your Position values in the opportunities table.
Updated nav structure and labels so Rewards sits under Earn, and PRO uses the new order and naming.