### PR TITLE
Enhance WithdrawalCompleted for position-based bridge rewards

### DIFF
--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -76,7 +76,7 @@ contract record MercataBridge is Ownable {
     event WithdrawalAborted(uint256 withdrawalId);
 
     /// @notice Emitted when a withdrawal is completed and tokens are burned
-    event WithdrawalCompleted(uint256 withdrawalId);
+    event WithdrawalCompleted(uint256 withdrawalId, address user, address stratoToken, uint256 stratoTokenAmount);
 
     /// @notice Emitted when a withdrawal is pending custody transaction
     event WithdrawalPending(string custodyTxHash, uint256 withdrawalId);
@@ -1044,7 +1044,7 @@ contract record MercataBridge is Ownable {
         w.bridgeStatus = BridgeStatus.COMPLETED;
         w.timestamp = block.timestamp;
 
-        emit WithdrawalCompleted(id);
+        emit WithdrawalCompleted(id, w.stratoSender, w.stratoToken, w.stratoTokenAmount);
     }
 
     /**

--- a/mercata/services/rewards-poller/src/config/attributeMapping.json
+++ b/mercata/services/rewards-poller/src/config/attributeMapping.json
@@ -152,6 +152,32 @@
       "amount": "value"
     }
   },
+  "f84425db11cf977dfcaace0431a080e0ff2604ca": {
+    "Minted": {
+      "amount": "value"
+    },
+    "Burned": {
+      "amount": "value"
+    }
+  },
+  "a049efb1a3417801b3dd3877dd566aa24b95b3a0": {
+    "Minted": {
+      "amount": "value"
+    },
+    "Burned": {
+      "amount": "value"
+    }
+  },
+  "22550671fcad04a213697ac7ae4f4366e96446ed": {
+    "Deposit": {
+      "amount": "shares",
+      "user": "owner"
+    },
+    "Withdraw": {
+      "amount": "shares",
+      "user": "receiver"
+    }
+  },
   "ceeb982f671b4ee2b4471e5b49f3126739537f15": {
     "Deposit": {
       "amount": "shares",

--- a/mercata/services/rewards-poller/src/config/attributeMapping.json
+++ b/mercata/services/rewards-poller/src/config/attributeMapping.json
@@ -15,6 +15,10 @@
     "DepositCompleted": {
       "amount": "stratoTokenAmount",
       "user": "stratoRecipient"
+    },
+    "WithdrawalCompleted": {
+      "amount": "stratoTokenAmount",
+      "user": "user"
     }
   },
   "0000000000000000000000000000000000001011": {

--- a/mercata/services/rewards-poller/src/utils/attributeMapping.ts
+++ b/mercata/services/rewards-poller/src/utils/attributeMapping.ts
@@ -12,6 +12,7 @@ const PriceOracleBatchUpdateEvents = `${MERCATA_PREFIX}PriceOracle-BatchPricesUp
 const PRICE_CONVERSION_MAP: Record<string, string> = {
   Swap: "tokenIn",
   DepositCompleted: "stratoToken",
+  WithdrawalCompleted: "stratoToken",
 };
 
 const toBigIntSafeString = (value: string | number): string => {
@@ -186,7 +187,7 @@ export const extractAmountFromAttributes = async (
       return null;
     }
 
-    if (eventName === "DepositCompleted") {
+    if (eventName === "DepositCompleted" || eventName === "WithdrawalCompleted") {
       const isUsdt =
         tokenAddress.toLowerCase() === config.usdst.address.toLowerCase();
 

--- a/mercata/ui/src/lib/rewards/activityLinks.ts
+++ b/mercata/ui/src/lib/rewards/activityLinks.ts
@@ -13,9 +13,9 @@ export const getActivityLink = (activityName: string): string | null => {
 
   const lowerName = activityName.toLowerCase();
 
-  // Direct mint activities - goes to the Deposits page, Easy Savings tab
-  if (lowerName.includes('direct mint')) {
-    return '/dashboard/deposits?tab=easy-savings';
+  // Bridge-related activities - goes to the Fund page
+  if (lowerName.includes('direct mint') || lowerName.includes('bridge')) {
+    return '/dashboard/deposits';
   }
 
   // CDP-related activities - goes to the Borrow page, Vaults sub-tab


### PR DESCRIPTION
## Summary

- Enhance `WithdrawalCompleted` event with `user`, `stratoToken`, `stratoTokenAmount` fields
- Add rewards poller support for `WithdrawalCompleted` (attribute mapping + USDST filter)
- Enables converting bridge "Direct Mint" from OneTime to Position activity

Closes #6582

## Admin Instructions (post-deploy)

Deploy the enhanced MercataBridge.sol first so Cirrus indexes the new event fields, then run these Rewards contract admin calls.

### Testnet (Helium)

Rewards: `170147f58738c9f46112a874030420b823901f3b`

1. `setEmissionRate(15, 0)` -- kill emissions on old "Direct Mint" OneTime
2. `setSourceContract(15, 0x0000000000000000000000000000000000000001)` -- free DepositCompleted mapping on bridge
3. Create new Position activity:
```
addPositionActivitySimple(
    "Bridge USDST Position",
    <emissionRate>,
    0x0000000000000000000000000000000000001008,
    "DepositCompleted",
    "WithdrawalCompleted"
)
```
Old "Direct Mint" emission was `28935185185185185`. New activity will be ID 21.

### Prod (Upquark)

Rewards: `4a116cf8cb056036632aef08f7c0df27c720f1c0`

1. Skip -- activity 17 emission already 0
2. `setSourceContract(17, 0x0000000000000000000000000000000000000001)` -- free DepositCompleted mapping
3. Same `addPositionActivitySimple(...)` call. New activity will be ID 22.

### Why a new activity?

`activityType` is immutable after creation. The existing "Direct Mint" is OneTime (activity 15 on testnet / 17 on prod). Position requires Deposit+Withdraw action types. `sourceEventInfo` enforces unique `(sourceContract, eventName)` per activity, so the old activity must be pointed to a dead address first to free the mapping.

Google Doc: https://docs.google.com/document/d/1XKsDtLjulHLHmN6CumBClypus0SlqKTv22p3DYF5a2A/edit?usp=sharing
