### PR TITLE
Fix missing stable pool incentive APY classification

### DIFF
--- a/mercata/backend/src/api/services/rewardsStakeSemantics.json
+++ b/mercata/backend/src/api/services/rewardsStakeSemantics.json
@@ -27,11 +27,13 @@
       "000000000000000000000000000000000000101c",
       "000000000000000000000000000000000000101e",
       "ac621a150f49198036f84ffe90b4f2286b623583",
-      "69010124cdaa64286f6e413267a7001ea9379df4"
+      "69010124cdaa64286f6e413267a7001ea9379df4",
+      "96c26f8306a0097d985d1654b4596c48bb6277c4",
+      "a049efb1a3417801b3dd3877dd566aa24b95b3a0",
+      "f84425db11cf977dfcaace0431a080e0ff2604ca"
     ],
     "notes": [
       "lpMintBurnSources are raw token units in rewards-poller: Token-Transfer value for Minted/Burned"
     ]
   }
 }
-


### PR DESCRIPTION
## Summary
- add missing stable LP token source contracts to rewards stake semantics token-units allowlist
- this enables backend totalStakeUsd enrichment for those activities, so incentive APY renders instead of '-'

## Included LP Sources
- 96c26f8306a0097d985d1654b4596c48bb6277c4 (sUSDSST-USDST Swap LP)
- a049efb1a3417801b3dd3877dd566aa24b95b3a0 (syrupUSDC-USDST Swap LP)
- f84425db11cf977dfcaace0431a080e0ff2604ca (USDC-USDT-USDST Swap LP)

Related issue: https://github.com/strato-net/strato-platform/issues/6598