### PR TITLE
fix(ui): rewards season verbiage (#6605)

### DIFF
--- a/mercata/ui/src/components/rewards/RewardsOverview.tsx
+++ b/mercata/ui/src/components/rewards/RewardsOverview.tsx
@@ -34,14 +34,11 @@ export const RewardsOverview = ({ state, loading, onRefresh }: RewardsOverviewPr
     }
   };
 
-  // Build season display from currentSeason
-  const seasonDisplay = `Season ${state?.currentSeason || 2}`;
-
   if (loading) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>{seasonDisplay} Reward Overview</CardTitle>
+          <CardTitle>Rewards Overview</CardTitle>
           <CardDescription>Global rewards system statistics</CardDescription>
         </CardHeader>
         <CardContent>
@@ -60,7 +57,7 @@ export const RewardsOverview = ({ state, loading, onRefresh }: RewardsOverviewPr
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Reward Overview</CardTitle>
+          <CardTitle>Rewards Overview</CardTitle>
           <CardDescription>Global rewards system statistics</CardDescription>
         </CardHeader>
         <CardContent>
@@ -97,7 +94,7 @@ export const RewardsOverview = ({ state, loading, onRefresh }: RewardsOverviewPr
       <CardHeader className="px-4 md:px-6 pb-3 md:pb-4">
         <div className="flex items-start justify-between gap-2">
           <div>
-            <CardTitle className="text-lg md:text-xl">{seasonDisplay} Reward Overview</CardTitle>
+            <CardTitle className="text-lg md:text-xl">Rewards Overview</CardTitle>
             <CardDescription className="text-xs md:text-sm">Global rewards system statistics</CardDescription>
           </div>
           {onRefresh && (

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -297,7 +297,7 @@ const Dashboard = () => {
             />
 
             <AssetSummary
-              title={`Rewards (Season ${rewardsState?.currentSeason || 2})`}
+              title="Rewards"
               value={(() => {
                 if (!isLoggedIn) return "-";
                 if (rankLoading) return "Loading...";

--- a/mercata/ui/src/pages/Rewards.tsx
+++ b/mercata/ui/src/pages/Rewards.tsx
@@ -135,7 +135,7 @@ const Rewards = () => {
             className="w-full"
           >
             <TabsList className="grid w-full grid-cols-3 mb-6">
-            <TabsTrigger value="activities">Activities</TabsTrigger>
+            <TabsTrigger value="activities">Activities (Season {state?.currentSeason || 2})</TabsTrigger>
                <TabsTrigger value="my-rewards">My Rewards</TabsTrigger>
               <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
             </TabsList>


### PR DESCRIPTION
Fixes strato-net/strato-platform#6605

- Portfolio rewards card title is `Rewards` (no season).
- Rewards overview header is `Rewards Overview` (no season).
- Activities tab shows `Activities (Season N)` using `currentSeason` from rewards state.
