### PR TITLE
Add vault-send-tx, Across bridge PoC, and custom token self-relay tools

### DIFF
--- a/strato/tools/vault-send-tx/README.md
+++ b/strato/tools/vault-send-tx/README.md
@@ -158,6 +158,96 @@ Additional environment variables:
 | `ORIGIN_RPC` | Across chain RPC | Override origin RPC |
 | `DESTINATION_RPC` | Across chain RPC | Override destination RPC |
 
+## Test token workflow
+
+To try a custom-asset route, this package also includes a plain owner-mintable
+ERC-20 and scripts to deploy/mint it with the vault signer.
+
+Files:
+- `TestMintableERC20.sol`
+- `deploy-test-token.js`
+- `mint-test-token.js`
+
+Deploy on the current `NETWORK_RPC` chain:
+
+```bash
+# Dry-run deployment
+node deploy-test-token.js --name "Test USDST" --symbol tUSDST --decimals 18
+
+# Broadcast deployment
+node deploy-test-token.js --name "Test USDST" --symbol tUSDST --decimals 18 --submit
+```
+
+Mint after deployment:
+
+```bash
+# Dry-run mint
+node mint-test-token.js \
+  --token 0x... \
+  --to 0x... \
+  --amount 1000 \
+  --decimals 18
+
+# Broadcast mint
+node mint-test-token.js \
+  --token 0x... \
+  --to 0x... \
+  --amount 1000 \
+  --decimals 18 \
+  --submit
+```
+
+Minimal experiment flow:
+- deploy the same test token to `Sepolia` and `Base Sepolia`
+- mint inventory on both chains
+- quote/custom-fill the exact token addresses with `across-bridge.js --input-token ... --output-token ...`
+- run your own relayer/filler against that route
+
+## Self-relayed custom fills
+
+For custom token routes that the public Across quote path will not price, you can
+use the included self-relay script to:
+- approve the origin and destination SpokePools
+- submit a direct `depositV3Now()` on the origin chain
+- parse the emitted `FundsDeposited` event
+- call `fillV3Relay()` on the destination chain using your own inventory
+
+Example:
+
+```bash
+node self-relay-fill.js \
+  --input-token 0x... \
+  --output-token 0x... \
+  --recipient 0x... \
+  --amount 1 \
+  --decimals 18 \
+  --submit
+```
+
+Optional flags:
+- `--input-token 0x...`
+- `--output-token 0x...`
+- `--recipient 0x...` defaults to the vault address
+- `--amount 1`
+- `--decimals 18`
+- `--fill-deadline-offset 3600`
+
+## Refund check
+
+To watch whether the origin spoke pool has created a claimable relayer refund for
+the custom token, use:
+
+```bash
+node check-relayer-refund.js \
+  --token 0x... \
+  --relayer 0x...
+```
+
+Optional flags:
+- `--rpc https://...`
+- `--spoke-pool 0x...`
+- `--lookback-blocks 50000`
+
 ## Environment variables
 
 | Variable      | Default                                        | Description                          |

--- a/strato/tools/vault-send-tx/README.md
+++ b/strato/tools/vault-send-tx/README.md
@@ -1,0 +1,110 @@
+# vault-send-tx
+
+Sign and send transactions on external chains using the STRATO vault signing service.
+
+The vault is an open-source key management service that stores private keys
+server-side and signs arbitrary 32-byte hashes via secp256k1. BlockApps runs
+a hosted instance at `vault.blockapps.net`, but anyone can run their own — the
+vault ships as part of the STRATO node stack (`docker-compose.vault.yml`).
+Long-term this is intended to become a standalone, open-source embedded wallet.
+
+This script builds a transaction locally, asks a vault instance to sign the
+hash, and submits the signed tx to any EVM chain's RPC.
+
+## How it works
+
+```
+┌──────────┐     GET /key        ┌────────────┐
+│  script   │ ──────────────────▶ │   vault    │
+│           │ ◀────────────────── │ (your own  │
+│ build tx  │    { address }      │  or hosted)│
+│ hash tx   │                     │            │
+│           │  POST /signature    │            │
+│           │ ──────────────────▶ │ decrypt pk │
+│           │ ◀────────────────── │ sign hash  │
+│           │    { r, s, v }      └────────────┘
+│           │
+│ assemble  │  eth_sendRawTransaction
+│ signed tx │ ──────────────────▶  EVM chain RPC
+└──────────┘
+```
+
+The vault never sees the transaction details — only a 32-byte keccak hash.
+The private key never leaves the vault. Chain ID, nonce, gas are all handled
+client-side.
+
+## Prerequisites
+
+1. **Node.js 18+**
+2. **A vault instance** — either the hosted one or your own (`docker-compose.vault.yml`)
+3. **`strato-auth`** on your PATH (installed via `stack install` from `strato/libs/strato-auth`)
+4. **`~/.secrets/oauth_credentials`** with your OAuth config:
+   ```
+   OAUTH_DISCOVERY_URL=<discovery-url>
+   OAUTH_CLIENT_ID=<client-id>
+   OAUTH_CLIENT_SECRET=<client-secret>
+   ```
+
+## Setup
+
+```bash
+cd strato/tools/vault-send-tx
+npm install
+```
+
+## Authenticate
+
+```bash
+strato-auth
+```
+
+Opens a device-flow login. Visit the URL, enter the code, log in. Token is
+saved to `~/.secrets/stratoToken` and auto-refreshes until the refresh token
+expires.
+
+## Usage
+
+```bash
+# Dry-run: build + sign, but don't submit (safe to repeat)
+node send-tx.js
+
+# Send 0.001 ETH to an address on Sepolia (default network)
+node send-tx.js --to 0x... --value 0.001 --submit
+
+# Same thing on Base Sepolia
+NETWORK_RPC=https://sepolia.base.org \
+  node send-tx.js --to 0x... --value 0.001 --submit
+
+# Arbitrum Sepolia
+NETWORK_RPC=https://sepolia-rollup.arbitrum.io/rpc \
+  node send-tx.js --submit
+
+# Point at your own vault
+VAULT_URL=http://localhost:8093 \
+  node send-tx.js --submit
+```
+
+## Environment variables
+
+| Variable      | Default                                        | Description                          |
+|---------------|------------------------------------------------|--------------------------------------|
+| `NETWORK_RPC` | `https://ethereum-sepolia-rpc.publicnode.com`  | Target chain RPC                     |
+| `VAULT_URL`   | `https://vault.blockapps.net:8093`             | Vault instance (hosted or your own)  |
+
+Chain ID is auto-detected from the RPC — no hardcoded chain assumptions.
+
+## CLI flags
+
+| Flag              | Description                         |
+|-------------------|-------------------------------------|
+| `--to 0x...`      | Recipient address (default: self)   |
+| `--value 0.001`   | Amount in ETH (default: 0)          |
+| `--submit`        | Actually broadcast (default: dry-run) |
+
+## What this proves
+
+The vault's `POST /signature` endpoint is **chain-agnostic** — it signs any
+32-byte secp256k1 hash. No vault code changes were needed to go from
+STRATO-only to any EVM chain. Same key, same address, any network.
+
+This is the foundation for multi-chain vault signing.

--- a/strato/tools/vault-send-tx/README.md
+++ b/strato/tools/vault-send-tx/README.md
@@ -84,6 +84,80 @@ VAULT_URL=http://localhost:8093 \
   node send-tx.js --submit
 ```
 
+## Across test runner
+
+This package also includes a minimal Across bridge PoC for moving supported
+assets across supported EVM chains with the vault signer.
+
+Default behavior:
+- discovers the Across-supported chain RPCs and token addresses
+- fetches an Across quote for `1 USDC`
+- prints balances and quote details
+- in dry-run mode, signs but does not broadcast
+- with `--submit`, sends approval txs if needed, sends the bridge tx, then polls
+  Across until the deposit is `filled`
+- retries the temporary `DepositNotFound` indexer lag that can happen on testnet
+- refreshes the quote after approvals so the bridge tx uses current allowance state
+
+Examples:
+
+```bash
+# Dry-run the default Sepolia -> Base Sepolia USDC test
+node across-bridge.js
+
+# Broadcast the live test
+ACROSS_API_KEY=... node across-bridge.js --submit
+
+# Reverse direction
+ACROSS_API_KEY=... node across-bridge.js \
+  --origin-chain-id 84532 \
+  --destination-chain-id 11155111 \
+  --submit
+
+# Change amount or recipient
+ACROSS_API_KEY=... node across-bridge.js \
+  --amount 0.5 \
+  --recipient 0x... \
+  --submit
+
+# Bridge native ETH instead of USDC
+ACROSS_API_KEY=... node across-bridge.js \
+  --symbol ETH \
+  --amount 0.001 \
+  --submit
+
+# Override token lookup with exact Across-supported token addresses
+ACROSS_API_KEY=... node across-bridge.js \
+  --origin-chain-id 84532 \
+  --destination-chain-id 11155111 \
+  --input-token 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+  --output-token 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 \
+  --amount 0.5 \
+  --submit
+```
+
+Arguments:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--origin-chain-id` | `11155111` | Origin chain ID |
+| `--destination-chain-id` | `84532` | Destination chain ID |
+| `--symbol` | `USDC` | Token symbol looked up through Across |
+| `--input-token` | unset | Exact origin token address to use instead of symbol lookup |
+| `--output-token` | unset | Exact destination token address to use instead of symbol lookup |
+| `--amount` | `1` | Human-readable token amount |
+| `--recipient` | vault address | Destination recipient |
+| `--submit` | off | Broadcast approval and bridge txs |
+
+Additional environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ACROSS_API_BASE` | `https://testnet.across.to/api` | Across API base URL |
+| `ACROSS_API_KEY` | unset | Bearer token for Across API |
+| `ORIGIN_RPC` | Across chain RPC | Override origin RPC |
+| `DESTINATION_RPC` | Across chain RPC | Override destination RPC |
+
 ## Environment variables
 
 | Variable      | Default                                        | Description                          |

--- a/strato/tools/vault-send-tx/TestMintableERC20.sol
+++ b/strato/tools/vault-send-tx/TestMintableERC20.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TestMintableERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+    uint256 public totalSupply;
+    address public owner;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    error NotOwner();
+    error ZeroAddress();
+    error InsufficientBalance();
+    error InsufficientAllowance();
+
+    constructor(string memory _name, string memory _symbol, uint8 _decimals, address _owner) {
+        if (_owner == address(0)) revert ZeroAddress();
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+        owner = _owner;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        if (currentAllowance < value) revert InsufficientAllowance();
+        unchecked {
+            allowance[from][msg.sender] = currentAllowance - value;
+        }
+        emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function mint(address to, uint256 value) external onlyOwner returns (bool) {
+        if (to == address(0)) revert ZeroAddress();
+        totalSupply += value;
+        balanceOf[to] += value;
+        emit Transfer(address(0), to, value);
+        return true;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        if (to == address(0)) revert ZeroAddress();
+        uint256 fromBalance = balanceOf[from];
+        if (fromBalance < value) revert InsufficientBalance();
+        unchecked {
+            balanceOf[from] = fromBalance - value;
+        }
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+    }
+}

--- a/strato/tools/vault-send-tx/across-bridge.js
+++ b/strato/tools/vault-send-tx/across-bridge.js
@@ -1,0 +1,505 @@
+/**
+ * Minimal Across bridge runner using the vault signing utility.
+ *
+ * Default flow:
+ *  - discover Across-supported chains and token addresses
+ *  - fetch a quote for USDC Sepolia -> Base Sepolia
+ *  - optionally execute approval txs
+ *  - send the Across bridge tx via the vault signer
+ *  - poll Across deposit status until filled
+ *  - compare destination token balance before/after
+ *
+ * Usage:
+ *   node across-bridge.js
+ *   node across-bridge.js --submit
+ *   node across-bridge.js --amount 1 --submit
+ *   node across-bridge.js --origin-chain-id 84532 --destination-chain-id 11155111 --submit
+ *
+ * Env:
+ *   ACROSS_API_BASE   default: https://testnet.across.to/api
+ *   ACROSS_API_KEY    optional bearer token for Across API
+ *   ORIGIN_RPC        optional origin chain RPC override
+ *   DESTINATION_RPC   optional destination chain RPC override
+ *   VAULT_URL         optional vault URL override
+ */
+
+const { ethers } = require("ethers");
+const {
+  vaultGetAddress,
+  signTransaction,
+  submitSignedTransaction,
+} = require("./send-tx");
+
+const ERC20_ABI = [
+  "function balanceOf(address owner) view returns (uint256)",
+  "function allowance(address owner, address spender) view returns (uint256)",
+];
+
+const DEFAULT_API_BASE = process.env.ACROSS_API_BASE || "https://testnet.across.to/api";
+const DEFAULT_ORIGIN_CHAIN_ID = 11155111;
+const DEFAULT_DESTINATION_CHAIN_ID = 84532;
+const DEFAULT_SYMBOL = "USDC";
+const DEFAULT_AMOUNT = "1";
+const DEFAULT_POLL_INTERVAL_MS = 10000;
+const DEFAULT_POLL_TIMEOUT_MS = 12 * 60 * 1000;
+const NATIVE_TOKEN = "0x0000000000000000000000000000000000000000";
+const FALLBACK_CHAIN_CONFIG = {
+  11155111: {
+    chainId: 11155111,
+    name: "Sepolia",
+    publicRpcUrl: "https://ethereum-sepolia-rpc.publicnode.com",
+    explorerUrl: "https://sepolia.etherscan.io",
+  },
+  84532: {
+    chainId: 84532,
+    name: "Base Sepolia",
+    publicRpcUrl: "https://sepolia.base.org",
+    explorerUrl: "https://sepolia.basescan.org",
+  },
+};
+
+function getArgValue(args, flag, fallback) {
+  const idx = args.indexOf(flag);
+  if (idx < 0) return fallback;
+  return args[idx + 1];
+}
+
+function hasFlag(args, flag) {
+  return args.includes(flag);
+}
+
+function normalizeAddress(value, label) {
+  try {
+    return ethers.getAddress(value);
+  } catch {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeAcrossHeaders() {
+  const headers = { Accept: "application/json" };
+  if (process.env.ACROSS_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.ACROSS_API_KEY}`;
+  }
+  return headers;
+}
+
+async function acrossGet(path, params = {}) {
+  const url = new URL(`${DEFAULT_API_BASE}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const response = await fetch(url, { headers: makeAcrossHeaders() });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(`Across ${response.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function getAcrossChains() {
+  return acrossGet("/swap/chains");
+}
+
+async function getAcrossTokens(chainId) {
+  return acrossGet("/swap/tokens", { chainId });
+}
+
+function findChain(chains, chainId) {
+  const chain = chains.find((item) => Number(item.chainId) === Number(chainId));
+  return chain || FALLBACK_CHAIN_CONFIG[Number(chainId)] || null;
+}
+
+function findToken(tokens, symbol) {
+  const upper = String(symbol).toUpperCase();
+  const token = tokens.find((item) => String(item.symbol).toUpperCase() === upper);
+  if (!token) {
+    throw new Error(`Across did not return token symbol ${symbol}`);
+  }
+  return token;
+}
+
+function resolveToken({ tokens, symbol, explicitAddress, label }) {
+  if (explicitAddress) {
+    const normalized = normalizeAddress(explicitAddress, label);
+    const match = tokens.find(
+      (item) => String(item.address).toLowerCase() === normalized.toLowerCase()
+    );
+    if (match) return match;
+    if (normalized.toLowerCase() === NATIVE_TOKEN) {
+      return {
+        chainId: tokens[0]?.chainId,
+        address: NATIVE_TOKEN,
+        decimals: 18,
+        symbol: "ETH",
+        name: "Ether",
+      };
+    }
+    throw new Error(`Across did not return ${label} address ${normalized}`);
+  }
+  return findToken(tokens, symbol);
+}
+
+async function getQuote({
+  originChainId,
+  destinationChainId,
+  inputToken,
+  outputToken,
+  amount,
+  depositor,
+  recipient,
+}) {
+  return acrossGet("/swap/approval", {
+    tradeType: "exactInput",
+    originChainId,
+    destinationChainId,
+    inputToken,
+    outputToken,
+    amount,
+    depositor,
+    recipient,
+  });
+}
+
+function getRpcUrl(chain, envOverrideName) {
+  const override = process.env[envOverrideName];
+  if (override) return override;
+  if (chain.publicRpcUrl) return chain.publicRpcUrl;
+  throw new Error(`Missing ${envOverrideName} and Across did not return a public RPC URL`);
+}
+
+function formatTokenAmount(amount, decimals) {
+  return ethers.formatUnits(BigInt(amount), Number(decimals));
+}
+
+async function readTokenBalance(provider, tokenAddress, owner) {
+  if (String(tokenAddress).toLowerCase() === NATIVE_TOKEN) {
+    return provider.getBalance(owner);
+  }
+  const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  return contract.balanceOf(owner);
+}
+
+async function readAllowance(provider, tokenAddress, owner, spender) {
+  if (String(tokenAddress).toLowerCase() === NATIVE_TOKEN) {
+    return (2n ** 256n) - 1n;
+  }
+  const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  return contract.allowance(owner, spender);
+}
+
+function txRequestFromAcrossTx(tx) {
+  const rawGas = tx.gasLimit || tx.gas;
+  return {
+    to: normalizeAddress(tx.to, "transaction target"),
+    data: tx.data || "0x",
+    value: tx.value || "0",
+    gasLimit: rawGas && rawGas !== "0" ? rawGas : undefined,
+    maxFeePerGas: tx.maxFeePerGas,
+    maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+  };
+}
+
+async function signAndMaybeSubmitTx({ label, provider, fromAddress, tx, submit }) {
+  const txRequest = txRequestFromAcrossTx(tx);
+  if (!txRequest.gasLimit) {
+    const estimatedGas = await provider.estimateGas({
+      from: fromAddress,
+      to: txRequest.to,
+      data: txRequest.data,
+      value: BigInt(txRequest.value || "0"),
+    });
+    txRequest.gasLimit = (estimatedGas * 12n) / 10n;
+  }
+
+  console.log(`\n=== ${label}: entry ===`);
+  console.log(`target=${tx.to} valueWei=${tx.value || "0"} gas=${txRequest.gasLimit}`);
+
+  const signedTx = await signTransaction(provider, fromAddress, txRequest);
+
+  console.log(`=== ${label}: signed ===`);
+  console.log(`hash=${signedTx.hash}`);
+
+  if (!submit) {
+    console.log(`=== ${label}: exit dry-run ===`);
+    return { hash: signedTx.hash, signedTx, receipt: null };
+  }
+
+  const { response, receipt } = await submitSignedTransaction(provider, signedTx);
+
+  console.log(`=== ${label}: exit submitted ===`);
+  console.log(`txHash=${response.hash} block=${receipt.blockNumber} status=${receipt.status}`);
+
+  return { hash: response.hash, signedTx, receipt };
+}
+
+async function pollDepositStatus({ originChainId, depositTxnRef }) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < DEFAULT_POLL_TIMEOUT_MS) {
+    let status;
+    try {
+      status = await acrossGet("/deposit/status", { originChainId, depositTxnRef });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("DepositNotFoundException")) {
+        console.log("\n=== deposit-status poll ===");
+        console.log(
+          `status=indexing originChainId=${originChainId} depositTxnRef=${depositTxnRef} fillTxnRef=pending`
+        );
+        await sleep(DEFAULT_POLL_INTERVAL_MS);
+        continue;
+      }
+      throw error;
+    }
+
+    console.log("\n=== deposit-status poll ===");
+    console.log(
+      `status=${status.status} originChainId=${status.originChainId} destinationChainId=${status.destinationChainId} fillTxnRef=${status.fillTxnRef || "pending"}`
+    );
+
+    if (status.status === "filled") return status;
+    if (status.status === "expired" || status.status === "refunded") {
+      throw new Error(`Across deposit ended in terminal state: ${status.status}`);
+    }
+
+    await sleep(DEFAULT_POLL_INTERVAL_MS);
+  }
+
+  throw new Error("Timed out waiting for Across deposit to fill");
+}
+
+async function waitForAllowance({
+  provider,
+  tokenAddress,
+  owner,
+  spender,
+  minimum,
+}) {
+  if (String(tokenAddress).toLowerCase() === NATIVE_TOKEN) return;
+
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30000) {
+    const allowance = await readAllowance(provider, tokenAddress, owner, spender);
+    console.log(`allowanceCheckCurrent=${allowance.toString()} allowanceCheckExpected=${minimum}`);
+    if (allowance >= BigInt(minimum)) return;
+    await sleep(2000);
+  }
+
+  throw new Error(`Allowance did not reach ${minimum} in time for ${spender}`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const submit = hasFlag(args, "--submit");
+  const originChainId = Number(getArgValue(args, "--origin-chain-id", DEFAULT_ORIGIN_CHAIN_ID));
+  const destinationChainId = Number(
+    getArgValue(args, "--destination-chain-id", DEFAULT_DESTINATION_CHAIN_ID)
+  );
+  const symbol = getArgValue(args, "--symbol", DEFAULT_SYMBOL);
+  const amountHuman = getArgValue(args, "--amount", DEFAULT_AMOUNT);
+  const requestedRecipient = getArgValue(args, "--recipient");
+  const inputTokenAddressArg = getArgValue(args, "--input-token");
+  const outputTokenAddressArg = getArgValue(args, "--output-token");
+
+  console.log("Across Minimal Bridge Runner");
+  console.log("============================");
+  console.log(`apiBase=${DEFAULT_API_BASE}`);
+  console.log(`submit=${submit}`);
+  console.log(`originChainId=${originChainId}`);
+  console.log(`destinationChainId=${destinationChainId}`);
+  console.log(`symbol=${symbol}`);
+  console.log(`amount=${amountHuman}`);
+
+  console.log("\n=== discover-vault-address: entry ===");
+  const { address: depositor } = await vaultGetAddress();
+  const recipient = requestedRecipient ? normalizeAddress(requestedRecipient, "recipient") : depositor;
+  console.log(`depositor=${depositor}`);
+  console.log(`recipient=${recipient}`);
+  console.log("=== discover-vault-address: exit ===");
+
+  console.log("\n=== across-discovery: entry ===");
+  const chains = await getAcrossChains();
+  const [originTokens, destinationTokens] = await Promise.all([
+    getAcrossTokens(originChainId),
+    getAcrossTokens(destinationChainId),
+  ]);
+  const originChain = findChain(chains, originChainId);
+  const destinationChain = findChain(chains, destinationChainId);
+  if (!originChain) {
+    throw new Error(`No RPC metadata found for origin chain ${originChainId}`);
+  }
+  if (!destinationChain) {
+    throw new Error(`No RPC metadata found for destination chain ${destinationChainId}`);
+  }
+  const inputToken = resolveToken({
+    tokens: originTokens,
+    symbol,
+    explicitAddress: inputTokenAddressArg,
+    label: "input token",
+  });
+  const outputToken = resolveToken({
+    tokens: destinationTokens,
+    symbol,
+    explicitAddress: outputTokenAddressArg,
+    label: "output token",
+  });
+  const amount = ethers.parseUnits(amountHuman, Number(inputToken.decimals)).toString();
+  console.log(
+    `origin=${originChain.name} rpc=${getRpcUrl(originChain, "ORIGIN_RPC")} token=${inputToken.address}`
+  );
+  console.log(
+    `destination=${destinationChain.name} rpc=${getRpcUrl(destinationChain, "DESTINATION_RPC")} token=${outputToken.address}`
+  );
+  console.log(`amountBaseUnits=${amount}`);
+  console.log("=== across-discovery: exit ===");
+
+  const originProvider = new ethers.JsonRpcProvider(getRpcUrl(originChain, "ORIGIN_RPC"));
+  const destinationProvider = new ethers.JsonRpcProvider(
+    getRpcUrl(destinationChain, "DESTINATION_RPC")
+  );
+
+  console.log("\n=== preflight-balances: entry ===");
+  const [originNativeBalance, destinationNativeBalance, originTokenBalanceBefore, destinationTokenBalanceBefore] =
+    await Promise.all([
+      originProvider.getBalance(depositor),
+      destinationProvider.getBalance(recipient),
+      readTokenBalance(originProvider, inputToken.address, depositor),
+      readTokenBalance(destinationProvider, outputToken.address, recipient),
+    ]);
+  console.log(`originNativeEth=${ethers.formatEther(originNativeBalance)}`);
+  console.log(`destinationNativeEth=${ethers.formatEther(destinationNativeBalance)}`);
+  console.log(
+    `origin${symbol}Before=${formatTokenAmount(originTokenBalanceBefore, inputToken.decimals)}`
+  );
+  console.log(
+    `destination${symbol}Before=${formatTokenAmount(destinationTokenBalanceBefore, outputToken.decimals)}`
+  );
+  console.log("=== preflight-balances: exit ===");
+
+  console.log("\n=== across-quote: entry ===");
+  let quote = await getQuote({
+    originChainId,
+    destinationChainId,
+    inputToken: inputToken.address,
+    outputToken: outputToken.address,
+    amount,
+    depositor,
+    recipient,
+  });
+  console.log(`quoteId=${quote.id}`);
+  console.log(`expectedFillTime=${quote.expectedFillTime}`);
+  console.log(`expectedOutputAmount=${quote.expectedOutputAmount}`);
+  console.log(`minOutputAmount=${quote.minOutputAmount}`);
+  console.log(
+    `allowanceActual=${quote.checks?.allowance?.actual || "n/a"} allowanceExpected=${quote.checks?.allowance?.expected || "n/a"}`
+  );
+  console.log(
+    `balanceActual=${quote.checks?.balance?.actual || "n/a"} balanceExpected=${quote.checks?.balance?.expected || "n/a"}`
+  );
+  console.log(`approvalTxCount=${quote.approvalTxns?.length || 0}`);
+  console.log(`swapTarget=${quote.swapTx?.to || "missing"}`);
+  console.log("=== across-quote: exit ===");
+
+  if (!quote.swapTx) {
+    throw new Error("Across quote did not include swapTx");
+  }
+
+  if (originNativeBalance === 0n && submit) {
+    throw new Error(`Vault address ${depositor} has 0 native balance on origin chain ${originChainId}`);
+  }
+
+  if (originTokenBalanceBefore < BigInt(amount)) {
+    throw new Error(
+      `Insufficient ${symbol} balance. Need ${amountHuman}, have ${formatTokenAmount(
+        originTokenBalanceBefore,
+        inputToken.decimals
+      )}`
+    );
+  }
+
+  const allowanceSpender =
+    quote.checks?.allowance?.spender || quote.approvalTxns?.[0]?.to || quote.swapTx.to;
+  if (allowanceSpender) {
+    const allowance = await readAllowance(originProvider, inputToken.address, depositor, allowanceSpender);
+    console.log("\n=== allowance-check ===");
+    console.log(`spender=${allowanceSpender}`);
+    console.log(`allowance=${allowance.toString()}`);
+  }
+
+  for (let i = 0; i < (quote.approvalTxns || []).length; i += 1) {
+    await signAndMaybeSubmitTx({
+      label: `approval-${i + 1}`,
+      provider: originProvider,
+      fromAddress: depositor,
+      tx: quote.approvalTxns[i],
+      submit,
+    });
+  }
+
+  if ((quote.approvalTxns || []).length > 0) {
+    await waitForAllowance({
+      provider: originProvider,
+      tokenAddress: inputToken.address,
+      owner: depositor,
+      spender: allowanceSpender,
+      minimum: quote.checks?.allowance?.expected || amount,
+    });
+
+    quote = await getQuote({
+      originChainId,
+      destinationChainId,
+      inputToken: inputToken.address,
+      outputToken: outputToken.address,
+      amount,
+      depositor,
+      recipient,
+    });
+  }
+
+  const bridgeResult = await signAndMaybeSubmitTx({
+    label: "across-swap",
+    provider: originProvider,
+    fromAddress: depositor,
+    tx: quote.swapTx,
+    submit,
+  });
+
+  if (!submit) {
+    console.log("\nDry-run complete. Re-run with --submit to broadcast approvals and bridge tx.");
+    return;
+  }
+
+  const status = await pollDepositStatus({
+    originChainId,
+    depositTxnRef: bridgeResult.hash,
+  });
+
+  console.log("\n=== post-bridge-balances: entry ===");
+  const [originTokenBalanceAfter, destinationTokenBalanceAfter] = await Promise.all([
+    readTokenBalance(originProvider, inputToken.address, depositor),
+    readTokenBalance(destinationProvider, outputToken.address, recipient),
+  ]);
+  const originDelta = originTokenBalanceAfter - originTokenBalanceBefore;
+  const destinationDelta = destinationTokenBalanceAfter - destinationTokenBalanceBefore;
+  console.log(`origin${symbol}After=${formatTokenAmount(originTokenBalanceAfter, inputToken.decimals)}`);
+  console.log(
+    `destination${symbol}After=${formatTokenAmount(destinationTokenBalanceAfter, outputToken.decimals)}`
+  );
+  console.log(`originDelta=${formatTokenAmount(originDelta, inputToken.decimals)}`);
+  console.log(`destinationDelta=${formatTokenAmount(destinationDelta, outputToken.decimals)}`);
+  console.log(`fillTxnRef=${status.fillTxnRef}`);
+  console.log("=== post-bridge-balances: exit ===");
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/check-relayer-refund.js
+++ b/strato/tools/vault-send-tx/check-relayer-refund.js
@@ -1,0 +1,83 @@
+const { ethers } = require("ethers");
+
+const SPOKE_POOL_ABI = [
+  "function getRelayerRefund(address l2TokenAddress, address refundAddress) view returns (uint256)",
+  "event RelayedRootBundle(uint32 indexed rootBundleId, bytes32 indexed relayerRefundRoot, bytes32 indexed slowRelayRoot)",
+  "event ExecutedRelayerRefundRoot(uint256 amountToReturn,uint256 chainId,uint256[] refundAmounts,uint32 indexed rootBundleId,uint32 leafId,bytes32 indexed l2TokenAddress,address[] refundAddresses,bool deferredRefunds,address caller)",
+  "event ClaimedRelayerRefund(bytes32 indexed l2TokenAddress, bytes32 indexed refundAddress, uint256 amount, address indexed caller)",
+];
+
+const DEFAULT_ORIGIN_RPC = process.env.ORIGIN_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const DEFAULT_ORIGIN_SPOKE_POOL = process.env.ORIGIN_SPOKE_POOL || "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662";
+
+function getArgValue(args, flag, fallback) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : fallback;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tokenArg = getArgValue(args, "--token", process.env.TOKEN_ADDRESS);
+  const relayerArg = getArgValue(args, "--relayer", process.env.RELAYER_ADDRESS);
+  if (!tokenArg || !relayerArg) {
+    throw new Error(
+      "Usage: node check-relayer-refund.js --token 0x... --relayer 0x... [--rpc https://...] [--spoke-pool 0x...] [--lookback-blocks 50000]"
+    );
+  }
+  const rpc = getArgValue(args, "--rpc", DEFAULT_ORIGIN_RPC);
+  const spokePool = ethers.getAddress(getArgValue(args, "--spoke-pool", DEFAULT_ORIGIN_SPOKE_POOL));
+  const token = ethers.getAddress(tokenArg);
+  const relayer = ethers.getAddress(relayerArg);
+  const lookback = Number(getArgValue(args, "--lookback-blocks", "50000"));
+
+  const provider = new ethers.JsonRpcProvider(rpc);
+  const contract = new ethers.Contract(spokePool, SPOKE_POOL_ABI, provider);
+  const currentBlock = await provider.getBlockNumber();
+  const fromBlock = Math.max(0, currentBlock - lookback);
+
+  const [refund, relayedRoots, executedRefundEvents, claimedRefundEvents] = await Promise.all([
+    contract.getRelayerRefund(token, relayer),
+    contract.queryFilter(contract.filters.RelayedRootBundle(), fromBlock, currentBlock),
+    contract.queryFilter(contract.filters.ExecutedRelayerRefundRoot(), fromBlock, currentBlock),
+    contract.queryFilter(contract.filters.ClaimedRelayerRefund(), fromBlock, currentBlock),
+  ]);
+
+  const executedRefunds = executedRefundEvents.filter(
+    (evt) => ethers.getAddress(ethers.dataSlice(evt.args.l2TokenAddress, 12)) === token
+  );
+  const claimedRefunds = claimedRefundEvents.filter(
+    (evt) =>
+      ethers.getAddress(ethers.dataSlice(evt.args.l2TokenAddress, 12)) === token &&
+      ethers.getAddress(evt.args.caller) === relayer
+  );
+
+  console.log("Relayer Refund Check");
+  console.log("====================");
+  console.log(`rpc=${rpc}`);
+  console.log(`spokePool=${spokePool}`);
+  console.log(`token=${token}`);
+  console.log(`relayer=${relayer}`);
+  console.log(`currentBlock=${currentBlock}`);
+  console.log(`fromBlock=${fromBlock}`);
+  console.log(`claimableRefund=${refund.toString()}`);
+  console.log(`relayedRootBundlesSeen=${relayedRoots.length}`);
+  console.log(`executedRefundLeavesForToken=${executedRefunds.length}`);
+  console.log(`claimedRefundEventsForRelayer=${claimedRefunds.length}`);
+
+  if (executedRefunds.length > 0) {
+    const latest = executedRefunds[executedRefunds.length - 1];
+    console.log(`latestExecutedRefundTx=${latest.transactionHash}`);
+    console.log(`latestExecutedRefundBlock=${latest.blockNumber}`);
+  }
+
+  if (claimedRefunds.length > 0) {
+    const latest = claimedRefunds[claimedRefunds.length - 1];
+    console.log(`latestClaimedRefundTx=${latest.transactionHash}`);
+    console.log(`latestClaimedRefundBlock=${latest.blockNumber}`);
+  }
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/deploy-test-token.js
+++ b/strato/tools/vault-send-tx/deploy-test-token.js
@@ -1,0 +1,113 @@
+const { readFileSync } = require("fs");
+const path = require("path");
+const solc = require("solc");
+const { ethers } = require("ethers");
+const { vaultGetAddress, signTransaction, submitSignedTransaction } = require("./send-tx");
+
+const DEFAULT_NETWORK_RPC = process.env.NETWORK_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const CONTRACT_FILE = path.join(__dirname, "TestMintableERC20.sol");
+
+function getArgValue(args, flag, fallback) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : fallback;
+}
+
+function hasFlag(args, flag) {
+  return args.includes(flag);
+}
+
+function compileContract() {
+  const source = readFileSync(CONTRACT_FILE, "utf8");
+  const input = {
+    language: "Solidity",
+    sources: {
+      "TestMintableERC20.sol": { content: source },
+    },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  if (output.errors) {
+    const fatalErrors = output.errors.filter((err) => err.severity === "error");
+    if (fatalErrors.length) {
+      throw new Error(fatalErrors.map((err) => err.formattedMessage).join("\n"));
+    }
+  }
+
+  const contract = output.contracts["TestMintableERC20.sol"].TestMintableERC20;
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const submit = hasFlag(args, "--submit");
+  const name = getArgValue(args, "--name", "Test USDST");
+  const symbol = getArgValue(args, "--symbol", "tUSDST");
+  const decimals = Number(getArgValue(args, "--decimals", "18"));
+  const ownerArg = getArgValue(args, "--owner");
+
+  console.log("Deploy Test Mintable ERC20");
+  console.log("==========================");
+  console.log(`rpc=${DEFAULT_NETWORK_RPC}`);
+  console.log(`submit=${submit}`);
+  console.log(`name=${name}`);
+  console.log(`symbol=${symbol}`);
+  console.log(`decimals=${decimals}`);
+
+  const { address: vaultAddress } = await vaultGetAddress();
+  const owner = ownerArg ? ethers.getAddress(ownerArg) : vaultAddress;
+  console.log(`vaultAddress=${vaultAddress}`);
+  console.log(`owner=${owner}`);
+
+  const { abi, bytecode } = compileContract();
+  const provider = new ethers.JsonRpcProvider(DEFAULT_NETWORK_RPC);
+  const factory = new ethers.Interface(abi);
+  const deployData = ethers.concat([
+    bytecode,
+    factory.encodeDeploy([name, symbol, decimals, owner]),
+  ]);
+
+  const gasEstimate = await provider.estimateGas({
+    from: vaultAddress,
+    data: deployData,
+  });
+  const gasLimit = (gasEstimate * 12n) / 10n;
+
+  const signedTx = await signTransaction(provider, vaultAddress, {
+    to: null,
+    data: deployData,
+    value: 0n,
+    gasLimit,
+  });
+
+  console.log(`deployTxHash=${signedTx.hash}`);
+  if (!submit) {
+    console.log("Dry-run complete. Re-run with --submit to broadcast.");
+    return;
+  }
+
+  const { response, receipt } = await submitSignedTransaction(provider, signedTx);
+  const contractAddress = ethers.getCreateAddress({
+    from: vaultAddress,
+    nonce: response.nonce,
+  });
+
+  console.log(`submittedTxHash=${response.hash}`);
+  console.log(`block=${receipt.blockNumber}`);
+  console.log(`contractAddress=${contractAddress}`);
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/mint-test-token.js
+++ b/strato/tools/vault-send-tx/mint-test-token.js
@@ -1,0 +1,77 @@
+const { ethers } = require("ethers");
+const { vaultGetAddress, signTransaction, submitSignedTransaction } = require("./send-tx");
+
+const DEFAULT_NETWORK_RPC = process.env.NETWORK_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const ERC20_MINT_ABI = ["function mint(address to, uint256 value) returns (bool)"];
+
+function getArgValue(args, flag, fallback) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : fallback;
+}
+
+function hasFlag(args, flag) {
+  return args.includes(flag);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const submit = hasFlag(args, "--submit");
+  const token = getArgValue(args, "--token");
+  const to = getArgValue(args, "--to");
+  const amount = getArgValue(args, "--amount");
+  const decimals = Number(getArgValue(args, "--decimals", "18"));
+
+  if (!token || !to || !amount) {
+    throw new Error("Usage: node mint-test-token.js --token 0x... --to 0x... --amount 1000 [--decimals 18] [--submit]");
+  }
+
+  const tokenAddress = ethers.getAddress(token);
+  const recipient = ethers.getAddress(to);
+  const mintAmount = ethers.parseUnits(amount, decimals);
+
+  console.log("Mint Test Token");
+  console.log("===============");
+  console.log(`rpc=${DEFAULT_NETWORK_RPC}`);
+  console.log(`submit=${submit}`);
+  console.log(`token=${tokenAddress}`);
+  console.log(`to=${recipient}`);
+  console.log(`amount=${amount}`);
+  console.log(`amountBaseUnits=${mintAmount}`);
+
+  const { address: vaultAddress } = await vaultGetAddress();
+  console.log(`vaultAddress=${vaultAddress}`);
+
+  const provider = new ethers.JsonRpcProvider(DEFAULT_NETWORK_RPC);
+  const iface = new ethers.Interface(ERC20_MINT_ABI);
+  const data = iface.encodeFunctionData("mint", [recipient, mintAmount]);
+  const gasEstimate = await provider.estimateGas({
+    from: vaultAddress,
+    to: tokenAddress,
+    data,
+    value: 0n,
+  });
+  const gasLimit = (gasEstimate * 12n) / 10n;
+
+  const signedTx = await signTransaction(provider, vaultAddress, {
+    to: tokenAddress,
+    data,
+    value: 0n,
+    gasLimit,
+  });
+
+  console.log(`mintTxHash=${signedTx.hash}`);
+  if (!submit) {
+    console.log("Dry-run complete. Re-run with --submit to broadcast.");
+    return;
+  }
+
+  const { response, receipt } = await submitSignedTransaction(provider, signedTx);
+  console.log(`submittedTxHash=${response.hash}`);
+  console.log(`block=${receipt.blockNumber}`);
+  console.log(`status=${receipt.status}`);
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/package-lock.json
+++ b/strato/tools/vault-send-tx/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "ethers": "^6.16.0"
+        "ethers": "^6.16.0",
+        "solc": "^0.8.30"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -52,6 +53,19 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ethers": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
@@ -77,6 +91,85 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/solc": {
+      "version": "0.8.34",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.34.tgz",
+      "integrity": "sha512-qf8HajA1sHhXRV0hMSDXLjVbc4v3Q+SQbL9zok+1WmgVj7Z4oMjMHxaysCzfGtFVqjZdfDDJWyZI+tcx5bO7Dw==",
+      "dependencies": {
+        "command-exists": "^1.2.8",
+        "commander": "^8.1.0",
+        "follow-redirects": "^1.12.1",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "bin": {
+        "solcjs": "solc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/tslib": {

--- a/strato/tools/vault-send-tx/package-lock.json
+++ b/strato/tools/vault-send-tx/package-lock.json
@@ -1,0 +1,113 @@
+{
+  "name": "vault-sepolia",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vault-sepolia",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.16.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/strato/tools/vault-send-tx/package.json
+++ b/strato/tools/vault-send-tx/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "across:test": "node across-bridge.js"
   },
   "keywords": [],
   "author": "",

--- a/strato/tools/vault-send-tx/package.json
+++ b/strato/tools/vault-send-tx/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-sepolia",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ethers": "^6.16.0"
+  }
+}

--- a/strato/tools/vault-send-tx/package.json
+++ b/strato/tools/vault-send-tx/package.json
@@ -5,12 +5,17 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "across:test": "node across-bridge.js"
+    "across:test": "node across-bridge.js",
+    "token:deploy": "node deploy-test-token.js",
+    "token:mint": "node mint-test-token.js",
+    "self-relay:test": "node self-relay-fill.js",
+    "refund:check": "node check-relayer-refund.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ethers": "^6.16.0"
+    "ethers": "^6.16.0",
+    "solc": "^0.8.30"
   }
 }

--- a/strato/tools/vault-send-tx/self-relay-fill.js
+++ b/strato/tools/vault-send-tx/self-relay-fill.js
@@ -1,0 +1,187 @@
+const { ethers } = require("ethers");
+const { vaultGetAddress, signTransaction, submitSignedTransaction } = require("./send-tx");
+
+const ERC20_ABI = [
+  "function approve(address spender, uint256 value) returns (bool)",
+  "function allowance(address owner, address spender) view returns (uint256)",
+  "function balanceOf(address owner) view returns (uint256)",
+];
+
+const SPOKE_POOL_ABI = [
+  "function depositV3Now(address depositor,address recipient,address inputToken,address outputToken,uint256 inputAmount,uint256 outputAmount,uint256 destinationChainId,address exclusiveRelayer,uint32 fillDeadlineOffset,uint32 exclusivityDeadline,bytes message) payable",
+  "function fillV3Relay((address depositor,address recipient,address exclusiveRelayer,address inputToken,address outputToken,uint256 inputAmount,uint256 outputAmount,uint256 originChainId,uint32 depositId,uint32 fillDeadline,uint32 exclusivityDeadline,bytes message) relayData,uint256 repaymentChainId)",
+  "event FundsDeposited(bytes32 inputToken,bytes32 outputToken,uint256 inputAmount,uint256 outputAmount,uint256 indexed destinationChainId,uint256 indexed depositId,uint32 quoteTimestamp,uint32 fillDeadline,uint32 exclusivityDeadline,bytes32 indexed depositor,bytes32 recipient,bytes32 exclusiveRelayer,bytes message)",
+];
+
+const DEFAULT_ORIGIN_RPC = process.env.ORIGIN_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const DEFAULT_DESTINATION_RPC = process.env.DESTINATION_RPC || "https://sepolia.base.org";
+const DEFAULT_ORIGIN_SPOKE_POOL = process.env.ORIGIN_SPOKE_POOL || "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662";
+const DEFAULT_DESTINATION_SPOKE_POOL =
+  process.env.DESTINATION_SPOKE_POOL || "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F";
+const DEFAULT_ORIGIN_CHAIN_ID = Number(process.env.ORIGIN_CHAIN_ID || "11155111");
+const DEFAULT_DESTINATION_CHAIN_ID = Number(process.env.DESTINATION_CHAIN_ID || "84532");
+
+function getArgValue(args, flag, fallback) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : fallback;
+}
+
+function hasFlag(args, flag) {
+  return args.includes(flag);
+}
+
+async function sendTx({ provider, fromAddress, txRequest, label, submit }) {
+  const gasEstimate = await provider.estimateGas({
+    from: fromAddress,
+    to: txRequest.to,
+    data: txRequest.data,
+    value: BigInt(txRequest.value || "0"),
+  });
+  const gasLimit = (gasEstimate * 12n) / 10n;
+  const signedTx = await signTransaction(provider, fromAddress, { ...txRequest, gasLimit });
+  console.log(`\n=== ${label} ===`);
+  console.log(`hash=${signedTx.hash}`);
+  if (!submit) return { hash: signedTx.hash, receipt: null };
+  const { response, receipt } = await submitSignedTransaction(provider, signedTx);
+  console.log(`submitted=${response.hash} block=${receipt.blockNumber} status=${receipt.status}`);
+  return { hash: response.hash, receipt };
+}
+
+async function ensureAllowance({ provider, tokenAddress, owner, spender, amount, submit, label }) {
+  const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  const allowance = await token.allowance(owner, spender);
+  console.log(`${label}Allowance=${allowance.toString()}`);
+  if (allowance >= amount) return;
+
+  const iface = new ethers.Interface(ERC20_ABI);
+  const data = iface.encodeFunctionData("approve", [spender, ethers.MaxUint256]);
+  await sendTx({
+    provider,
+    fromAddress: owner,
+    txRequest: { to: tokenAddress, data, value: 0n },
+    label: `${label}-approve`,
+    submit,
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const submit = hasFlag(args, "--submit");
+  const inputTokenArg = getArgValue(args, "--input-token", process.env.INPUT_TOKEN);
+  const outputTokenArg = getArgValue(args, "--output-token", process.env.OUTPUT_TOKEN);
+  if (!inputTokenArg || !outputTokenArg) {
+    throw new Error(
+      "Usage: node self-relay-fill.js --input-token 0x... --output-token 0x... [--recipient 0x...] [--amount 1] [--decimals 18] [--submit]"
+    );
+  }
+
+  const amount = ethers.parseUnits(getArgValue(args, "--amount", "1"), Number(getArgValue(args, "--decimals", "18")));
+  const fillDeadlineOffset = Number(getArgValue(args, "--fill-deadline-offset", "3600"));
+
+  const { address: relayer } = await vaultGetAddress();
+  const recipient = ethers.getAddress(getArgValue(args, "--recipient", relayer));
+  const inputToken = ethers.getAddress(inputTokenArg);
+  const outputToken = ethers.getAddress(outputTokenArg);
+  const originProvider = new ethers.JsonRpcProvider(DEFAULT_ORIGIN_RPC);
+  const destinationProvider = new ethers.JsonRpcProvider(DEFAULT_DESTINATION_RPC);
+  const spokePoolIface = new ethers.Interface(SPOKE_POOL_ABI);
+
+  console.log("Self Relay Custom Fill");
+  console.log("======================");
+  console.log(`submit=${submit}`);
+  console.log(`relayer=${relayer}`);
+  console.log(`recipient=${recipient}`);
+  console.log(`inputToken=${inputToken}`);
+  console.log(`outputToken=${outputToken}`);
+  console.log(`amount=${amount.toString()}`);
+
+  await ensureAllowance({
+    provider: originProvider,
+    tokenAddress: inputToken,
+    owner: relayer,
+    spender: DEFAULT_ORIGIN_SPOKE_POOL,
+    amount,
+    submit,
+    label: "origin",
+  });
+
+  await ensureAllowance({
+    provider: destinationProvider,
+    tokenAddress: outputToken,
+    owner: relayer,
+    spender: DEFAULT_DESTINATION_SPOKE_POOL,
+    amount,
+    submit,
+    label: "destination",
+  });
+
+  const depositData = spokePoolIface.encodeFunctionData("depositV3Now", [
+    relayer,
+    recipient,
+    inputToken,
+    outputToken,
+    amount,
+    amount,
+    DEFAULT_DESTINATION_CHAIN_ID,
+    ethers.ZeroAddress,
+    fillDeadlineOffset,
+    0,
+    "0x",
+  ]);
+
+  const depositResult = await sendTx({
+    provider: originProvider,
+    fromAddress: relayer,
+    txRequest: { to: DEFAULT_ORIGIN_SPOKE_POOL, data: depositData, value: 0n },
+    label: "depositV3Now",
+    submit,
+  });
+
+  if (!submit) return;
+
+  const receipt = await originProvider.getTransactionReceipt(depositResult.hash);
+  const depositLog = receipt.logs
+    .map((log) => {
+      try {
+        return spokePoolIface.parseLog(log);
+      } catch {
+        return null;
+      }
+    })
+    .find((log) => log && log.name === "FundsDeposited");
+
+  if (!depositLog) throw new Error("FundsDeposited event not found");
+
+  const relayData = {
+    depositor: relayer,
+    recipient,
+    exclusiveRelayer: ethers.ZeroAddress,
+    inputToken,
+    outputToken,
+    inputAmount: depositLog.args.inputAmount,
+    outputAmount: depositLog.args.outputAmount,
+    originChainId: DEFAULT_ORIGIN_CHAIN_ID,
+    depositId: Number(depositLog.args.depositId),
+    fillDeadline: depositLog.args.fillDeadline,
+    exclusivityDeadline: depositLog.args.exclusivityDeadline,
+    message: "0x",
+  };
+
+  console.log(`depositId=${relayData.depositId}`);
+  console.log(`fillDeadline=${relayData.fillDeadline}`);
+  console.log(`exclusivityDeadline=${relayData.exclusivityDeadline}`);
+
+  const fillData = spokePoolIface.encodeFunctionData("fillV3Relay", [relayData, DEFAULT_ORIGIN_CHAIN_ID]);
+  await sendTx({
+    provider: destinationProvider,
+    fromAddress: relayer,
+    txRequest: { to: DEFAULT_DESTINATION_SPOKE_POOL, data: fillData, value: 0n },
+    label: "fillV3Relay",
+    submit,
+  });
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/send-tx.js
+++ b/strato/tools/vault-send-tx/send-tx.js
@@ -107,7 +107,9 @@ function toBigIntOrUndefined(value) {
 }
 
 async function signTransaction(provider, fromAddress, txRequest) {
-  const to = txRequest.to || fromAddress;
+  const to = Object.prototype.hasOwnProperty.call(txRequest, "to")
+    ? txRequest.to
+    : fromAddress;
   const value =
     txRequest.value !== undefined
       ? toBigIntOrUndefined(txRequest.value)
@@ -124,7 +126,6 @@ async function signTransaction(provider, fromAddress, txRequest) {
     type: 2,
     chainId,
     nonce: txRequest.nonce ?? nonce,
-    to,
     value,
     data,
     maxFeePerGas: toBigIntOrUndefined(txRequest.maxFeePerGas) ?? feeData.maxFeePerGas,
@@ -132,10 +133,13 @@ async function signTransaction(provider, fromAddress, txRequest) {
       toBigIntOrUndefined(txRequest.maxPriorityFeePerGas) ?? feeData.maxPriorityFeePerGas,
     gasLimit: toBigIntOrUndefined(txRequest.gasLimit) ?? 21000n,
   };
+  if (to !== null && to !== undefined) {
+    tx.to = to;
+  }
 
   console.log("\n--- Unsigned Transaction ---");
   console.log("  from:                ", fromAddress);
-  console.log("  to:                  ", tx.to);
+  console.log("  to:                  ", tx.to ?? "[contract creation]");
   console.log("  value:               ", ethers.formatEther(tx.value), "ETH");
   console.log("  nonce:               ", tx.nonce);
   console.log("  maxFeePerGas:        ", ethers.formatUnits(tx.maxFeePerGas, "gwei"), "gwei");

--- a/strato/tools/vault-send-tx/send-tx.js
+++ b/strato/tools/vault-send-tx/send-tx.js
@@ -1,0 +1,223 @@
+/**
+ * Vault → EVM transaction sender
+ *
+ * Uses the STRATO vault signing service to sign and submit
+ * a transaction on any EVM chain. Same key, any network.
+ *
+ * Usage:
+ *   node send-tx.js                    # dry-run (sign only, no submit)
+ *   node send-tx.js --submit           # sign and submit
+ *   node send-tx.js --to 0x... --value 0.001 --submit
+ *
+ * Env:
+ *   NETWORK_RPC  - RPC endpoint (default: Sepolia public RPC)
+ *   VAULT_URL    - vault service (default: https://vault.blockapps.net:8093)
+ *
+ * Requires: ~/.secrets/stratoToken (run `strato-auth` first)
+ */
+
+const { ethers } = require("ethers");
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const http = require("http");
+
+const VAULT_URL = process.env.VAULT_URL || "https://vault.blockapps.net:8093";
+const NETWORK_RPC = process.env.NETWORK_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+
+// ---------------------------------------------------------------------------
+// Vault API helpers
+// ---------------------------------------------------------------------------
+
+function loadToken() {
+  const tokenPath = path.join(
+    process.env.HOME,
+    ".secrets",
+    "stratoToken"
+  );
+  const data = JSON.parse(fs.readFileSync(tokenPath, "utf8"));
+  const now = Math.floor(Date.now() / 1000);
+  if (now >= data.expires_at) {
+    throw new Error("Token expired. Run `strato-auth` to re-authenticate.");
+  }
+  return data.access_token;
+}
+
+function vaultRequest(method, endpoint, body) {
+  const token = loadToken();
+  const url = new URL(`${VAULT_URL}/strato/v2.3/${endpoint}`);
+  const mod = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : null;
+    const req = mod.request(
+      url,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(payload && { "Content-Type": "application/json" }),
+        },
+      },
+      (res) => {
+        let chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString();
+          if (res.statusCode >= 400) {
+            reject(new Error(`Vault ${res.statusCode}: ${text}`));
+          } else {
+            resolve(JSON.parse(text));
+          }
+        });
+      }
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+async function vaultGetAddress() {
+  const resp = await vaultRequest("GET", "key");
+  return { address: ethers.getAddress("0x" + resp.address), pubkey: resp.pubkey };
+}
+
+async function vaultSign(hash) {
+  const hashHex = hash.startsWith("0x") ? hash.slice(2) : hash;
+  const resp = await vaultRequest("POST", "signature", { msgHash: hashHex });
+  return { r: "0x" + resp.r, s: "0x" + resp.s, v: resp.v };
+}
+
+// ---------------------------------------------------------------------------
+// Transaction construction + signing
+// ---------------------------------------------------------------------------
+
+async function buildAndSign(provider, fromAddress, opts) {
+  const to = opts.to || fromAddress; // default: send to self
+  const value = ethers.parseEther(opts.value || "0");
+
+  const [nonce, feeData] = await Promise.all([
+    provider.getTransactionCount(fromAddress, "latest"),
+    provider.getFeeData(),
+  ]);
+
+  const { chainId } = await provider.getNetwork();
+
+  const tx = {
+    type: 2,
+    chainId,
+    nonce,
+    to,
+    value,
+    data: "0x",
+    maxFeePerGas: feeData.maxFeePerGas,
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+    gasLimit: 21000n, // simple ETH transfer
+  };
+
+  console.log("\n--- Unsigned Transaction ---");
+  console.log("  from:                ", fromAddress);
+  console.log("  to:                  ", tx.to);
+  console.log("  value:               ", ethers.formatEther(tx.value), "ETH");
+  console.log("  nonce:               ", tx.nonce);
+  console.log("  maxFeePerGas:        ", ethers.formatUnits(tx.maxFeePerGas, "gwei"), "gwei");
+  console.log("  maxPriorityFeePerGas:", ethers.formatUnits(tx.maxPriorityFeePerGas, "gwei"), "gwei");
+  console.log("  chainId:             ", tx.chainId);
+
+  // Serialize the unsigned tx to get the signing hash
+  const unsignedSerialized = ethers.Transaction.from(tx).unsignedSerialized;
+  const signingHash = ethers.keccak256(unsignedSerialized);
+
+  console.log("\n--- Signing via Vault ---");
+  console.log("  signing hash:", signingHash);
+
+  const sig = await vaultSign(signingHash);
+  console.log("  vault response: r =", sig.r.slice(0, 18) + "...");
+  console.log("                  s =", sig.s.slice(0, 18) + "...");
+  console.log("                  v =", sig.v);
+
+  // Assemble the signed transaction
+  // ethers v6: vault v (0/1) maps to yParity for EIP-1559
+  const signedTx = ethers.Transaction.from({
+    ...tx,
+    signature: ethers.Signature.from({
+      r: sig.r,
+      s: sig.s,
+      v: 27 + sig.v, // ethers expects 27/28
+    }),
+  });
+
+  // Verify the recovered address matches
+  const recovered = signedTx.from;
+  if (recovered.toLowerCase() !== fromAddress.toLowerCase()) {
+    throw new Error(
+      `Signature recovery mismatch!\n  expected: ${fromAddress}\n  recovered: ${recovered}`
+    );
+  }
+  console.log("  recovered from:  ", recovered, "✓");
+
+  return signedTx;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const submit = args.includes("--submit");
+  const toIdx = args.indexOf("--to");
+  const valIdx = args.indexOf("--value");
+  const to = toIdx >= 0 ? args[toIdx + 1] : undefined;
+  const value = valIdx >= 0 ? args[valIdx + 1] : "0";
+
+  console.log("Vault → EVM Transaction Sender");
+  console.log("===============================\n");
+
+  // 1. Get address from vault
+  console.log("Fetching address from vault...");
+  const { address } = await vaultGetAddress();
+  console.log("  vault address:", address);
+
+  // 2. Connect to network
+  const provider = new ethers.JsonRpcProvider(NETWORK_RPC);
+  const { chainId, name: networkName } = await provider.getNetwork();
+  console.log("  network:       ", networkName, `(chainId ${chainId})`);
+  const balance = await provider.getBalance(address);
+  console.log("  balance:       ", ethers.formatEther(balance), "ETH");
+
+  if (balance === 0n && submit) {
+    console.error("\n  ⚠ Balance is 0. Fund this address first.");
+    console.error("    Address:", address);
+    process.exit(1);
+  }
+
+  // 3. Build and sign
+  const signedTx = await buildAndSign(provider, address, { to, value });
+
+  console.log("\n--- Signed Transaction ---");
+  console.log("  hash:", signedTx.hash);
+  console.log("  raw: ", signedTx.serialized.slice(0, 40) + "...");
+
+  // 4. Submit (or dry-run)
+  if (submit) {
+    console.log("\n--- Submitting ---");
+    const resp = await provider.broadcastTransaction(signedTx.serialized);
+    console.log("  tx hash:", resp.hash);
+    console.log("\n  Waiting for confirmation...");
+    const receipt = await resp.wait();
+    console.log("  confirmed in block:", receipt.blockNumber);
+    console.log("  gas used:", receipt.gasUsed.toString());
+    console.log("  status:", receipt.status === 1 ? "SUCCESS ✓" : "FAILED ✗");
+  } else {
+    console.log("\n  Dry-run mode. Use --submit to broadcast.");
+    console.log("  Full signed tx hex:");
+    console.log(" ", signedTx.serialized);
+  }
+}
+
+main().catch((err) => {
+  console.error("\nError:", err.message);
+  process.exit(1);
+});

--- a/strato/tools/vault-send-tx/send-tx.js
+++ b/strato/tools/vault-send-tx/send-tx.js
@@ -23,7 +23,8 @@ const https = require("https");
 const http = require("http");
 
 const VAULT_URL = process.env.VAULT_URL || "https://vault.blockapps.net:8093";
-const NETWORK_RPC = process.env.NETWORK_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const DEFAULT_NETWORK_RPC = "https://ethereum-sepolia-rpc.publicnode.com";
+const NETWORK_RPC = process.env.NETWORK_RPC || DEFAULT_NETWORK_RPC;
 
 // ---------------------------------------------------------------------------
 // Vault API helpers
@@ -93,10 +94,25 @@ async function vaultSign(hash) {
 // Transaction construction + signing
 // ---------------------------------------------------------------------------
 
-async function buildAndSign(provider, fromAddress, opts) {
-  const to = opts.to || fromAddress; // default: send to self
-  const value = ethers.parseEther(opts.value || "0");
+function toBigIntOrUndefined(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(value);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    return BigInt(trimmed);
+  }
+  throw new Error(`Unsupported bigint value: ${String(value)}`);
+}
 
+async function signTransaction(provider, fromAddress, txRequest) {
+  const to = txRequest.to || fromAddress;
+  const value =
+    txRequest.value !== undefined
+      ? toBigIntOrUndefined(txRequest.value)
+      : ethers.parseEther(txRequest.valueEth || "0");
+  const data = txRequest.data || "0x";
   const [nonce, feeData] = await Promise.all([
     provider.getTransactionCount(fromAddress, "latest"),
     provider.getFeeData(),
@@ -107,13 +123,14 @@ async function buildAndSign(provider, fromAddress, opts) {
   const tx = {
     type: 2,
     chainId,
-    nonce,
+    nonce: txRequest.nonce ?? nonce,
     to,
     value,
-    data: "0x",
-    maxFeePerGas: feeData.maxFeePerGas,
-    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
-    gasLimit: 21000n, // simple ETH transfer
+    data,
+    maxFeePerGas: toBigIntOrUndefined(txRequest.maxFeePerGas) ?? feeData.maxFeePerGas,
+    maxPriorityFeePerGas:
+      toBigIntOrUndefined(txRequest.maxPriorityFeePerGas) ?? feeData.maxPriorityFeePerGas,
+    gasLimit: toBigIntOrUndefined(txRequest.gasLimit) ?? 21000n,
   };
 
   console.log("\n--- Unsigned Transaction ---");
@@ -123,7 +140,9 @@ async function buildAndSign(provider, fromAddress, opts) {
   console.log("  nonce:               ", tx.nonce);
   console.log("  maxFeePerGas:        ", ethers.formatUnits(tx.maxFeePerGas, "gwei"), "gwei");
   console.log("  maxPriorityFeePerGas:", ethers.formatUnits(tx.maxPriorityFeePerGas, "gwei"), "gwei");
+  console.log("  gasLimit:            ", tx.gasLimit.toString());
   console.log("  chainId:             ", tx.chainId);
+  console.log("  data bytes:          ", (tx.data.length - 2) / 2);
 
   // Serialize the unsigned tx to get the signing hash
   const unsignedSerialized = ethers.Transaction.from(tx).unsignedSerialized;
@@ -158,6 +177,19 @@ async function buildAndSign(provider, fromAddress, opts) {
   console.log("  recovered from:  ", recovered, "✓");
 
   return signedTx;
+}
+
+async function buildAndSign(provider, fromAddress, opts) {
+  return signTransaction(provider, fromAddress, {
+    to: opts.to,
+    valueEth: opts.value || "0",
+    gasLimit: 21000n,
+  });
+}
+
+async function submitSignedTransaction(provider, signedTx) {
+  const resp = await provider.broadcastTransaction(signedTx.serialized);
+  return { response: resp, receipt: await resp.wait() };
 }
 
 // ---------------------------------------------------------------------------
@@ -203,10 +235,9 @@ async function main() {
   // 4. Submit (or dry-run)
   if (submit) {
     console.log("\n--- Submitting ---");
-    const resp = await provider.broadcastTransaction(signedTx.serialized);
+    const { response: resp, receipt } = await submitSignedTransaction(provider, signedTx);
     console.log("  tx hash:", resp.hash);
     console.log("\n  Waiting for confirmation...");
-    const receipt = await resp.wait();
     console.log("  confirmed in block:", receipt.blockNumber);
     console.log("  gas used:", receipt.gasUsed.toString());
     console.log("  status:", receipt.status === 1 ? "SUCCESS ✓" : "FAILED ✗");
@@ -217,7 +248,20 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("\nError:", err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("\nError:", err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_NETWORK_RPC,
+  loadToken,
+  vaultRequest,
+  vaultGetAddress,
+  vaultSign,
+  signTransaction,
+  buildAndSign,
+  submitSignedTransaction,
+};


### PR DESCRIPTION
## Summary
- add a reusable vault-backed EVM tx sender for arbitrary calldata and value transfers
- add an Across bridge PoC for supported ERC-20 and native ETH transfers across supported EVM chains
- add custom token deployment, minting, self-relayed fill, and refund-check tooling for experimenting with routes the public quote path will not price

## Test plan
- [x] Dry-run `send-tx.js`, `across-bridge.js`, `deploy-test-token.js`, `mint-test-token.js`, `self-relay-fill.js`, and `check-relayer-refund.js`
- [x] Live: bridge `1 USDC` from Sepolia to Base Sepolia
- [x] Live: bridge `0.001 ETH` from Sepolia to Base Sepolia
- [x] Live: bridge `0.5 USDC` from Base Sepolia to Sepolia
- [x] Live: deploy and mint a plain test ERC-20 on Sepolia and Base Sepolia
- [x] Live: submit direct `depositV3Now()` and `fillV3Relay()` for the custom token route using self-supplied inventory
- [x] Check current relayer refund state for the custom route on the origin spoke pool