### PR TITLE
Metrics for deflillama

### DIFF
--- a/mercata/adapters/defillama/DefiLlamaStablecoinsMetadataDraft.md
+++ b/mercata/adapters/defillama/DefiLlamaStablecoinsMetadataDraft.md
@@ -1,0 +1,117 @@
+# DefiLlama Stablecoins Metadata Draft
+
+## Purpose
+
+This file captures the concrete STRATO stablecoin asset set and metadata needed for a DefiLlama stablecoin submission.
+
+It is intentionally separate from the draft stablecoin adapter logic because the exact DefiLlama submission path may require:
+
+- asset registration / metadata changes
+- a stablecoin-specific adapter shape
+- or both
+
+## STRATO Chain
+
+- chain key: `strato`
+- public source endpoint: `https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/stablecoins`
+
+## Included Stablecoins
+
+### `USDST`
+
+- address: `937efa7e3a77e20bbdbd7c0d32b6514f368c1010`
+- symbol: `USDST`
+- name: `USDST`
+- decimals: `18`
+- peg type: `peggedUSD`
+- classification: native STRATO stablecoin
+
+### `USDC`
+
+- address: `6aeacaa19c68e53035bf495d15e0a328fc600ba8`
+- symbol: `USDC`
+- name: `STRATO USDC`
+- decimals: `18`
+- peg type: `peggedUSD`
+- classification: bridged representation on STRATO
+
+### `USDT`
+
+- address: `5ed0bdfb378ac0d06249d70759536d7a41906216`
+- symbol: `USDT`
+- name: `STRATO USDT`
+- decimals: `18`
+- peg type: `peggedUSD`
+- classification: bridged representation on STRATO
+
+## Explicit Exclusions
+
+These assets may appear in STRATO TVL when they are locked, but they should not be counted as canonical stablecoin supply:
+
+- `sUSDS` at `6e2d93d323edf1b3cc4672a909681b6a430cae64`
+- `syrupUSDC` at `c6c3e9881665d53ae8c222e24ca7a8d069aa56ca`
+
+Reason:
+
+- they are yield-bearing wrappers, not canonical circulating stablecoins
+
+## Methodology
+
+Stablecoin supply on STRATO counts the circulating supply of canonical USD-pegged assets issued or represented on STRATO. Current scope includes `USDST`, `USDC`, and `USDT`. Yield-bearing wrappers such as `sUSDS` and `syrupUSDC` are excluded from stablecoin supply and treated separately from canonical circulating stablecoins.
+
+## Current Prod Snapshot
+
+Current production output from `prod-stablecoins-output.json`:
+
+- total stablecoin supply: approximately `$814.9M`
+- `USDST`: approximately `$801.0M`
+- `USDC`: approximately `$9.28M`
+- `USDT`: approximately `$4.60M`
+
+## Candidate Review Notes
+
+Use these points if DefiLlama asks for supporting context:
+
+- STRATO stablecoin supply is separate from STRATO TVL
+- `USDST` is the native STRATO stablecoin
+- `USDC` and `USDT` are STRATO-side bridged representations
+- the backend endpoint is public, read-only, and unauthenticated
+- the endpoint returns stablecoin-specific supply rows, not protocol TVL balances
+
+## Candidate Asset Registration Shape
+
+If DefiLlama asks for chain asset metadata rather than just prose, these are the concrete rows to register for `strato`:
+
+```json
+[
+  {
+    "chain": "strato",
+    "address": "937efa7e3a77e20bbdbd7c0d32b6514f368c1010",
+    "symbol": "USDST",
+    "name": "USDST",
+    "decimals": 18,
+    "pegType": "peggedUSD",
+    "classification": "native"
+  },
+  {
+    "chain": "strato",
+    "address": "6aeacaa19c68e53035bf495d15e0a328fc600ba8",
+    "symbol": "USDC",
+    "name": "STRATO USDC",
+    "decimals": 18,
+    "pegType": "peggedUSD",
+    "classification": "bridged_representation"
+  },
+  {
+    "chain": "strato",
+    "address": "5ed0bdfb378ac0d06249d70759536d7a41906216",
+    "symbol": "USDT",
+    "name": "STRATO USDT",
+    "decimals": 18,
+    "pegType": "peggedUSD",
+    "classification": "bridged_representation"
+  }
+]
+```
+
+This JSON block is a draft reference, not a claim about DefiLlama's exact file schema.

--- a/mercata/adapters/defillama/DefiLlamaStablecoinsPR.md
+++ b/mercata/adapters/defillama/DefiLlamaStablecoinsPR.md
@@ -1,0 +1,55 @@
+# DefiLlama Stablecoins PR Body
+
+## Summary
+
+- Add STRATO stablecoin coverage for canonical USD-pegged assets on STRATO
+- Include `USDST`, `USDC`, and `USDT`
+- Exclude yield-bearing wrappers such as `sUSDS` and `syrupUSDC` from canonical stablecoin supply
+
+## Methodology
+
+Stablecoin supply on STRATO counts the circulating supply of canonical USD-pegged assets issued or represented on STRATO. Current scope includes `USDST`, `USDC`, and `USDT`. Yield-bearing wrappers such as `sUSDS` and `syrupUSDC` are excluded from stablecoin supply and treated separately from canonical circulating stablecoins.
+
+## Data Source
+
+- Public stablecoins endpoint: `https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/stablecoins`
+- The endpoint is read-only and unauthenticated
+- The endpoint returns current stablecoin supply snapshots for STRATO-recognized canonical stablecoins
+
+## STRATO Stablecoin Set
+
+- `USDST`
+  - address: `937efa7e3a77e20bbdbd7c0d32b6514f368c1010`
+  - decimals: `18`
+  - classification: native STRATO stablecoin
+- `USDC`
+  - address: `6aeacaa19c68e53035bf495d15e0a328fc600ba8`
+  - decimals: `18`
+  - classification: bridged representation on STRATO
+- `USDT`
+  - address: `5ed0bdfb378ac0d06249d70759536d7a41906216`
+  - decimals: `18`
+  - classification: bridged representation on STRATO
+
+## Notes
+
+- Current prod stablecoin supply is approximately `$814.9M` using this methodology
+- Stablecoin supply is tracked separately from STRATO TVL
+- If a different DefiLlama file path or stablecoin-specific adapter shape is preferred for STRATO, this asset set and methodology can be moved accordingly
+
+## Short Version
+
+## Summary
+
+- Add STRATO stablecoin coverage for `USDST`, `USDC`, and `USDT`
+- Exclude `sUSDS` and `syrupUSDC` from canonical stablecoin supply
+- Use the public read-only stablecoins endpoint as the reviewable source
+
+## Methodology
+
+Counts circulating USD-pegged stablecoin supply on STRATO for `USDST`, `USDC`, and `USDT`. Excludes yield-bearing wrappers such as `sUSDS` and `syrupUSDC`.
+
+## Data Source
+
+- `https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/stablecoins`
+- Public, read-only, unauthenticated

--- a/mercata/adapters/defillama/DefiLlamaTVLAdapterPR.md
+++ b/mercata/adapters/defillama/DefiLlamaTVLAdapterPR.md
@@ -1,0 +1,41 @@
+# DefiLlama TVL Adapter PR Body
+
+## Summary
+
+- Add a STRATO TVL adapter backed by a public read-only metrics endpoint
+- Count underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults
+- Exclude wallet balances, receipt/share tokens, protocol debt, and double counting across products
+
+## Methodology
+
+STRATO TVL counts the USD value of underlying assets currently locked in STRATO DeFi contracts, counted once at the underlying-asset level. Included buckets are CDP collateral, lending supplied assets, lending collateral, AMM/stable pool reserves, saveUSDST underlying, safety module underlying, and diversified vault underlying. Excluded items are user wallet balances, receipt/share tokens, protocol debt, and any double counting of the same underlying across products.
+
+## Data Source
+
+- Public TVL endpoint: `https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/tvl`
+- The endpoint is read-only and unauthenticated
+- The adapter uses the endpoint's raw asset balances and does not rely on the endpoint's precomputed USD totals
+
+## Notes
+
+- Stablecoin supply is tracked separately and is not included in this TVL adapter
+- Current prod endpoint output is approximately `$7.52M` TVL using this methodology
+- STRATO should be treated as its own chain for this adapter
+
+## Short Version
+
+## Summary
+
+- Add STRATO TVL adapter using the public read-only metrics endpoint
+- Count underlying assets locked in CDP, lending, pools, saveUSDST, safety module, and vaults
+- Exclude wallet balances, receipt/share tokens, protocol debt, and double counting
+
+## Methodology
+
+Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.
+
+## Data Source
+
+- `https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/tvl`
+- Public, read-only, unauthenticated
+- Adapter uses raw balances from the endpoint

--- a/mercata/adapters/defillama/draft-defillama-stablecoins-adapter.js
+++ b/mercata/adapters/defillama/draft-defillama-stablecoins-adapter.js
@@ -1,0 +1,42 @@
+const STABLECOINS_ENDPOINT = 'https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/stablecoins'
+const INCLUDED_SYMBOLS = ['USDST', 'USDC', 'USDT']
+const EXCLUDED_SYMBOLS = ['SUSDS', 'SYRUPUSDC']
+const METHODOLOGY = 'Counts circulating USD-pegged stablecoin supply on STRATO for USDST, USDC, and USDT. Excludes yield-bearing wrappers such as sUSDS and syrupUSDC.'
+
+// Provisional draft:
+// DefiLlama's stablecoin submission path is less clearly documented than the TVL
+// path. This file captures the endpoint fetch/filter logic that would back a
+// stablecoin integration, while the exact final export shape may still need to
+// be adjusted to match the repo path requested by DefiLlama reviewers.
+
+async function fetchStratoStablecoins() {
+  const response = await fetch(STABLECOINS_ENDPOINT)
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch STRATO stablecoins endpoint: ${response.status} ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  const assets = Array.isArray(data?.assets) ? data.assets : []
+
+  return assets
+    .filter((asset) => INCLUDED_SYMBOLS.includes(String(asset?.symbol || '').toUpperCase()))
+    .map((asset) => ({
+      address: asset.address,
+      name: asset.name,
+      symbol: asset.symbol,
+      decimals: asset.decimals,
+      totalSupply: asset.totalSupply,
+      priceUsd: asset.priceUsd,
+      totalUsd: asset.totalUsd,
+    }))
+}
+
+module.exports = {
+  chain: 'strato',
+  endpoint: STABLECOINS_ENDPOINT,
+  methodology: METHODOLOGY,
+  includedSymbols: INCLUDED_SYMBOLS,
+  excludedSymbols: EXCLUDED_SYMBOLS,
+  fetchStratoStablecoins,
+}

--- a/mercata/adapters/defillama/draft-defillama-tvl-adapter.js
+++ b/mercata/adapters/defillama/draft-defillama-tvl-adapter.js
@@ -1,0 +1,30 @@
+const TVL_ENDPOINT = 'https://YOUR_PUBLIC_STRATO_API_HOST/api/v1/metrics/tvl'
+const METHODOLOGY = 'Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.'
+
+// TODO: Replace with the actual STRATO launch timestamp/block expected by DefiLlama.
+const START = 0
+
+async function tvl(_, __, ___, { api }) {
+  const response = await fetch(TVL_ENDPOINT)
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch STRATO TVL endpoint: ${response.status} ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  const assets = Array.isArray(data?.assets) ? data.assets : []
+
+  for (const asset of assets) {
+    if (!asset?.address || asset.amount == null) continue
+    api.add(asset.address, asset.amount)
+  }
+}
+
+module.exports = {
+  methodology: METHODOLOGY,
+  start: START,
+  timetravel: false,
+  strato: {
+    tvl,
+  },
+}

--- a/mercata/backend/src/api/controllers/metrics.controller.ts
+++ b/mercata/backend/src/api/controllers/metrics.controller.ts
@@ -1,0 +1,38 @@
+import { Request, Response, NextFunction } from "express";
+import RestStatus from "http-status-codes";
+import {
+  getStablecoinMetrics,
+  getTvlMetrics,
+} from "../services/metrics.service";
+
+class MetricsController {
+  static async getTvl(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+      const metrics = await getTvlMetrics(accessToken);
+      res.status(RestStatus.OK).json(metrics);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getStablecoins(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+      const metrics = await getStablecoinMetrics(accessToken);
+      res.status(RestStatus.OK).json(metrics);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default MetricsController;

--- a/mercata/backend/src/api/routes.ts
+++ b/mercata/backend/src/api/routes.ts
@@ -26,6 +26,7 @@ import vaultRoutes from "./routes/vault.routes";
 import onrampRoutes from "./routes/onramp.routes";
 import metalForgeRoutes from "./routes/metalForge.routes";
 import earnRoutes from "./routes/earn.routes";
+import metricsRoutes from "./routes/metrics.routes";
 
 const router = Router();
 
@@ -106,6 +107,9 @@ router.use("/metal-forge", metalForgeRoutes);
 
 // ----- Earn Routes -----
 router.use("/earn", earnRoutes);
+
+// ----- Metrics Routes -----
+router.use("/v1/metrics", metricsRoutes);
 
 // ----- Documentation Routes -----
 // Serve static files for Swagger customizations

--- a/mercata/backend/src/api/routes/metrics.routes.ts
+++ b/mercata/backend/src/api/routes/metrics.routes.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import authHandler from "../middleware/authHandler";
+import MetricsController from "../controllers/metrics.controller";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /v1/metrics/tvl:
+ *   get:
+ *     summary: Get protocol TVL metrics
+ *     description: Retrieve the canonical STRATO TVL snapshot across DeFi-locked protocol balances
+ *     tags: [Metrics]
+ *     responses:
+ *       200:
+ *         description: TVL metrics payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties: true
+ */
+router.get("/tvl", authHandler.authorizeRequest(true), MetricsController.getTvl);
+
+/**
+ * @openapi
+ * /v1/metrics/stablecoins:
+ *   get:
+ *     summary: Get stablecoin supply metrics
+ *     description: Retrieve circulating stablecoin metrics for STRATO-recognized stable assets
+ *     tags: [Metrics]
+ *     responses:
+ *       200:
+ *         description: Stablecoin metrics payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties: true
+ */
+router.get("/stablecoins", authHandler.authorizeRequest(true), MetricsController.getStablecoins);
+
+export default router;

--- a/mercata/backend/src/api/services/metrics.service.ts
+++ b/mercata/backend/src/api/services/metrics.service.ts
@@ -1,0 +1,600 @@
+import { cirrus } from "../../utils/mercataApiHelper";
+import { constants } from "../../config/constants";
+import { getOraclePrices } from "./oracle.service";
+import { getCDPStats } from "./cdp.service";
+import { getPool, getPublicLiquidityInfo } from "./lending.service";
+import { getSaveUsdstInfo } from "./saveUsdst.service";
+import { getPublicSafetyModuleInfo, getSafetyModuleConfig } from "./safety.service";
+import { getVaultInfo } from "./vault.service";
+import { getPools } from "./swapping.service";
+import { getBridgeableTokens } from "./bridge.service";
+import {
+  buildTokenClassificationContext,
+  classifyToken,
+} from "./tokenClassification.service";
+
+const { Token, USDST, CollateralVault, LendingPool, PriceOracle } = constants;
+const WAD = 10n ** 18n;
+const METHODOLOGY_VERSION = "1";
+
+interface TokenRecord {
+  address: string;
+  _name?: string;
+  _symbol?: string;
+  _totalSupply?: string;
+  customDecimals?: number | string;
+}
+
+interface MetricBucketSummary {
+  totalUsd: string;
+}
+
+interface TvlAssetSummary {
+  address: string;
+  symbol: string;
+  decimals: number;
+  amount: string;
+  priceUsd: string;
+  totalUsd: string;
+}
+
+interface TvlPoolSummary {
+  address: string;
+  isStable: boolean;
+  totalUsd: string;
+  assets: TvlAssetSummary[];
+}
+
+interface TvlPositionSummary extends TvlAssetSummary {
+  sourceBucket: string;
+  sourceKey: string;
+}
+
+interface TvlMetrics {
+  timestamp: string;
+  methodologyVersion: string;
+  totalUsd: string;
+  assets: TvlAssetSummary[];
+  positions: TvlPositionSummary[];
+  breakdown: {
+    cdp: MetricBucketSummary & { assets: TvlAssetSummary[] };
+    lendingSupply: MetricBucketSummary & {
+      address: string;
+      symbol: string;
+      decimals: number;
+      amount: string;
+      priceUsd: string;
+    };
+    lendingCollateral: MetricBucketSummary & { assets: TvlAssetSummary[] };
+    pools: MetricBucketSummary & { pools: TvlPoolSummary[] };
+    saveUsdst: MetricBucketSummary & {
+      address: string;
+      symbol: string;
+      decimals: number;
+      amount: string;
+      priceUsd: string;
+    };
+    safetyModule: MetricBucketSummary & {
+      address: string;
+      symbol: string;
+      decimals: number;
+      amount: string;
+      priceUsd: string;
+    };
+    vaults: MetricBucketSummary & { assets: TvlAssetSummary[] };
+  };
+}
+
+interface StablecoinAssetSummary {
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  totalSupply: string;
+  priceUsd: string;
+  totalUsd: string;
+}
+
+interface StablecoinMetrics {
+  timestamp: string;
+  methodologyVersion: string;
+  totalUsd: string;
+  assets: StablecoinAssetSummary[];
+}
+
+const normalizeAddress = (value: string | undefined | null): string =>
+  (value || "").toLowerCase();
+
+const parseBigIntLike = (value: unknown): bigint => {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+  if (value === null || value === undefined) return 0n;
+
+  const raw = String(value).trim();
+  if (!raw) return 0n;
+  if (/^-?\d+$/.test(raw)) return BigInt(raw);
+  return 0n;
+};
+
+const pow10 = (decimals: number): bigint => 10n ** BigInt(decimals);
+
+const toDecimals = (value: number | string | undefined, fallback = 18): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "" && !Number.isNaN(Number(value))) {
+    return Number(value);
+  }
+  return fallback;
+};
+
+const mulDiv = (amount: string, priceUsd: string, scale: bigint): string => {
+  const amountBig = parseBigIntLike(amount);
+  const priceBig = parseBigIntLike(priceUsd);
+  if (amountBig === 0n || priceBig === 0n) return "0";
+  return ((amountBig * priceBig) / scale).toString();
+};
+
+const sumUsd = (values: string[]): string =>
+  values.reduce((sum, value) => sum + parseBigIntLike(value), 0n).toString();
+
+const getActiveTokens = async (accessToken: string): Promise<TokenRecord[]> => {
+  const response = await cirrus.get(accessToken, `/${Token}`, {
+    params: {
+      select: "address,_name,_symbol,_totalSupply::text,customDecimals",
+      status: "eq.2",
+      _totalSupply: "gt.0",
+    },
+  });
+
+  return (response.data || []) as TokenRecord[];
+};
+
+const buildTokenMap = (tokens: TokenRecord[]): Map<string, TokenRecord> =>
+  new Map(tokens.map((token) => [normalizeAddress(token.address), token]));
+
+const buildClassificationContext = async (
+  accessToken: string
+) => {
+  const [lendingInfo, saveInfo, pools, bridgeTokens] = await Promise.all([
+    getPublicLiquidityInfo(accessToken),
+    getSaveUsdstInfo(accessToken),
+    getPools(accessToken, undefined) as Promise<any[]>,
+    getBridgeableTokens(accessToken).catch(() => []),
+  ]);
+
+  let vaultInfo;
+  try {
+    vaultInfo = await getVaultInfo(accessToken);
+  } catch {
+    vaultInfo = { shareTokenAddress: "" };
+  }
+
+  const classificationContext = buildTokenClassificationContext({
+    lendingReceiptTokenAddresses: [lendingInfo?.withdrawable?.address],
+    safetyReceiptTokenAddresses: [getSafetyModuleConfig().sToken.address],
+    vaultShareTokenAddresses: [vaultInfo.shareTokenAddress],
+    lpTokenAddresses: (pools || []).map((pool: any) => pool.lpToken?.address).filter(Boolean),
+    receiptTokenSymbols: [saveInfo.shareSymbol],
+    bridgeStablecoinAddresses: (bridgeTokens || [])
+      .filter((token: any) => ["USDC", "USDT", "USDST"].includes((token.stratoTokenSymbol || "").toUpperCase()))
+      .map((token: any) => token.stratoToken),
+  });
+
+  return {
+    classificationContext,
+  };
+};
+
+const buildAssetSummary = (
+  tokenMap: Map<string, TokenRecord>,
+  params: {
+    address: string;
+    symbol?: string;
+    amount?: string;
+    priceUsd?: string;
+    totalUsd?: string;
+    fallbackDecimals?: number;
+  }
+): TvlAssetSummary => {
+  const normalizedAddress = normalizeAddress(params.address);
+  const token = tokenMap.get(normalizedAddress);
+  return {
+    address: params.address,
+    symbol: params.symbol || token?._symbol || params.address,
+    decimals: toDecimals(token?.customDecimals, params.fallbackDecimals ?? 18),
+    amount: params.amount || "0",
+    priceUsd: params.priceUsd || "0",
+    totalUsd: params.totalUsd || "0",
+  };
+};
+
+const aggregateAssets = (assets: TvlAssetSummary[]): TvlAssetSummary[] => {
+  const grouped = new Map<string, TvlAssetSummary>();
+
+  for (const asset of assets) {
+    const key = normalizeAddress(asset.address);
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { ...asset });
+      continue;
+    }
+
+    existing.amount = (parseBigIntLike(existing.amount) + parseBigIntLike(asset.amount)).toString();
+    existing.totalUsd = (parseBigIntLike(existing.totalUsd) + parseBigIntLike(asset.totalUsd)).toString();
+    if (existing.priceUsd === "0" && asset.priceUsd !== "0") {
+      existing.priceUsd = asset.priceUsd;
+    }
+  }
+
+  return Array.from(grouped.values()).sort((left, right) => {
+    const leftUsd = parseBigIntLike(left.totalUsd);
+    const rightUsd = parseBigIntLike(right.totalUsd);
+    if (leftUsd === rightUsd) return left.symbol.localeCompare(right.symbol);
+    return rightUsd > leftUsd ? 1 : -1;
+  });
+};
+
+const buildPositions = (entries: Array<{ sourceBucket: string; sourceKey: string; asset: TvlAssetSummary }>): TvlPositionSummary[] =>
+  entries.map(({ sourceBucket, sourceKey, asset }) => ({
+    ...asset,
+    sourceBucket,
+    sourceKey,
+  }));
+
+const getLendingCollateralAssets = async (
+  accessToken: string,
+  tokenMap: Map<string, TokenRecord>
+): Promise<TvlAssetSummary[]> => {
+  const registry = await getPool(accessToken, {
+    select:
+      `lendingPool:lendingPool_fkey(` +
+        `borrowableAsset,assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value)` +
+      `),` +
+      `collateralVault:collateralVault_fkey(address),` +
+      `oracle:priceOracle_fkey(prices:${PriceOracle}-prices(asset:key,price:value::text))`,
+  });
+
+  const collateralVaultAddress = registry.collateralVault?.address;
+  if (!collateralVaultAddress) return [];
+
+  const borrowableAsset = normalizeAddress(registry.lendingPool?.borrowableAsset);
+  const assetConfigMap = new Map<string, any>();
+  (registry.lendingPool?.assetConfigs || []).forEach((config: any) => {
+    assetConfigMap.set(normalizeAddress(config.asset), config.AssetConfig || {});
+  });
+
+  const priceMap = new Map<string, string>();
+  (registry.oracle?.prices || []).forEach((price: any) => {
+    priceMap.set(normalizeAddress(price.asset), price.price || "0");
+  });
+
+  const response = await cirrus.get(accessToken, `/${CollateralVault}-userCollaterals`, {
+    params: {
+      address: `eq.${collateralVaultAddress}`,
+      select: "asset:key2,amount:value::text",
+      value: "gt.0",
+    },
+  });
+
+  const totals = new Map<string, bigint>();
+  for (const entry of response.data || []) {
+    const asset = normalizeAddress(entry.asset);
+    if (!asset || asset === borrowableAsset) continue;
+    totals.set(asset, (totals.get(asset) || 0n) + parseBigIntLike(entry.amount));
+  }
+
+  return Array.from(totals.entries()).map(([address, amount]) => {
+    const token = tokenMap.get(address);
+    const config = assetConfigMap.get(address);
+    const unitScale = parseBigIntLike(config?.unitScale || pow10(toDecimals(token?.customDecimals, 18)).toString());
+    const priceUsd = priceMap.get(address) || "0";
+    const totalUsd = mulDiv(amount.toString(), priceUsd, unitScale);
+    return buildAssetSummary(tokenMap, {
+      address,
+      symbol: token?._symbol,
+      amount: amount.toString(),
+      priceUsd,
+      totalUsd,
+      fallbackDecimals: toDecimals(token?.customDecimals, 18),
+    });
+  });
+};
+
+export const getTvlMetrics = async (accessToken: string): Promise<TvlMetrics> => {
+  const [priceMap, tokens, cdpStats, safetyInfo] = await Promise.all([
+    getOraclePrices(accessToken),
+    getActiveTokens(accessToken),
+    getCDPStats(accessToken, ""),
+    getPublicSafetyModuleInfo(accessToken),
+  ]);
+
+  const tokenMap = buildTokenMap(tokens);
+  const {
+    lendingInfo,
+    saveInfo,
+    pools,
+  } = await Promise.all([
+    getPublicLiquidityInfo(accessToken),
+    getSaveUsdstInfo(accessToken),
+    getPools(accessToken, undefined) as Promise<any[]>,
+  ]).then(([lendingInfo, saveInfo, pools]) => ({
+    lendingInfo,
+    saveInfo,
+    pools,
+  }));
+
+  let vaultInfo;
+  try {
+    vaultInfo = await getVaultInfo(accessToken);
+  } catch {
+    vaultInfo = {
+      totalEquity: "0",
+      assets: [],
+      shareTokenAddress: "",
+    };
+  }
+
+  const lendingCollateralAssets = await getLendingCollateralAssets(accessToken, tokenMap);
+
+  const cdpAssets: TvlAssetSummary[] = (cdpStats.assets || []).map((asset) =>
+    buildAssetSummary(tokenMap, {
+      address: asset.asset,
+      symbol: asset.symbol,
+      amount: asset.totalCollateral,
+      priceUsd: priceMap.get(asset.asset) || "0",
+      totalUsd: asset.collateralValueUSD,
+    })
+  );
+
+  const lendingSupplyAddress = lendingInfo?.supplyable?.address || USDST;
+  const lendingSupplyToken = tokenMap.get(normalizeAddress(lendingSupplyAddress));
+  const lendingSupplyDecimals = toDecimals(lendingSupplyToken?.customDecimals, 18);
+  const lendingSupplySymbol = lendingInfo?.supplyable?._symbol || lendingSupplyToken?._symbol || "USDST";
+  const lendingSupplyPrice = lendingInfo?.supplyable?.price || priceMap.get(lendingSupplyAddress) || WAD.toString();
+  const lendingSupplyUsd = mulDiv(
+    lendingInfo?.totalUSDSTSupplied || "0",
+    lendingSupplyPrice,
+    pow10(lendingSupplyDecimals)
+  );
+
+  const poolSummaries: TvlPoolSummary[] = (pools || []).map((pool: any) => {
+    const poolAssets: TvlAssetSummary[] = pool.coins?.length
+      ? pool.coins.map((coin: any) =>
+          buildAssetSummary(tokenMap, {
+            address: coin.address,
+            symbol: coin._symbol,
+            amount: coin.poolBalance,
+            priceUsd: coin.price,
+            totalUsd: mulDiv(
+              coin.poolBalance || "0",
+              coin.price || "0",
+              pow10(toDecimals(coin.customDecimals, 18))
+            ),
+            fallbackDecimals: toDecimals(coin.customDecimals, 18),
+          })
+        )
+      : [
+          buildAssetSummary(tokenMap, {
+            address: pool.tokenA.address,
+            symbol: pool.tokenA._symbol,
+            amount: pool.tokenA.poolBalance,
+            priceUsd: pool.tokenA.price,
+            totalUsd: mulDiv(
+              pool.tokenA.poolBalance || "0",
+              pool.tokenA.price || "0",
+              pow10(toDecimals(pool.tokenA.customDecimals, 18))
+            ),
+            fallbackDecimals: toDecimals(pool.tokenA.customDecimals, 18),
+          }),
+          buildAssetSummary(tokenMap, {
+            address: pool.tokenB.address,
+            symbol: pool.tokenB._symbol,
+            amount: pool.tokenB.poolBalance,
+            priceUsd: pool.tokenB.price,
+            totalUsd: mulDiv(
+              pool.tokenB.poolBalance || "0",
+              pool.tokenB.price || "0",
+              pow10(toDecimals(pool.tokenB.customDecimals, 18))
+            ),
+            fallbackDecimals: toDecimals(pool.tokenB.customDecimals, 18),
+          }),
+        ];
+
+    return {
+      address: pool.address,
+      isStable: Boolean(pool.isStable),
+      totalUsd: pool.totalLiquidityUSD || "0",
+      assets: poolAssets,
+    };
+  });
+  const poolsTotalUsd = sumUsd(poolSummaries.map((pool) => pool.totalUsd));
+
+  const saveAssetToken = tokenMap.get(normalizeAddress(saveInfo.assetAddress));
+  const savePrice = priceMap.get(saveInfo.assetAddress) || WAD.toString();
+  const saveAmount = saveInfo.pricingAssets || saveInfo.totalAssets || "0";
+  const saveDecimals = toDecimals(saveAssetToken?.customDecimals, 18);
+  const saveUsd = mulDiv(saveAmount, savePrice, pow10(saveDecimals));
+
+  const safetyConfig = getSafetyModuleConfig();
+  const safetyAssetAddress = safetyConfig.asset.address || USDST;
+  const safetyAssetToken = tokenMap.get(normalizeAddress(safetyAssetAddress));
+  const safetyPrice = priceMap.get(safetyAssetAddress) || WAD.toString();
+  const safetyDecimals = toDecimals(safetyAssetToken?.customDecimals, 18);
+  const safetyUsd = mulDiv(
+    safetyInfo.totalAssets || "0",
+    safetyPrice,
+    pow10(safetyDecimals)
+  );
+
+  const vaultAssets: TvlAssetSummary[] = (vaultInfo.assets || []).map((asset: any) =>
+    buildAssetSummary(tokenMap, {
+      address: asset.address,
+      symbol: asset.symbol,
+      amount: asset.balance,
+      priceUsd: asset.priceUsd,
+      totalUsd: asset.valueUsd,
+      fallbackDecimals: toDecimals(tokenMap.get(normalizeAddress(asset.address))?.customDecimals, 18),
+    })
+  );
+  const vaultTotalUsd = vaultInfo.totalEquity || "0";
+
+  const allPositions = buildPositions([
+    ...cdpAssets.map((asset) => ({ sourceBucket: "cdp", sourceKey: asset.address, asset })),
+    {
+      sourceBucket: "lendingSupply",
+      sourceKey: lendingSupplyAddress,
+      asset: buildAssetSummary(tokenMap, {
+        address: lendingSupplyAddress,
+        symbol: lendingSupplySymbol,
+        amount: lendingInfo.totalUSDSTSupplied || "0",
+        priceUsd: lendingSupplyPrice,
+        totalUsd: lendingSupplyUsd,
+        fallbackDecimals: lendingSupplyDecimals,
+      }),
+    },
+    ...lendingCollateralAssets.map((asset) => ({ sourceBucket: "lendingCollateral", sourceKey: asset.address, asset })),
+    ...poolSummaries.flatMap((pool) =>
+      pool.assets.map((asset) => ({
+        sourceBucket: "pools",
+        sourceKey: `${pool.address}:${asset.address}`,
+        asset,
+      }))
+    ),
+    {
+      sourceBucket: "saveUsdst",
+      sourceKey: saveInfo.assetAddress || USDST,
+      asset: buildAssetSummary(tokenMap, {
+        address: saveInfo.assetAddress || USDST,
+        symbol: saveInfo.assetSymbol || "USDST",
+        amount: saveAmount,
+        priceUsd: savePrice,
+        totalUsd: saveUsd,
+        fallbackDecimals: saveDecimals,
+      }),
+    },
+    {
+      sourceBucket: "safetyModule",
+      sourceKey: safetyAssetAddress,
+      asset: buildAssetSummary(tokenMap, {
+        address: safetyAssetAddress,
+        symbol: safetyAssetToken?._symbol || "USDST",
+        amount: safetyInfo.totalAssets || "0",
+        priceUsd: safetyPrice,
+        totalUsd: safetyUsd,
+        fallbackDecimals: safetyDecimals,
+      }),
+    },
+    ...vaultAssets.map((asset) => ({ sourceBucket: "vaults", sourceKey: asset.address, asset })),
+  ]);
+  const aggregatedAssets = aggregateAssets(allPositions.map((position) => ({
+    address: position.address,
+    symbol: position.symbol,
+    decimals: position.decimals,
+    amount: position.amount,
+    priceUsd: position.priceUsd,
+    totalUsd: position.totalUsd,
+  })));
+
+  const totalUsd = sumUsd([
+    cdpStats.totalCollateralValueUSD || "0",
+    lendingSupplyUsd,
+    sumUsd(lendingCollateralAssets.map((asset) => asset.totalUsd)),
+    poolsTotalUsd,
+    saveUsd,
+    safetyUsd,
+    vaultTotalUsd,
+  ]);
+
+  return {
+    timestamp: new Date().toISOString(),
+    methodologyVersion: METHODOLOGY_VERSION,
+    totalUsd,
+    assets: aggregatedAssets,
+    positions: allPositions,
+    breakdown: {
+      cdp: {
+        totalUsd: cdpStats.totalCollateralValueUSD || "0",
+        assets: cdpAssets,
+      },
+      lendingSupply: {
+        totalUsd: lendingSupplyUsd,
+        address: lendingSupplyAddress,
+        symbol: lendingSupplySymbol,
+        decimals: lendingSupplyDecimals,
+        amount: lendingInfo.totalUSDSTSupplied || "0",
+        priceUsd: lendingSupplyPrice,
+      },
+      lendingCollateral: {
+        totalUsd: sumUsd(lendingCollateralAssets.map((asset) => asset.totalUsd)),
+        assets: lendingCollateralAssets,
+      },
+      pools: {
+        totalUsd: poolsTotalUsd,
+        pools: poolSummaries,
+      },
+      saveUsdst: {
+        totalUsd: saveUsd,
+        address: saveInfo.assetAddress || USDST,
+        symbol: saveInfo.assetSymbol || "USDST",
+        decimals: saveDecimals,
+        amount: saveAmount,
+        priceUsd: savePrice,
+      },
+      safetyModule: {
+        totalUsd: safetyUsd,
+        address: safetyAssetAddress,
+        symbol: safetyAssetToken?._symbol || "USDST",
+        decimals: safetyDecimals,
+        amount: safetyInfo.totalAssets || "0",
+        priceUsd: safetyPrice,
+      },
+      vaults: {
+        totalUsd: vaultTotalUsd,
+        assets: vaultAssets,
+      },
+    },
+  };
+};
+
+export const getStablecoinMetrics = async (accessToken: string): Promise<StablecoinMetrics> => {
+  const [tokens, priceMap] = await Promise.all([
+    getActiveTokens(accessToken),
+    getOraclePrices(accessToken),
+  ]);
+  const { classificationContext } = await buildClassificationContext(accessToken);
+
+  const assets: StablecoinAssetSummary[] = tokens
+    .map((token) => ({
+      token,
+      classification: classifyToken(token, classificationContext),
+    }))
+    .filter(({ classification }) => classification.classification.includeInStablecoinSupply)
+    .map(({ token, classification }) => {
+      const decimals = toDecimals(token.customDecimals, 18);
+      const priceUsd = priceMap.get(token.address) || WAD.toString();
+      const totalSupply = token._totalSupply || "0";
+      const totalUsd = mulDiv(totalSupply, priceUsd, pow10(decimals));
+
+      return {
+        address: token.address,
+        name: token._name || token._symbol || token.address,
+        symbol: token._symbol || "UNKNOWN",
+        decimals,
+        totalSupply,
+        priceUsd,
+        totalUsd,
+      };
+    })
+    .sort((left, right) => {
+      const leftUsd = parseBigIntLike(left.totalUsd);
+      const rightUsd = parseBigIntLike(right.totalUsd);
+      if (leftUsd === rightUsd) return left.symbol.localeCompare(right.symbol);
+      return rightUsd > leftUsd ? 1 : -1;
+    });
+
+  return {
+    timestamp: new Date().toISOString(),
+    methodologyVersion: METHODOLOGY_VERSION,
+    totalUsd: sumUsd(assets.map((asset) => asset.totalUsd)),
+    assets,
+  };
+};

--- a/mercata/backend/src/api/services/tokenClassification.service.ts
+++ b/mercata/backend/src/api/services/tokenClassification.service.ts
@@ -1,0 +1,290 @@
+import {
+  ExplicitTokenClassification,
+  getBaseExplicitClassifications,
+  getConfiguredMetalAddresses,
+  getConfiguredMetalSymbols,
+  getConfiguredStablecoinAddresses,
+  getConfiguredStablecoinSymbols,
+  normalizeClassificationAddress,
+  TokenClassificationContext,
+  TokenClassificationResult,
+} from "../../config/tokenClassification";
+
+interface ClassifiableToken {
+  address: string;
+  _symbol?: string;
+}
+
+interface ClassificationContextParams {
+  lpTokenAddresses?: Iterable<string>;
+  lendingReceiptTokenAddresses?: Iterable<string>;
+  safetyReceiptTokenAddresses?: Iterable<string>;
+  vaultShareTokenAddresses?: Iterable<string>;
+  receiptTokenSymbols?: Iterable<string>;
+  bridgeStablecoinAddresses?: Iterable<string>;
+  explicitByAddress?: Map<string, ExplicitTokenClassification>;
+}
+
+const createResult = (
+  classification: TokenClassificationResult["classification"],
+  source: TokenClassificationResult["source"],
+  confidence: TokenClassificationResult["confidence"]
+): TokenClassificationResult => ({
+  classification,
+  source,
+  confidence,
+});
+
+export const buildTokenClassificationContext = (
+  params: ClassificationContextParams = {}
+): TokenClassificationContext => {
+  const explicitByAddress = new Map<string, ExplicitTokenClassification>(getBaseExplicitClassifications());
+  params.explicitByAddress?.forEach((value, key) => {
+    explicitByAddress.set(normalizeClassificationAddress(key), value);
+  });
+
+  const stablecoinAddresses = new Set<string>([
+    ...getConfiguredStablecoinAddresses(),
+    ...Array.from(explicitByAddress.entries())
+      .filter(([, value]) => value.classification.includeInStablecoinSupply)
+      .map(([key]) => key),
+  ]);
+
+  const metalAddresses = new Set<string>(getConfiguredMetalAddresses());
+  const lpTokenAddresses = new Set<string>(
+    Array.from(params.lpTokenAddresses || [], (address) => normalizeClassificationAddress(address)).filter(Boolean)
+  );
+  const lendingReceiptTokenAddresses = new Set<string>(
+    Array.from(params.lendingReceiptTokenAddresses || [], (address) => normalizeClassificationAddress(address)).filter(Boolean)
+  );
+  const safetyReceiptTokenAddresses = new Set<string>(
+    Array.from(params.safetyReceiptTokenAddresses || [], (address) => normalizeClassificationAddress(address)).filter(Boolean)
+  );
+  const vaultShareTokenAddresses = new Set<string>(
+    Array.from(params.vaultShareTokenAddresses || [], (address) => normalizeClassificationAddress(address)).filter(Boolean)
+  );
+  const receiptTokenSymbols = new Set<string>(
+    Array.from(params.receiptTokenSymbols || [], (symbol) => (symbol || "").trim().toUpperCase())
+      .filter(Boolean)
+  );
+  const bridgeStablecoinAddresses = new Set<string>(
+    Array.from(params.bridgeStablecoinAddresses || [], (address) => normalizeClassificationAddress(address))
+      .filter(Boolean)
+  );
+
+  return {
+    explicitByAddress,
+    stablecoinAddresses,
+    metalAddresses,
+    stablecoinSymbols: getConfiguredStablecoinSymbols(),
+    metalSymbols: getConfiguredMetalSymbols(),
+    lpTokenAddresses,
+    lendingReceiptTokenAddresses,
+    safetyReceiptTokenAddresses,
+    vaultShareTokenAddresses,
+    receiptTokenSymbols,
+    bridgeStablecoinAddresses,
+  };
+};
+
+export const classifyToken = (
+  token: ClassifiableToken,
+  context: TokenClassificationContext
+): TokenClassificationResult => {
+  const address = normalizeClassificationAddress(token.address);
+  const symbol = (token._symbol || "").trim().toUpperCase();
+
+  const explicit = context.explicitByAddress.get(address);
+  if (explicit) {
+    return {
+      classification: explicit.classification,
+      source: explicit.source,
+      confidence: explicit.confidence,
+    };
+  }
+
+  if (context.lpTokenAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "lp_token",
+        economicRole: "receipt",
+        issuanceOrigin: "protocol_minted",
+        isStablecoin: false,
+        isMetal: false,
+        isReceiptToken: true,
+        includeInTvlUnderlying: false,
+        includeInStablecoinSupply: false,
+      },
+      "protocol_inference",
+      "high"
+    );
+  }
+
+  if (context.lendingReceiptTokenAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "lending_receipt",
+        economicRole: "receipt",
+        issuanceOrigin: "protocol_minted",
+        isStablecoin: false,
+        isMetal: false,
+        isReceiptToken: true,
+        includeInTvlUnderlying: false,
+        includeInStablecoinSupply: false,
+      },
+      "protocol_inference",
+      "high"
+    );
+  }
+
+  if (context.safetyReceiptTokenAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "safety_receipt",
+        economicRole: "receipt",
+        issuanceOrigin: "protocol_minted",
+        isStablecoin: false,
+        isMetal: false,
+        isReceiptToken: true,
+        includeInTvlUnderlying: false,
+        includeInStablecoinSupply: false,
+      },
+      "protocol_inference",
+      "high"
+    );
+  }
+
+  if (context.vaultShareTokenAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "vault_share",
+        economicRole: "receipt",
+        issuanceOrigin: "protocol_minted",
+        isStablecoin: false,
+        isMetal: false,
+        isReceiptToken: true,
+        includeInTvlUnderlying: false,
+        includeInStablecoinSupply: false,
+      },
+      "protocol_inference",
+      "high"
+    );
+  }
+
+  if (context.receiptTokenSymbols.has(symbol)) {
+    return createResult(
+      {
+        assetClass: "vault_share",
+        economicRole: "receipt",
+        issuanceOrigin: "protocol_minted",
+        isStablecoin: false,
+        isMetal: false,
+        isReceiptToken: true,
+        includeInTvlUnderlying: false,
+        includeInStablecoinSupply: false,
+      },
+      "protocol_inference",
+      "medium"
+    );
+  }
+
+  if (context.stablecoinAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "stablecoin",
+        economicRole: "underlying",
+        issuanceOrigin: "native",
+        isStablecoin: true,
+        isMetal: false,
+        isReceiptToken: false,
+        includeInTvlUnderlying: true,
+        includeInStablecoinSupply: true,
+      },
+      "registry_override",
+      "high"
+    );
+  }
+
+  if (context.bridgeStablecoinAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "stablecoin",
+        economicRole: "bridged_representation",
+        issuanceOrigin: "bridged",
+        isStablecoin: true,
+        isMetal: false,
+        isReceiptToken: false,
+        includeInTvlUnderlying: true,
+        includeInStablecoinSupply: true,
+      },
+      "bridge_route_inference",
+      "medium"
+    );
+  }
+
+  if (context.metalAddresses.has(address)) {
+    return createResult(
+      {
+        assetClass: "metal",
+        economicRole: "underlying",
+        issuanceOrigin: "native",
+        isStablecoin: false,
+        isMetal: true,
+        isReceiptToken: false,
+        includeInTvlUnderlying: true,
+        includeInStablecoinSupply: false,
+      },
+      "registry_override",
+      "high"
+    );
+  }
+
+  if (context.stablecoinSymbols.has(symbol)) {
+    return createResult(
+      {
+        assetClass: "stablecoin",
+        economicRole: "underlying",
+        issuanceOrigin: "unknown",
+        isStablecoin: true,
+        isMetal: false,
+        isReceiptToken: false,
+        includeInTvlUnderlying: true,
+        includeInStablecoinSupply: true,
+      },
+      "symbol_heuristic",
+      "low"
+    );
+  }
+
+  if (context.metalSymbols.has(symbol)) {
+    return createResult(
+      {
+        assetClass: "metal",
+        economicRole: "underlying",
+        issuanceOrigin: "unknown",
+        isStablecoin: false,
+        isMetal: true,
+        isReceiptToken: false,
+        includeInTvlUnderlying: true,
+        includeInStablecoinSupply: false,
+      },
+      "symbol_heuristic",
+      "low"
+    );
+  }
+
+  return createResult(
+    {
+      assetClass: "other",
+      economicRole: "underlying",
+      issuanceOrigin: "unknown",
+      isStablecoin: false,
+      isMetal: false,
+      isReceiptToken: false,
+      includeInTvlUnderlying: true,
+      includeInStablecoinSupply: false,
+    },
+    "default",
+    "low"
+  );
+};

--- a/mercata/backend/src/config/tokenClassification.ts
+++ b/mercata/backend/src/config/tokenClassification.ts
@@ -1,0 +1,111 @@
+import {
+  CANONICAL_METAL_SYMBOLS,
+  CANONICAL_STABLECOIN_SYMBOLS,
+  getCanonicalTokenRegistry,
+} from "./tokenRegistry";
+
+export type TokenAssetClass =
+  | "stablecoin"
+  | "metal"
+  | "crypto"
+  | "lp_token"
+  | "vault_share"
+  | "lending_receipt"
+  | "safety_receipt"
+  | "voucher"
+  | "other";
+
+export type TokenEconomicRole =
+  | "underlying"
+  | "receipt"
+  | "reward"
+  | "synthetic"
+  | "bridged_representation"
+  | "other";
+
+export type TokenIssuanceOrigin =
+  | "native"
+  | "bridged"
+  | "wrapped"
+  | "protocol_minted"
+  | "unknown";
+
+export type TokenClassificationSource =
+  | "registry_override"
+  | "protocol_inference"
+  | "bridge_route_inference"
+  | "symbol_heuristic"
+  | "default";
+
+export type TokenClassificationConfidence = "high" | "medium" | "low";
+
+export interface TokenClassification {
+  assetClass: TokenAssetClass;
+  economicRole: TokenEconomicRole;
+  issuanceOrigin: TokenIssuanceOrigin;
+  isStablecoin: boolean;
+  isMetal: boolean;
+  isReceiptToken: boolean;
+  includeInTvlUnderlying: boolean;
+  includeInStablecoinSupply: boolean;
+}
+
+export interface TokenClassificationResult {
+  classification: TokenClassification;
+  confidence: TokenClassificationConfidence;
+  source: TokenClassificationSource;
+}
+
+export interface ExplicitTokenClassification extends TokenClassificationResult {
+  canonicalSymbol?: string;
+}
+
+export interface TokenClassificationContext {
+  explicitByAddress: Map<string, ExplicitTokenClassification>;
+  stablecoinAddresses: Set<string>;
+  metalAddresses: Set<string>;
+  stablecoinSymbols: Set<string>;
+  metalSymbols: Set<string>;
+  lpTokenAddresses: Set<string>;
+  lendingReceiptTokenAddresses: Set<string>;
+  safetyReceiptTokenAddresses: Set<string>;
+  vaultShareTokenAddresses: Set<string>;
+  receiptTokenSymbols: Set<string>;
+  bridgeStablecoinAddresses: Set<string>;
+}
+
+export const normalizeClassificationAddress = (value: string | undefined | null): string =>
+  (value || "").toLowerCase().replace(/^0x/, "");
+
+export const parseAddressSet = (value: string | undefined): Set<string> =>
+  new Set(
+    (value || "")
+      .split(",")
+      .map((entry) => normalizeClassificationAddress(entry.trim()))
+      .filter(Boolean)
+  );
+
+export const parseSymbolSet = (value: string | undefined, defaults: string[]): Set<string> => {
+  const symbols = (value || "")
+    .split(",")
+    .map((entry) => entry.trim().toUpperCase())
+    .filter(Boolean);
+
+  return new Set(symbols.length > 0 ? symbols : defaults);
+};
+
+export const getBaseExplicitClassifications = (): Map<string, ExplicitTokenClassification> => {
+  return getCanonicalTokenRegistry();
+};
+
+export const getConfiguredStablecoinAddresses = (): Set<string> =>
+  parseAddressSet(process.env.STABLECOIN_TOKEN_ADDRESSES);
+
+export const getConfiguredMetalAddresses = (): Set<string> =>
+  parseAddressSet(process.env.METAL_TOKEN_ADDRESSES);
+
+export const getConfiguredStablecoinSymbols = (): Set<string> =>
+  parseSymbolSet(process.env.STABLECOIN_SYMBOLS, [...CANONICAL_STABLECOIN_SYMBOLS]);
+
+export const getConfiguredMetalSymbols = (): Set<string> =>
+  parseSymbolSet(process.env.METAL_SYMBOLS, [...CANONICAL_METAL_SYMBOLS]);

--- a/mercata/backend/src/config/tokenRegistry.ts
+++ b/mercata/backend/src/config/tokenRegistry.ts
@@ -1,0 +1,441 @@
+import { constants } from "./constants";
+import * as config from "./config";
+import type { ExplicitTokenClassification } from "./tokenClassification";
+
+const normalizeRegistryAddress = (value: string | undefined | null): string =>
+  (value || "").toLowerCase().replace(/^0x/, "");
+
+const createExplicit = (
+  entry: ExplicitTokenClassification
+): ExplicitTokenClassification => entry;
+
+interface CanonicalTokenRegistryEntry {
+  addresses: Array<string | undefined | null>;
+  entry: ExplicitTokenClassification;
+}
+
+const registerCanonicalEntry = (
+  registry: Map<string, ExplicitTokenClassification>,
+  definition: CanonicalTokenRegistryEntry
+) => {
+  for (const address of definition.addresses) {
+    const normalizedAddress = normalizeRegistryAddress(address);
+    if (!normalizedAddress) continue;
+    registry.set(normalizedAddress, createExplicit(definition.entry));
+  }
+};
+
+export const CANONICAL_STABLECOIN_SYMBOLS = ["USDST", "USDC", "USDT"] as const;
+export const CANONICAL_METAL_SYMBOLS = ["GOLD", "SILV", "PAXG", "XAUT", "XAUTST", "GOLDST", "SILVST"] as const;
+
+export const getCanonicalTokenRegistry = (): Map<string, ExplicitTokenClassification> => {
+  const registry = new Map<string, ExplicitTokenClassification>();
+
+  // This registry is intentionally limited to protocol-canonical assets and known
+  // protocol-issued receipt/reward tokens. It is not a full inventory of every
+  // token that may appear in BlockApps-Token on a given network.
+  const canonicalEntries: CanonicalTokenRegistryEntry[] = [
+    {
+      addresses: [constants.USDST],
+      entry: {
+        classification: {
+          assetClass: "stablecoin",
+          economicRole: "underlying",
+          issuanceOrigin: "native",
+          isStablecoin: true,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: true,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "USDST",
+      },
+    },
+    {
+      addresses: ["6aeacaa19c68e53035bf495d15e0a328fc600ba8"],
+      entry: {
+        classification: {
+          assetClass: "stablecoin",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: true,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: true,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "USDC",
+      },
+    },
+    {
+      addresses: ["5ed0bdfb378ac0d06249d70759536d7a41906216"],
+      entry: {
+        classification: {
+          assetClass: "stablecoin",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: true,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: true,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "USDT",
+      },
+    },
+    {
+      addresses: ["93fb7295859b2d70199e0a4883b7c320cf874e6c"],
+      entry: {
+        classification: {
+          assetClass: "crypto",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "ETH",
+      },
+    },
+    {
+      addresses: ["7a99b5ba11ac280cdd5caf52c12fe89fb1b8d2f9"],
+      entry: {
+        classification: {
+          assetClass: "crypto",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "WBTC",
+      },
+    },
+    {
+      addresses: ["f2aa370405030a434ae07e7826178325c675e925"],
+      entry: {
+        classification: {
+          assetClass: "crypto",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "WSTETH",
+      },
+    },
+    {
+      addresses: ["2e4789eb7db143576da25990a3c0298917a8a87d"],
+      entry: {
+        classification: {
+          assetClass: "crypto",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "RETH",
+      },
+    },
+    {
+      addresses: ["491cdfe98470bfe69b662ab368826dca0fc2f24d"],
+      entry: {
+        classification: {
+          assetClass: "metal",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: true,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "PAXG",
+      },
+    },
+    {
+      addresses: ["6e2d93d323edf1b3cc4672a909681b6a430cae64"],
+      entry: {
+        classification: {
+          assetClass: "stablecoin",
+          economicRole: "underlying",
+          issuanceOrigin: "wrapped",
+          isStablecoin: true,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "SUSDS",
+      },
+    },
+    {
+      addresses: ["c6c3e9881665d53ae8c222e24ca7a8d069aa56ca"],
+      entry: {
+        classification: {
+          assetClass: "stablecoin",
+          economicRole: "underlying",
+          issuanceOrigin: "wrapped",
+          isStablecoin: true,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "SYRUPUSDC",
+      },
+    },
+    {
+      addresses: ["f147e193fd1a629aa75aedd4758444ec0c969ca8"],
+      entry: {
+        classification: {
+          assetClass: "other",
+          economicRole: "underlying",
+          issuanceOrigin: "wrapped",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "WTSLAX",
+      },
+    },
+    {
+      addresses: ["1ac696799624c75050b10b7ee3e6fcf6f1f39aa1"],
+      entry: {
+        classification: {
+          assetClass: "other",
+          economicRole: "underlying",
+          issuanceOrigin: "wrapped",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "WSPYX",
+      },
+    },
+    {
+      addresses: ["cdc93d30182125e05eec985b631c7c61b3f63ff0"],
+      entry: {
+        classification: {
+          assetClass: "metal",
+          economicRole: "underlying",
+          issuanceOrigin: "native",
+          isStablecoin: false,
+          isMetal: true,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "GOLDST",
+      },
+    },
+    {
+      addresses: ["2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94"],
+      entry: {
+        classification: {
+          assetClass: "metal",
+          economicRole: "underlying",
+          issuanceOrigin: "native",
+          isStablecoin: false,
+          isMetal: true,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "SILVST",
+      },
+    },
+    {
+      addresses: ["47de839c03a3b014c0cc4f3b9352979a5038f910"],
+      entry: {
+        classification: {
+          assetClass: "metal",
+          economicRole: "bridged_representation",
+          issuanceOrigin: "bridged",
+          isStablecoin: false,
+          isMetal: true,
+          isReceiptToken: false,
+          includeInTvlUnderlying: true,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "XAUT",
+      },
+    },
+    {
+      addresses: ["000000000000000000000000000000000000100f"],
+      entry: {
+        classification: {
+          assetClass: "lending_receipt",
+          economicRole: "receipt",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: true,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "LENDUSDST",
+      },
+    },
+    {
+      addresses: ["2d436fce87f609a4d15f7ccb7cbbfaa8ffd143b3"],
+      entry: {
+        classification: {
+          assetClass: "vault_share",
+          economicRole: "receipt",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: true,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "SLP",
+      },
+    },
+    {
+      addresses: ["2680dc6693021cd3fefb84351570874fbef8332a"],
+      entry: {
+        classification: {
+          assetClass: "other",
+          economicRole: "reward",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "CATA",
+      },
+    },
+    {
+      addresses: [
+        "0000000000000000000000000000000000001018",
+        "000000000000000000000000000000000000101a",
+        "000000000000000000000000000000000000101c",
+        "000000000000000000000000000000000000101e",
+        "1141c2f2f20aaf3ee0eff67157ec9327a396ae47",
+        "69010124cdaa64286f6e413267a7001ea9379df4",
+        "07d7350ce8f9f809b2264da7728b22e2c0b438af",
+        "96c26f8306a0097d985d1654b4596c48bb6277c4",
+        "af543d9086416b048564fa165f9587aa565cce2f",
+        "ac621a150f49198036f84ffe90b4f2286b623583",
+        "2e99b16c78474c437c7003c814ca79a3ba50e5d8",
+        "488265afc86c2979c72900db087d421954c3ec4b",
+        "d18a739fc9daa5ff19d2083b1f9b20823133b0cb",
+        "a049efb1a3417801b3dd3877dd566aa24b95b3a0",
+        "f84425db11cf977dfcaace0431a080e0ff2604ca",
+        "aad3b82eb22fa76b8cd7a4f937de1263557c9956",
+      ],
+      entry: {
+        classification: {
+          assetClass: "lp_token",
+          economicRole: "receipt",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: true,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "LP_TOKEN",
+      },
+    },
+    {
+      addresses: [constants.voucher],
+      entry: {
+        classification: {
+          assetClass: "voucher",
+          economicRole: "other",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: false,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "VOUCHER",
+      },
+    },
+  ];
+
+  canonicalEntries.forEach((entry) => registerCanonicalEntry(registry, entry));
+
+  if (config.sToken) {
+    registerCanonicalEntry(registry, {
+      addresses: [config.sToken],
+      entry: {
+        classification: {
+          assetClass: "safety_receipt",
+          economicRole: "receipt",
+          issuanceOrigin: "protocol_minted",
+          isStablecoin: false,
+          isMetal: false,
+          isReceiptToken: true,
+          includeInTvlUnderlying: false,
+          includeInStablecoinSupply: false,
+        },
+        source: "registry_override",
+        confidence: "high",
+        canonicalSymbol: "SUSDST",
+      },
+    });
+  }
+
+  return registry;
+};

--- a/mercata/docs/Metrics.md
+++ b/mercata/docs/Metrics.md
@@ -1,0 +1,184 @@
+# Metrics Functional Spec
+
+## Purpose
+
+Expose two public, read-only backend metrics endpoints that external consumers can rely on for STRATO analytics:
+
+- `GET /v1/metrics/tvl`
+- `GET /v1/metrics/stablecoins`
+
+Primary target consumer is DefiLlama, but the endpoints are intentionally generic and reusable by any read-only integrator.
+
+These endpoints do not mutate protocol state, mint assets, transfer assets, or persist derived metrics. They compute a fresh snapshot from current protocol data and return JSON.
+
+## Actors
+
+- External integrator: requests a public metrics snapshot.
+- Backend API: authorizes the request as public, gathers live protocol data, and returns normalized JSON.
+- Protocol data sources: Cirrus-backed contract state and oracle pricing used by the backend services.
+- Backend config and token registry: provide contract addresses and explicit token classification where runtime inference is not enough.
+
+## Endpoints
+
+### `GET /v1/metrics/tvl`
+
+Returns the current STRATO TVL snapshot.
+
+Business meaning:
+
+- TVL is the USD value of underlying assets locked in STRATO DeFi contracts.
+- Assets are counted once at the underlying-asset level.
+- Receipt or share tokens are not counted as TVL.
+
+### `GET /v1/metrics/stablecoins`
+
+Returns the current circulating stablecoin supply snapshot for STRATO-recognized stable assets.
+
+Business meaning:
+
+- Stablecoin supply is separate from TVL.
+- This endpoint reports total supply of included stablecoins, priced in USD.
+- Yield-bearing wrappers are not counted as stablecoin supply unless explicitly classified that way.
+
+## TVL User Flow
+
+### Request flow
+
+1. A client requests `GET /v1/metrics/tvl`.
+2. The route is exposed as public via `authorizeRequest(true)`.
+3. `MetricsController.getTvl()` calls `getTvlMetrics(accessToken)`.
+4. The service gathers live data from the existing backend service layer.
+5. The service normalizes positions into a common asset shape.
+6. The service aggregates positions by underlying token address into top-level `assets`.
+7. The service returns the raw balances, per-position breakdown, and summed USD totals.
+
+### Buckets included in TVL
+
+- CDP collateral
+- Lending supplied underlying
+- Lending collateral
+- Pool reserves
+- `saveUSDST` underlying
+- Safety module underlying
+- Vault underlying
+
+### TVL inclusion rules
+
+- Include assets currently locked in protocol-controlled contracts.
+- Count underlying assets, not receipt/share tokens.
+- Aggregate the same underlying token across buckets into one top-level asset row.
+
+### TVL exclusion rules
+
+- User wallet balances
+- LP tokens
+- Lending receipt tokens
+- Vault share tokens
+- Safety receipt tokens
+- Other share/claim tokens that represent already-counted locked assets
+- Protocol debt as additive TVL
+- Any double counting of the same underlying across products
+
+## Stablecoin User Flow
+
+### Request flow
+
+1. A client requests `GET /v1/metrics/stablecoins`.
+2. The route is exposed as public via `authorizeRequest(true)`.
+3. `MetricsController.getStablecoins()` calls `getStablecoinMetrics(accessToken)`.
+4. The service loads active tokens and oracle prices.
+5. The service builds token-classification context from live protocol state plus explicit registry entries.
+6. Tokens are filtered to `includeInStablecoinSupply`.
+7. The service returns per-asset total supply, price, and USD value.
+
+### Stablecoin inclusion rules
+
+- Include canonical STRATO stablecoins and recognized bridged stablecoins.
+- Current intended production scope is `USDST`, `USDC`, and `USDT`.
+
+### Stablecoin exclusion rules
+
+- Exclude yield-bearing wrappers from stablecoin supply, even if they appear in TVL as locked assets.
+- Current examples: `sUSDS` and `syrupUSDC`.
+
+## Output Contract
+
+### TVL response
+
+Returns:
+
+- `timestamp`
+- `methodologyVersion`
+- `totalUsd`
+- `assets`: aggregated underlying assets across all included buckets
+- `positions`: unaggregated per-bucket positions with `sourceBucket` and `sourceKey`
+- `breakdown`: per-bucket detail
+
+Important behavioral detail:
+
+- Top-level `assets` are aggregated by token address from the raw `positions` set.
+- `positions` preserve bucket-level provenance for debugging and review.
+
+### Stablecoin response
+
+Returns:
+
+- `timestamp`
+- `methodologyVersion`
+- `totalUsd`
+- `assets`: stablecoin supply rows with `address`, `name`, `symbol`, `decimals`, `totalSupply`, `priceUsd`, and `totalUsd`
+
+## Data Dependencies
+
+The metrics slice relies on the existing backend service layer rather than bespoke direct queries for each product bucket.
+
+Key dependencies include:
+
+- Oracle pricing
+- CDP stats
+- Lending liquidity and collateral state
+- Swapping pools
+- `saveUSDST`
+- Safety module
+- Vaults
+- Token classification context
+
+## Config And Classification Dependencies
+
+### `saveUsdstVault`
+
+`saveUSDST` TVL depends on `config.saveUsdstVault`. If this address is wrong or unset, the `saveUsdst` bucket will not reflect the intended deployed vault.
+
+### Token registry
+
+Explicit token registry entries are used to make token classification deterministic for:
+
+- stablecoin supply filtering
+- metal and bridged asset identification
+- receipt/share token exclusion behavior
+- known LP and protocol token handling
+
+The token registry is intentionally not a full `BlockApps-Token` inventory. It is a canonical classification layer for protocol-relevant assets and known receipt/reward tokens.
+
+## Error Handling
+
+- The endpoints are read-only.
+- Failures in required upstream reads bubble up through the controller and are handled by the backend error middleware.
+- No protocol state is modified when requests fail.
+- Missing or incorrect configuration can cause incomplete bucket coverage, especially for `saveUSDST`.
+
+## Non-Goals
+
+- These endpoints do not replace protocol-specific product APIs.
+- They are not intended to expose every token on STRATO.
+- They do not define stablecoin supply and TVL as the same metric.
+- They are not intended to return receipt-token inventories.
+
+## Reference Snapshots
+
+Captured example outputs live at the repo root:
+
+- `prod-tvl-output.json`
+- `prod-stablecoins-output.json`
+
+These are useful for review, adapter drafting, and PR preparation, but the deployed endpoints remain the source of truth.


### PR DESCRIPTION
- add public read-only STRATO metrics endpoints for TVL and stablecoin supply
- define TVL as underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults
- separate stablecoin supply from TVL and keep token classification internal to metrics filtering rather than exposing classification payloads

## What Changed

- added `GET /v1/metrics/tvl`
- added `GET /v1/metrics/stablecoins`
- added canonical token-registry coverage for protocol-relevant assets and receipt tokens needed for deterministic classification
- updated `saveUsdstVault` config default so the prod `saveUSDST` bucket resolves correctly in metrics
- token classification that needs to be expanded upon

## TVL Methodology

TVL counts the USD value of underlying assets currently locked in STRATO DeFi contracts, counted once at the underlying-asset level.

Included buckets:

- CDP collateral
- lending supplied underlying
- lending collateral
- pool reserves
- saveUSDST underlying
- safety module underlying
- vault underlying

Excluded from TVL:

- user wallet balances
- LP and other receipt/share tokens
- protocol debt as additive TVL
- double counting of the same underlying across products

## Stablecoin Scope

Stablecoin supply is reported separately from TVL.

Current intended scope:

- `USDST`
- `USDC`
- `USDT`

Excluded from stablecoin supply:

- yield-bearing wrappers such as `sUSDS`
- yield-bearing wrappers such as `syrupUSDC`

## Verification

- prod TVL snapshot captured in `prod-tvl-output.json`
- prod stablecoin snapshot captured in `prod-stablecoins-output.json`
- prod TVL currently resolves to about `$7.52M`
- prod stablecoin supply currently resolves to about `$814.9M`

## Follow-Up

- deploy the public metrics endpoints
- submit the separate DefiLlama adapter PR against `DefiLlama/DefiLlama-Adapters`