### PR TITLE
Fix URL for Safe Transaction Notification Emails

### DIFF
--- a/mercata/services/bridge/src/services/bridgeService.ts
+++ b/mercata/services/bridge/src/services/bridgeService.ts
@@ -164,14 +164,14 @@ export const confirmWithdrawalBatch = async (
       throw executeError;
     }
 
-    const emailPromises = withdrawals.map(async (withdrawal) => {
+    const emailPromises = transactionProposals.map(async (proposal) => {
       try {
-        await sendEmail(withdrawal.withdrawalId!, withdrawal.externalChainId);
+        await sendEmail(proposal.safeTxHash, proposal.externalChainId);
         return "success";
       } catch (emailError) {
         logError("BridgeService", emailError as Error, {
           operation: "sendEmail",
-          withdrawalId: withdrawal.withdrawalId!,
+          safeTxHash: proposal.safeTxHash,
         });
         return "failed";
       }

--- a/mercata/services/bridge/src/services/emailService.ts
+++ b/mercata/services/bridge/src/services/emailService.ts
@@ -9,19 +9,22 @@ const getSafeChainIdentifier = (chainId: number | string): string => {
   const chainIdNum = typeof chainId === "string" ? parseInt(chainId, 10) : chainId;
   const chainMap: Record<number, string> = {
     1: "eth",
+    8453: "base",
     11155111: "sep",
+    59144: "linea",
+    84532: "basesep",
   };
   return chainMap[chainIdNum] || `chain-${chainIdNum}`;
 };
 
-const sendEmail = async (txHash: string, chainId: number | string) => {
+const sendEmail = async (safeTxHash: string, chainId: number | string) => {
   const emailAddresses = process.env.TRANSACTION_APPROVER_EMAILS?.split(
     ",",
   ).map((email) => email.trim());
   const safeAddress = config.safe.address;
   const chainIdentifier = getSafeChainIdentifier(chainId);
 
-  const safeTxLink = `https://app.safe.global/transactions/tx?safe=${chainIdentifier}:${safeAddress}&id=multisig_${safeAddress}_${txHash}`;
+  const safeTxLink = `https://app.safe.global/transactions/tx?safe=${chainIdentifier}:${safeAddress}&id=multisig_${safeAddress}_${safeTxHash}`;
 
   const msg: MailDataRequired = {
     to: emailAddresses || [],


### PR DESCRIPTION
Fixes #6401

Add missing short chain identifiers for base, linea, and base sepolia to bridge email service; use Safe transaction hash rather than STRATO withdrawal ID in Safe URL sent in the transaction pending notification email.