### PR TITLE
Return Just [] for empty response value in SolidVM transactions

### DIFF
--- a/strato/VM/evm-solidity/src/BlockApps/SolidityVarReader.hs
+++ b/strato/VM/evm-solidity/src/BlockApps/SolidityVarReader.hs
@@ -105,7 +105,7 @@ valueToSolidityValue = \case
   ValueVariadic values -> SolidityArray $ map valueToSolidityValue values
 
 svmValueToSolidityValues :: String -> Maybe [SVMType.Type] -> Maybe [SolidityValue]
-svmValueToSolidityValues "" _ = Nothing
+svmValueToSolidityValues "" _ = Just []
 svmValueToSolidityValues resp mReturnTypes =
   case Aeson.eitherDecode (BLC.pack resp) of
     Left _ -> Nothing


### PR DESCRIPTION
Fixes the `Failed to parse response: ` errors seen on testnet