### PR TITLE
Stabilize yield APY with interval-contained noon anchors

### DIFF
--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -2,7 +2,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const SECONDS_PER_YEAR = 31_536_000;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
-const YIELD_ANCHOR_STEP_DAYS = 3;
+const YIELD_ANCHOR_STEP_DAYS = 5;
 
 export interface YieldHistoryInterval {
   fromMs: number;

--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -1,0 +1,162 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SECONDS_PER_YEAR = 31_536_000;
+const YIELD_ANCHOR_UTC_HOUR = 12;
+const DEFAULT_YIELD_WINDOW_DAYS = 30;
+
+export interface YieldHistoryInterval {
+  fromMs: number;
+  toMs: number;
+  value: string;
+}
+
+function parseCirrusTimestamp(ts?: string): number {
+  if (!ts) return Number.NaN;
+  if (ts === "infinity") return Number.POSITIVE_INFINITY;
+  if (ts === "-infinity") return Number.NEGATIVE_INFINITY;
+
+  const hasTimezone = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(ts);
+  return Date.parse(hasTimezone ? ts : `${ts}Z`);
+}
+
+function getHistoryValueAtAnchor(
+  history: Map<string, YieldHistoryInterval[]>,
+  key: string,
+  anchorMs: number,
+): string | null {
+  const intervals = history.get(key);
+  if (!intervals) return null;
+
+  for (const interval of intervals) {
+    if (interval.fromMs <= anchorMs && anchorMs <= interval.toMs) {
+      return interval.value;
+    }
+  }
+
+  return null;
+}
+
+function computeRatioFromRaw(tokenRaw: string, baseRaw: string): number | null {
+  try {
+    const token = BigInt(tokenRaw);
+    const base = BigInt(baseRaw);
+    if (token <= 0n || base <= 0n) return null;
+
+    const scaledRatio = (token * 1_000_000_000n) / base;
+    const ratio = Number(scaledRatio) / 1e9;
+    return isFinite(ratio) && ratio > 0 ? ratio : null;
+  } catch {
+    return null;
+  }
+}
+
+export function indexYieldHistoryRows(rows: any[]): Map<string, YieldHistoryInterval[]> {
+  const byKey = new Map<string, YieldHistoryInterval[]>();
+  for (const row of rows) {
+    const key = row?.key;
+    if (!key) continue;
+
+    const fromMs = parseCirrusTimestamp(row.valid_from);
+    const toMs = parseCirrusTimestamp(row.valid_to);
+    if (Number.isNaN(fromMs) || Number.isNaN(toMs)) continue;
+
+    const interval: YieldHistoryInterval = {
+      fromMs,
+      toMs,
+      value: row.value || "0",
+    };
+
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key)!.push(interval);
+  }
+
+  for (const intervals of byKey.values()) {
+    intervals.sort((a, b) => b.fromMs - a.fromMs);
+  }
+
+  return byKey;
+}
+
+export function buildYieldAnchors(nowMs: number, days: number = DEFAULT_YIELD_WINDOW_DAYS): number[] {
+  const now = new Date(nowMs);
+  const todayUtcStartMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const anchors: number[] = [];
+
+  for (let i = days - 1; i >= 0; i--) {
+    const dayStartMs = todayUtcStartMs - i * DAY_MS;
+    anchors.push(dayStartMs + YIELD_ANCHOR_UTC_HOUR * 60 * 60 * 1000);
+  }
+
+  return anchors;
+}
+
+function toCirrusUtcTime(d: Date): string {
+  return d.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC");
+}
+
+export function buildYieldAnchorOverlapFilter(anchorsMs: number[]): string {
+  return `(${anchorsMs
+    .map((ms) => {
+      const anchor = toCirrusUtcTime(new Date(ms));
+      return `and(valid_from.lte.${anchor},valid_to.gte.${anchor})`;
+    })
+    .join(",")})`;
+}
+
+export function getYieldWindowBounds(
+  nowMs: number,
+  days: number = DEFAULT_YIELD_WINDOW_DAYS,
+): { windowStart: string; windowEndExclusive: string; anchorsMs: number[] } {
+  const startDate = new Date(nowMs - (days - 1) * DAY_MS).toISOString().split("T")[0];
+  const endDateExclusive = new Date(nowMs + DAY_MS).toISOString().split("T")[0];
+
+  return {
+    windowStart: `${startDate} 00:00:00 UTC`,
+    windowEndExclusive: `${endDateExclusive} 00:00:00 UTC`,
+    anchorsMs: buildYieldAnchors(nowMs, days),
+  };
+}
+
+export function computeYieldAPYFromAnchors(
+  tokenAddress: string,
+  baseAddress: string,
+  currentPrices: Map<string, string>,
+  history: Map<string, YieldHistoryInterval[]>,
+  anchorsMs: number[],
+): string | null {
+  const ratioPoints: { anchorMs: number; ratio: number }[] = [];
+
+  for (let i = 0; i < anchorsMs.length; i++) {
+    const anchorMs = anchorsMs[i];
+    const isToday = i === anchorsMs.length - 1;
+
+    let tokenRaw = getHistoryValueAtAnchor(history, tokenAddress, anchorMs);
+    let baseRaw = getHistoryValueAtAnchor(history, baseAddress, anchorMs);
+
+    if (isToday) {
+      tokenRaw = tokenRaw || currentPrices.get(tokenAddress) || null;
+      baseRaw = baseRaw || currentPrices.get(baseAddress) || null;
+    }
+
+    if (!tokenRaw || !baseRaw) continue;
+
+    const ratio = computeRatioFromRaw(tokenRaw, baseRaw);
+    if (ratio === null) continue;
+
+    ratioPoints.push({ anchorMs, ratio });
+  }
+
+  if (ratioPoints.length < 2) return null;
+
+  const start = ratioPoints[0];
+  const end = ratioPoints[ratioPoints.length - 1];
+  const deltaSeconds = (end.anchorMs - start.anchorMs) / 1000;
+  if (!isFinite(deltaSeconds) || deltaSeconds <= 0) return null;
+
+  const growth = end.ratio / start.ratio;
+  if (!isFinite(growth) || growth <= 0) return null;
+
+  const apy = (Math.pow(growth, SECONDS_PER_YEAR / deltaSeconds) - 1) * 100;
+  if (!isFinite(apy)) return null;
+
+  return Math.max(0, apy).toFixed(2);
+}

--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -2,6 +2,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const SECONDS_PER_YEAR = 31_536_000;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
+const YIELD_ANCHOR_STEP_DAYS = 3;
 
 export interface YieldHistoryInterval {
   fromMs: number;
@@ -76,15 +77,21 @@ export function indexYieldHistoryRows(rows: any[]): Map<string, YieldHistoryInte
   return byKey;
 }
 
-export function buildYieldAnchors(nowMs: number, days: number = DEFAULT_YIELD_WINDOW_DAYS): number[] {
+export function buildYieldAnchors(
+  nowMs: number,
+  days: number = DEFAULT_YIELD_WINDOW_DAYS,
+  stepDays: number = YIELD_ANCHOR_STEP_DAYS,
+): number[] {
   const now = new Date(nowMs);
   const todayUtcStartMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
   const anchors: number[] = [];
+  const step = Math.max(1, stepDays);
 
-  for (let i = days - 1; i >= 0; i--) {
+  for (let i = days - 1; i > 0; i -= step) {
     const dayStartMs = todayUtcStartMs - i * DAY_MS;
     anchors.push(dayStartMs + YIELD_ANCHOR_UTC_HOUR * 60 * 60 * 1000);
   }
+  anchors.push(todayUtcStartMs + YIELD_ANCHOR_UTC_HOUR * 60 * 60 * 1000);
 
   return anchors;
 }

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -2,6 +2,7 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
+import { buildYieldAnchorOverlapFilter, computeYieldAPYFromAnchors, getYieldWindowBounds, indexYieldHistoryRows } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
 import {
   computeEquityFromMaps,
@@ -15,16 +16,14 @@ const { Pool, DECIMALS, Vault, Token } = constants;
 const ZERO_APY = "0.00";
 const ZERO_ADDRESS = "0000000000000000000000000000000000000000";
 const CATA_PRICE_USD = 0.25;
-const STABLE_BASE_SYMBOLS = new Set(["USDST", "USDC", "USDT"]);
 
 export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]> => {
   const now = Date.now();
   const twentyFourHoursAgo = toUTCTime(new Date(now - 24 * 60 * 60 * 1000));
-  const thirtyDaysAgoTime = new Date(now - 30 * 24 * 60 * 60 * 1000);
-  const thirtyDaysAgo = toUTCTime(thirtyDaysAgoTime);
-  const thirtyDaysAgoDate = thirtyDaysAgoTime.toISOString().split("T")[0];
+  const thirtyDaysAgo = toUTCTime(new Date(now - 30 * 24 * 60 * 60 * 1000));
+  const { windowStart, windowEndExclusive, anchorsMs } = getYieldWindowBounds(now);
   const vaultAddr = constants.vault;
-  const yieldHistoryAssets = [...new Set(yieldBenchmarks.flatMap((p) => [p.tokenAddress, p.baseAddress]))];
+  const yieldHistoryKeys = [...new Set(yieldBenchmarks.flatMap((p) => [p.tokenAddress, p.baseAddress]))];
 
   const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""})`;
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
@@ -35,7 +34,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     { data: mappingRows },
     { data: eventRows },
     { data: pools },
-    { data: yieldHistRows },
+    { data: yieldHistoryRows },
     { data: vaultRows },
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
@@ -48,14 +47,14 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
-    yieldHistoryAssets.length
+    yieldHistoryKeys.length
       ? cirrus.get(accessToken, "/history@mapping", { params: {
         address: `eq.${constants.priceOracle}`,
         collection_name: "eq.prices",
-        "key->>key": `in.(${yieldHistoryAssets.join(",")})`,
-        select: "key->>key,value::text",
-        valid_from: `lte.${thirtyDaysAgoDate}`,
-        valid_to: `gte.${thirtyDaysAgoDate}`,
+        "key->>key": `in.(${yieldHistoryKeys.join(",")})`,
+        select: "key->>key,value::text,valid_from,valid_to",
+        and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
+        or: buildYieldAnchorOverlapFilter(anchorsMs),
       }})
       : Promise.resolve({ data: [] as any[] }),
     vaultAddr
@@ -77,7 +76,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   // Parse mapping
   const prices = new Map<string, string>();
-  const historicalYieldPrices = new Map<string, string>();
+  const yieldHistoryByKey = indexYieldHistoryRows(yieldHistoryRows || []);
   let lendingCfg: any = null;
   let liqBalance: string | null = null;
   const vaultAssets: string[] = [];
@@ -89,9 +88,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       const addr = r.value.replace(/"/g, "");
       if (addr) vaultAssets.push(addr);
     }
-  }
-  for (const r of yieldHistRows || []) {
-    if (r.key) historicalYieldPrices.set(r.key, r.value || "0");
   }
 
   // Parse events (single pass)
@@ -173,12 +169,12 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
-    const apy = computeYieldAPY(
-      pair.baseSymbol,
-      prices.get(pair.tokenAddress),
-      prices.get(pair.baseAddress),
-      historicalYieldPrices.get(pair.tokenAddress),
-      historicalYieldPrices.get(pair.baseAddress),
+    const apy = computeYieldAPYFromAnchors(
+      pair.tokenAddress,
+      pair.baseAddress,
+      prices,
+      yieldHistoryByKey,
+      anchorsMs,
     );
     if (!apy) continue;
     add(pair.tokenAddress, { source: "base", apy, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
@@ -448,33 +444,4 @@ function findPoolRewardActivity(
 
   const withUsdStake = matches.find((activity) => safeBigInt(activity?.totalStakeUsd || "0") > 0n);
   return withUsdStake || matches[0];
-}
-
-function computeYieldAPY(
-  baseSymbol: string,
-  tokenNowRaw?: string,
-  baseNowRaw?: string,
-  tokenStartRaw?: string,
-  baseStartRaw?: string,
-): string | null {
-  try {
-    const tokenNow = BigInt(tokenNowRaw || "0");
-    const baseNowFallback = STABLE_BASE_SYMBOLS.has(baseSymbol) ? DECIMALS : 0n;
-    const baseNow = BigInt(baseNowRaw || "0") || baseNowFallback;
-    const tokenStart = BigInt(tokenStartRaw || "0");
-    const baseStart = BigInt(baseStartRaw || "0") || (STABLE_BASE_SYMBOLS.has(baseSymbol) ? baseNow : 0n);
-    if (tokenNow <= 0n || baseNow <= 0n || tokenStart <= 0n || baseStart <= 0n) return null;
-
-    const ratioNow = Number(tokenNow) / Number(baseNow);
-    const ratioStart = Number(tokenStart) / Number(baseStart);
-    if (!isFinite(ratioNow) || !isFinite(ratioStart) || ratioStart <= 0) return null;
-
-    const periodReturn = ratioNow / ratioStart - 1;
-    if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
-
-    const apy = (Math.pow(1 + periodReturn, 365 / 30) - 1) * 100;
-    return apy > 0 ? apy.toFixed(2) : null;
-  } catch {
-    return null;
-  }
 }


### PR DESCRIPTION
The core formula is:

`APY = (R2 / R1)^(31,536,000 / (t2 - t1)) - 1`

We apply this with a 30-day anchor window sampled every 5 days (including the current-day anchor), and compute `R1`/`R2` from the earliest/latest available anchors. This keeps the same APY formula, stabilizes point selection, and reduces query load.

| Pair | Old APY | New APY | DefiLlama APY | Comparator |
|---|---:|---:|---:|---|
| wstETH/ETH | 4.25% | 2.38% | 2.434% | Lido stETH base yield |
| rETH/ETH | 1.12% | 2.67% | 2.0267% | Rocket Pool rETH |
| sUSDS/USDST | 2.67% | 3.36% | 3.75% | Sky sUSDS |
| syrupUSDC/USDC | n/a | 4.20% | 4.6443% | Closest SYRUPUSDC lending pool |

Across comparable pairs (wstETH, rETH, sUSDS), mean absolute difference vs DefiLlama improved from ~1.27pp (old) to ~0.36pp (new).


