### PR TITLE
fix: read saveUsdstVault config lazily to populate stake fields

### DIFF
--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -49,7 +49,7 @@ const USD_NOTIONAL_SWAP_SOURCES = new Set<string>(STAKE_SEMANTICS.usd_notional.s
 const USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES = new Set<string>(STAKE_SEMANTICS.usd_notional.depositCompletedSources.map(normalizeAddr));
 const USD_NOTIONAL_AMOUNT_USD_SOURCES = new Set<string>(STAKE_SEMANTICS.usd_notional.amountUsdSources.map(normalizeAddr));
 const TOKEN_UNITS_SOURCES = new Set<string>(STAKE_SEMANTICS.token_units.lpMintBurnSources.map(normalizeAddr));
-const SAVE_USDST_SOURCE = normalizeAddr(config.saveUsdstVault || "");
+const getSaveUsdstSource = () => normalizeAddr(config.saveUsdstVault || "");
 
 const inferStakeSemantics = (activity: {
   name?: string;
@@ -79,7 +79,8 @@ const inferStakeSemantics = (activity: {
   // token quantities (e.g. LP token transfer `value`), but sometimes they're shares or
   // protocol-specific units. We only confidently mark token_units when the source itself
   // is the token contract (LP token mint/burn is tracked via Token-Transfer on that token).
-  if (TOKEN_UNITS_SOURCES.has(sourceContract) || (SAVE_USDST_SOURCE && sourceContract === SAVE_USDST_SOURCE)) {
+  const saveUsdstSource = getSaveUsdstSource();
+  if (TOKEN_UNITS_SOURCES.has(sourceContract) || (saveUsdstSource && sourceContract === saveUsdstSource)) {
     return { stakeDenomination: "token_units", stakeAssetAddress: sourceContract };
   }
 


### PR DESCRIPTION
## Summary

`SAVE_USDST_SOURCE` was captured as a module-level `const` at import time, before `initNetworkConfig()` had a chance to set `config.saveUsdstVault`. This meant it was always an empty string, so `inferStakeSemantics` never recognized the saveUSDST vault contract — resulting in `stakeDenomination: "unknown"` and all USD stake fields null. Changed to a lazy getter that reads the config at call time.

Closes #6670