### PR TITLE
feat: on-chain exchange rate APY for yield-bearing tokens

### DIFF
--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -1,7 +1,7 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
-const YIELD_ANCHOR_STEP_DAYS = 5;
+const YIELD_ANCHOR_STEP_DAYS = 1;
 
 export interface YieldHistoryInterval {
   fromMs: number;

--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -1,5 +1,4 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
-const SECONDS_PER_YEAR = 31_536_000;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
 const YIELD_ANCHOR_STEP_DAYS = 5;
@@ -17,37 +16,6 @@ function parseCirrusTimestamp(ts?: string): number {
 
   const hasTimezone = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(ts);
   return Date.parse(hasTimezone ? ts : `${ts}Z`);
-}
-
-function getHistoryValueAtAnchor(
-  history: Map<string, YieldHistoryInterval[]>,
-  key: string,
-  anchorMs: number,
-): string | null {
-  const intervals = history.get(key);
-  if (!intervals) return null;
-
-  for (const interval of intervals) {
-    if (interval.fromMs <= anchorMs && anchorMs <= interval.toMs) {
-      return interval.value;
-    }
-  }
-
-  return null;
-}
-
-function computeRatioFromRaw(tokenRaw: string, baseRaw: string): number | null {
-  try {
-    const token = BigInt(tokenRaw);
-    const base = BigInt(baseRaw);
-    if (token <= 0n || base <= 0n) return null;
-
-    const scaledRatio = (token * 1_000_000_000n) / base;
-    const ratio = Number(scaledRatio) / 1e9;
-    return isFinite(ratio) && ratio > 0 ? ratio : null;
-  } catch {
-    return null;
-  }
 }
 
 export function indexYieldHistoryRows(rows: any[]): Map<string, YieldHistoryInterval[]> {
@@ -123,47 +91,33 @@ export function getYieldWindowBounds(
   };
 }
 
-export function computeYieldAPYFromAnchors(
-  tokenAddress: string,
-  baseAddress: string,
-  currentPrices: Map<string, string>,
+export function computeExchangeRateAPY(
+  assetAddress: string,
   history: Map<string, YieldHistoryInterval[]>,
   anchorsMs: number[],
 ): string | null {
-  const ratioPoints: { anchorMs: number; ratio: number }[] = [];
+  const intervals = history.get(assetAddress);
+  if (!intervals || anchorsMs.length < 2) return null;
 
-  for (let i = 0; i < anchorsMs.length; i++) {
-    const anchorMs = anchorsMs[i];
-    const isToday = i === anchorsMs.length - 1;
+  let startRate: bigint | null = null, startMs = 0;
+  let endRate: bigint | null = null, endMs = 0;
 
-    let tokenRaw = getHistoryValueAtAnchor(history, tokenAddress, anchorMs);
-    let baseRaw = getHistoryValueAtAnchor(history, baseAddress, anchorMs);
-
-    if (isToday) {
-      tokenRaw = tokenRaw || currentPrices.get(tokenAddress) || null;
-      baseRaw = baseRaw || currentPrices.get(baseAddress) || null;
-    }
-
-    if (!tokenRaw || !baseRaw) continue;
-
-    const ratio = computeRatioFromRaw(tokenRaw, baseRaw);
-    if (ratio === null) continue;
-
-    ratioPoints.push({ anchorMs, ratio });
+  for (const anchorMs of anchorsMs) {
+    const iv = intervals.find(i => i.fromMs <= anchorMs && anchorMs <= i.toMs);
+    if (!iv) continue;
+    const rate = BigInt(iv.value || "0");
+    if (rate <= 0n) continue;
+    if (!startRate) { startRate = rate; startMs = anchorMs; }
+    endRate = rate;
+    endMs = anchorMs;
   }
 
-  if (ratioPoints.length < 2) return null;
+  if (!startRate || !endRate || endMs <= startMs) return null;
+  const daysDelta = (endMs - startMs) / (1000 * 60 * 60 * 24);
+  if (daysDelta < 1) return null;
 
-  const start = ratioPoints[0];
-  const end = ratioPoints[ratioPoints.length - 1];
-  const deltaSeconds = (end.anchorMs - start.anchorMs) / 1000;
-  if (!isFinite(deltaSeconds) || deltaSeconds <= 0) return null;
-
-  const growth = end.ratio / start.ratio;
+  const growth = Number(endRate) / Number(startRate);
   if (!isFinite(growth) || growth <= 0) return null;
-
-  const apy = (Math.pow(growth, SECONDS_PER_YEAR / deltaSeconds) - 1) * 100;
-  if (!isFinite(apy)) return null;
-
-  return Math.max(0, apy).toFixed(2);
+  const apy = (Math.pow(growth, 365 / daysDelta) - 1) * 100;
+  return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
 }

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -1,6 +1,6 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
-import { hiddenSwapPools, yieldBenchmarks } from "../../config/config";
+import { hiddenSwapPools, yieldBenchmarks, compositeYieldMap } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
 import { buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds, indexYieldHistoryRows } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
@@ -29,7 +29,10 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
 
   // Phase 1: parallel calls
-  const exchangeRateAddrs = yieldBenchmarks.map((b) => b.tokenAddress);
+  const exchangeRateAddrs = [...new Set([
+    ...yieldBenchmarks.map((b) => b.tokenAddress),
+    ...Object.values(compositeYieldMap),
+  ])];
 
   const [
     { data: storageRows },
@@ -217,8 +220,16 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   for (const pair of yieldBenchmarks) {
     const apy = computeExchangeRateAPY(pair.tokenAddress, exchangeRateHistory, anchorsMs);
     if (!apy) continue;
-    add(pair.tokenAddress, { source: "base", apy, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
-    baseYieldByAddr.set(pair.tokenAddress, parseFloat(apy));
+    let totalApy = parseFloat(apy);
+    // For AAVE aTokens wrapping LSTs, add the underlying staking yield
+    const underlyingAddr = compositeYieldMap[pair.tokenAddress];
+    if (underlyingAddr) {
+      const underlyingApy = computeExchangeRateAPY(underlyingAddr, exchangeRateHistory, anchorsMs);
+      if (underlyingApy) totalApy += parseFloat(underlyingApy);
+    }
+    const apyStr = totalApy.toFixed(2);
+    add(pair.tokenAddress, { source: "base", apy: apyStr, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
+    baseYieldByAddr.set(pair.tokenAddress, totalApy);
   }
   const vaultWeightedApy = currentVaultBalances.size > 0 && baseYieldByAddr.size > 0
     ? weightedBaseYield(

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -2,7 +2,7 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
-import { buildYieldAnchorOverlapFilter, computeYieldAPYFromAnchors, getYieldWindowBounds, indexYieldHistoryRows } from "../helpers/earnYield.helper";
+import { buildYieldAnchorOverlapFilter, computeYieldAPYFromAnchors, getYieldWindowBounds, indexYieldHistoryRows, YieldHistoryInterval } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
 import { fetchMultiTokenStablePools } from "../helpers/swapping.helper";
 import {
@@ -227,7 +227,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   // Build per-asset exchange rate APY from exchangeRates history mapping
   const exchangeRateHistory = indexYieldHistoryRows(exchangeRateRows || []);
-  const exchangeRateApyByAddr = new Map<string, string>();
 
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
@@ -438,38 +437,32 @@ function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null 
 
 function computeExchangeRateAPYFromHistory(
   assetAddress: string,
-  history: Map<string, import("../helpers/earnYield.helper").YieldHistoryInterval[]>,
+  history: Map<string, YieldHistoryInterval[]>,
   anchorsMs: number[],
 ): string | null {
   const intervals = history.get(assetAddress);
   if (!intervals || anchorsMs.length < 2) return null;
 
-  // Find the earliest and latest anchors that have data
-  let startRate: bigint | null = null;
-  let startMs = 0;
-  let endRate: bigint | null = null;
-  let endMs = 0;
+  let startRate: bigint | null = null, startMs = 0;
+  let endRate: bigint | null = null, endMs = 0;
 
   for (const anchorMs of anchorsMs) {
-    for (const iv of intervals) {
-      if (iv.fromMs <= anchorMs && anchorMs <= iv.toMs) {
-        const rate = BigInt(iv.value || "0");
-        if (rate <= 0n) break;
-        if (!startRate) { startRate = rate; startMs = anchorMs; }
-        endRate = rate;
-        endMs = anchorMs;
-        break;
-      }
-    }
+    const iv = intervals.find(i => i.fromMs <= anchorMs && anchorMs <= i.toMs);
+    if (!iv) continue;
+    const rate = BigInt(iv.value || "0");
+    if (rate <= 0n) continue;
+    if (!startRate) { startRate = rate; startMs = anchorMs; }
+    endRate = rate;
+    endMs = anchorMs;
   }
 
   if (!startRate || !endRate || endMs <= startMs) return null;
   const daysDelta = (endMs - startMs) / (1000 * 60 * 60 * 24);
   if (daysDelta < 1) return null;
 
-  const periodReturn = Number(endRate) / Number(startRate) - 1;
-  if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
-  const apy = (Math.pow(1 + periodReturn, 365 / daysDelta) - 1) * 100;
+  const growth = Number(endRate) / Number(startRate);
+  if (!isFinite(growth) || growth <= 0) return null;
+  const apy = (Math.pow(growth, 365 / daysDelta) - 1) * 100;
   return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
 }
 

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -2,7 +2,7 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
-import { buildYieldAnchorOverlapFilter, computeYieldAPYFromAnchors, getYieldWindowBounds, indexYieldHistoryRows, YieldHistoryInterval } from "../helpers/earnYield.helper";
+import { buildYieldAnchorOverlapFilter, getYieldWindowBounds, indexYieldHistoryRows, YieldHistoryInterval } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
 import { fetchMultiTokenStablePools } from "../helpers/swapping.helper";
 import {
@@ -24,22 +24,18 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const thirtyDaysAgo = toUTCTime(new Date(now - 30 * 24 * 60 * 60 * 1000));
   const { windowStart, windowEndExclusive, anchorsMs } = getYieldWindowBounds(now);
   const vaultAddr = constants.vault;
-  const yieldHistoryKeys = [...new Set(yieldBenchmarks.flatMap((p) => [p.tokenAddress, p.baseAddress]))];
 
   const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""})`;
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
 
   // Phase 1: parallel calls
-  const exchangeRateTrackedAddrs = yieldBenchmarks
-    .filter((b) => b.exchangeRateTracked)
-    .map((b) => b.tokenAddress);
+  const exchangeRateAddrs = yieldBenchmarks.map((b) => b.tokenAddress);
 
   const [
     { data: storageRows },
     { data: mappingRows },
     { data: eventRows },
     { data: pools },
-    { data: yieldHistoryRows },
     { data: vaultRows },
     saveUsdstInfo,
     { data: exchangeRateRows },
@@ -54,16 +50,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
-    yieldHistoryKeys.length
-      ? cirrus.get(accessToken, "/history@mapping", { params: {
-        address: `eq.${constants.priceOracle}`,
-        collection_name: "eq.prices",
-        "key->>key": `in.(${yieldHistoryKeys.join(",")})`,
-        select: "key->>key,value::text,valid_from,valid_to",
-        and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
-        or: buildYieldAnchorOverlapFilter(anchorsMs),
-      }})
-      : Promise.resolve({ data: [] as any[] }),
     vaultAddr
       ? cirrus.get(accessToken, `/${Vault}`, { params: {
         address: `eq.${vaultAddr}`,
@@ -71,11 +57,11 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       }})
       : Promise.resolve({ data: [] as any[] }),
     getSaveUsdstInfo(accessToken).catch(() => null),
-    exchangeRateTrackedAddrs.length
+    exchangeRateAddrs.length
       ? cirrus.get(accessToken, "/history@mapping", { params: {
         address: `eq.${constants.priceOracle}`,
         collection_name: "eq.exchangeRates",
-        "key->>key": `in.(${exchangeRateTrackedAddrs.join(",")})`,
+        "key->>key": `in.(${exchangeRateAddrs.join(",")})`,
         select: "key->>key,value::text,valid_from,valid_to",
         and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
         or: buildYieldAnchorOverlapFilter(anchorsMs),
@@ -94,7 +80,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   // Parse mapping
   const prices = new Map<string, string>();
-  const yieldHistoryByKey = indexYieldHistoryRows(yieldHistoryRows || []);
   let lendingCfg: any = null;
   let liqBalance: string | null = null;
   const vaultAssets: string[] = [];
@@ -230,20 +215,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
-    // Prefer on-chain exchange rate APY from mapping history; fall back to USD price ratio
-    let apy: string | null = null;
-    if (pair.exchangeRateTracked && exchangeRateHistory.size > 0) {
-      apy = computeExchangeRateAPYFromHistory(pair.tokenAddress, exchangeRateHistory, anchorsMs);
-    }
-    if (!apy) {
-      apy = computeYieldAPYFromAnchors(
-        pair.tokenAddress,
-        pair.baseAddress,
-        prices,
-        yieldHistoryByKey,
-        anchorsMs,
-      );
-    }
+    const apy = computeExchangeRateAPYFromHistory(pair.tokenAddress, exchangeRateHistory, anchorsMs);
     if (!apy) continue;
     add(pair.tokenAddress, { source: "base", apy, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
     baseYieldByAddr.set(pair.tokenAddress, parseFloat(apy));

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -29,7 +29,11 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""})`;
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
 
-  // Phase 1: 5 parallel calls
+  // Phase 1: parallel calls
+  const exchangeRateTrackedAddrs = yieldBenchmarks
+    .filter((b) => b.exchangeRateTracked)
+    .map((b) => b.tokenAddress);
+
   const [
     { data: storageRows },
     { data: mappingRows },
@@ -38,6 +42,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     { data: yieldHistoryRows },
     { data: vaultRows },
     saveUsdstInfo,
+    { data: exchangeRateRows },
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
       address: `in.(${constants.lendingPool},${constants.safetyModule},${constants.sToken}${vaultAddr ? `,${vaultAddr}` : ""})`,
@@ -66,6 +71,14 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       }})
       : Promise.resolve({ data: [] as any[] }),
     getSaveUsdstInfo(accessToken).catch(() => null),
+    exchangeRateTrackedAddrs.length
+      ? cirrus.get(accessToken, `/${constants.PriceOracleExchangeRatesEvents}`, { params: {
+        address: `eq.${constants.priceOracle}`,
+        block_timestamp: `gte.${thirtyDaysAgo}`,
+        select: "attributes,block_timestamp",
+        order: "block_timestamp.asc",
+      }}).catch(() => ({ data: [] as any[] }))
+      : Promise.resolve({ data: [] as any[] }),
   ]);
 
   // Parse storage
@@ -210,15 +223,48 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     }
   }
 
+  // Build per-asset exchange rate APY from ExchangeRatesUpdated events
+  const exchangeRateApyByAddr = new Map<string, string>();
+  if ((exchangeRateRows || []).length > 0) {
+    const perAsset = new Map<string, Array<{ rate: bigint; ts: number }>>();
+    for (const event of exchangeRateRows) {
+      const attrs = event.attributes || {};
+      const assets: string[] = Array.isArray(attrs.assets) ? attrs.assets : [];
+      const rates: string[] = Array.isArray(attrs.rates) ? attrs.rates : [];
+      const blockTs = new Date(event.block_timestamp).getTime();
+      for (let i = 0; i < assets.length; i++) {
+        const addr = (assets[i] || "").toLowerCase().replace(/^0x/, "");
+        if (!exchangeRateTrackedAddrs.includes(addr)) continue;
+        const rate = BigInt(rates[i] || "0");
+        if (rate <= 0n) continue;
+        if (!perAsset.has(addr)) perAsset.set(addr, []);
+        perAsset.get(addr)!.push({ rate, ts: blockTs });
+      }
+    }
+    for (const [addr, events] of perAsset) {
+      if (events.length < 2) continue;
+      const oldest = events[0];
+      const newest = events[events.length - 1];
+      const daysDelta = (newest.ts - oldest.ts) / (1000 * 60 * 60 * 24);
+      if (daysDelta < 1) continue;
+      const apy = computeExchangeRateAPY(newest.rate, oldest.rate, daysDelta);
+      if (apy) exchangeRateApyByAddr.set(addr, apy);
+    }
+  }
+
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
-    const apy = computeYieldAPYFromAnchors(
-      pair.tokenAddress,
-      pair.baseAddress,
-      prices,
-      yieldHistoryByKey,
-      anchorsMs,
-    );
+    // Prefer on-chain exchange rate APY; fall back to USD price ratio
+    let apy = pair.exchangeRateTracked ? exchangeRateApyByAddr.get(pair.tokenAddress) || null : null;
+    if (!apy) {
+      apy = computeYieldAPYFromAnchors(
+        pair.tokenAddress,
+        pair.baseAddress,
+        prices,
+        yieldHistoryByKey,
+        anchorsMs,
+      );
+    }
     if (!apy) continue;
     add(pair.tokenAddress, { source: "base", apy, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
     baseYieldByAddr.set(pair.tokenAddress, parseFloat(apy));
@@ -408,6 +454,14 @@ function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null 
   if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
 
   return ((Math.pow(1 + periodReturn, 365 / 30) - 1) * 100).toFixed(2);
+}
+
+function computeExchangeRateAPY(rateNow: bigint, rateStart: bigint, daysDelta: number): string | null {
+  if (rateNow <= 0n || rateStart <= 0n || daysDelta <= 0) return null;
+  const periodReturn = Number(rateNow) / Number(rateStart) - 1;
+  if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
+  const apy = (Math.pow(1 + periodReturn, 365 / daysDelta) - 1) * 100;
+  return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
 }
 
 function buildVolumeMap(swapEvents: any[], prices: Map<string, string>): Map<string, number> {

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -72,11 +72,13 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       : Promise.resolve({ data: [] as any[] }),
     getSaveUsdstInfo(accessToken).catch(() => null),
     exchangeRateTrackedAddrs.length
-      ? cirrus.get(accessToken, `/${constants.PriceOracleExchangeRatesEvents}`, { params: {
+      ? cirrus.get(accessToken, "/history@mapping", { params: {
         address: `eq.${constants.priceOracle}`,
-        block_timestamp: `gte.${thirtyDaysAgo}`,
-        select: "attributes,block_timestamp",
-        order: "block_timestamp.asc",
+        collection_name: "eq.exchangeRates",
+        "key->>key": `in.(${exchangeRateTrackedAddrs.join(",")})`,
+        select: "key->>key,value::text,valid_from,valid_to",
+        and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
+        or: buildYieldAnchorOverlapFilter(anchorsMs),
       }}).catch(() => ({ data: [] as any[] }))
       : Promise.resolve({ data: [] as any[] }),
   ]);
@@ -223,39 +225,17 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     }
   }
 
-  // Build per-asset exchange rate APY from ExchangeRatesUpdated events
+  // Build per-asset exchange rate APY from exchangeRates history mapping
+  const exchangeRateHistory = indexYieldHistoryRows(exchangeRateRows || []);
   const exchangeRateApyByAddr = new Map<string, string>();
-  if ((exchangeRateRows || []).length > 0) {
-    const perAsset = new Map<string, Array<{ rate: bigint; ts: number }>>();
-    for (const event of exchangeRateRows) {
-      const attrs = event.attributes || {};
-      const assets: string[] = Array.isArray(attrs.assets) ? attrs.assets : [];
-      const rates: string[] = Array.isArray(attrs.rates) ? attrs.rates : [];
-      const blockTs = new Date(event.block_timestamp).getTime();
-      for (let i = 0; i < assets.length; i++) {
-        const addr = (assets[i] || "").toLowerCase().replace(/^0x/, "");
-        if (!exchangeRateTrackedAddrs.includes(addr)) continue;
-        const rate = BigInt(rates[i] || "0");
-        if (rate <= 0n) continue;
-        if (!perAsset.has(addr)) perAsset.set(addr, []);
-        perAsset.get(addr)!.push({ rate, ts: blockTs });
-      }
-    }
-    for (const [addr, events] of perAsset) {
-      if (events.length < 2) continue;
-      const oldest = events[0];
-      const newest = events[events.length - 1];
-      const daysDelta = (newest.ts - oldest.ts) / (1000 * 60 * 60 * 24);
-      if (daysDelta < 1) continue;
-      const apy = computeExchangeRateAPY(newest.rate, oldest.rate, daysDelta);
-      if (apy) exchangeRateApyByAddr.set(addr, apy);
-    }
-  }
 
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
-    // Prefer on-chain exchange rate APY; fall back to USD price ratio
-    let apy = pair.exchangeRateTracked ? exchangeRateApyByAddr.get(pair.tokenAddress) || null : null;
+    // Prefer on-chain exchange rate APY from mapping history; fall back to USD price ratio
+    let apy: string | null = null;
+    if (pair.exchangeRateTracked && exchangeRateHistory.size > 0) {
+      apy = computeExchangeRateAPYFromHistory(pair.tokenAddress, exchangeRateHistory, anchorsMs);
+    }
     if (!apy) {
       apy = computeYieldAPYFromAnchors(
         pair.tokenAddress,
@@ -456,9 +436,38 @@ function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null 
   return ((Math.pow(1 + periodReturn, 365 / 30) - 1) * 100).toFixed(2);
 }
 
-function computeExchangeRateAPY(rateNow: bigint, rateStart: bigint, daysDelta: number): string | null {
-  if (rateNow <= 0n || rateStart <= 0n || daysDelta <= 0) return null;
-  const periodReturn = Number(rateNow) / Number(rateStart) - 1;
+function computeExchangeRateAPYFromHistory(
+  assetAddress: string,
+  history: Map<string, import("../helpers/earnYield.helper").YieldHistoryInterval[]>,
+  anchorsMs: number[],
+): string | null {
+  const intervals = history.get(assetAddress);
+  if (!intervals || anchorsMs.length < 2) return null;
+
+  // Find the earliest and latest anchors that have data
+  let startRate: bigint | null = null;
+  let startMs = 0;
+  let endRate: bigint | null = null;
+  let endMs = 0;
+
+  for (const anchorMs of anchorsMs) {
+    for (const iv of intervals) {
+      if (iv.fromMs <= anchorMs && anchorMs <= iv.toMs) {
+        const rate = BigInt(iv.value || "0");
+        if (rate <= 0n) break;
+        if (!startRate) { startRate = rate; startMs = anchorMs; }
+        endRate = rate;
+        endMs = anchorMs;
+        break;
+      }
+    }
+  }
+
+  if (!startRate || !endRate || endMs <= startMs) return null;
+  const daysDelta = (endMs - startMs) / (1000 * 60 * 60 * 24);
+  if (daysDelta < 1) return null;
+
+  const periodReturn = Number(endRate) / Number(startRate) - 1;
   if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
   const apy = (Math.pow(1 + periodReturn, 365 / daysDelta) - 1) * 100;
   return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -213,23 +213,19 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     }
   }
 
-  // Build per-asset exchange rate APY from exchangeRates history mapping
+  // Build per-asset exchange rate APY from exchangeRates history mapping.
+  // Requires 2+ oracle data points on different calendar days before APY appears (see computeExchangeRateAPY).
   const exchangeRateHistory = indexYieldHistoryRows(exchangeRateRows || []);
 
   const baseYieldByAddr = new Map<string, number>();
-  for (const pair of yieldBenchmarks) {
-    const apy = computeExchangeRateAPY(pair.tokenAddress, exchangeRateHistory, anchorsMs);
+  for (const { tokenAddress, tokenSymbol, baseSymbol } of yieldBenchmarks) {
+    const apy = computeExchangeRateAPY(tokenAddress, exchangeRateHistory, anchorsMs);
     if (!apy) continue;
-    let totalApy = parseFloat(apy);
-    // For AAVE aTokens wrapping LSTs, add the underlying staking yield
-    const underlyingAddr = compositeYieldMap[pair.tokenAddress];
-    if (underlyingAddr) {
-      const underlyingApy = computeExchangeRateAPY(underlyingAddr, exchangeRateHistory, anchorsMs);
-      if (underlyingApy) totalApy += parseFloat(underlyingApy);
-    }
-    const apyStr = totalApy.toFixed(2);
-    add(pair.tokenAddress, { source: "base", apy: apyStr, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
-    baseYieldByAddr.set(pair.tokenAddress, totalApy);
+    const underlying = compositeYieldMap[tokenAddress];
+    const underlyingApy = underlying ? computeExchangeRateAPY(underlying, exchangeRateHistory, anchorsMs) : null;
+    const totalApy = parseFloat(apy) + (underlyingApy ? parseFloat(underlyingApy) : 0);
+    add(tokenAddress, { source: "base", apy: totalApy.toFixed(2), meta: `${tokenSymbol}/${baseSymbol}` });
+    baseYieldByAddr.set(tokenAddress, totalApy);
   }
   const vaultWeightedApy = currentVaultBalances.size > 0 && baseYieldByAddr.size > 0
     ? weightedBaseYield(

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -2,7 +2,7 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
-import { buildYieldAnchorOverlapFilter, getYieldWindowBounds, indexYieldHistoryRows, YieldHistoryInterval } from "../helpers/earnYield.helper";
+import { buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds, indexYieldHistoryRows } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
 import { fetchMultiTokenStablePools } from "../helpers/swapping.helper";
 import {
@@ -215,7 +215,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
 
   const baseYieldByAddr = new Map<string, number>();
   for (const pair of yieldBenchmarks) {
-    const apy = computeExchangeRateAPYFromHistory(pair.tokenAddress, exchangeRateHistory, anchorsMs);
+    const apy = computeExchangeRateAPY(pair.tokenAddress, exchangeRateHistory, anchorsMs);
     if (!apy) continue;
     add(pair.tokenAddress, { source: "base", apy, meta: `${pair.tokenSymbol}/${pair.baseSymbol}` });
     baseYieldByAddr.set(pair.tokenAddress, parseFloat(apy));
@@ -405,37 +405,6 @@ function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null 
   if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
 
   return ((Math.pow(1 + periodReturn, 365 / 30) - 1) * 100).toFixed(2);
-}
-
-function computeExchangeRateAPYFromHistory(
-  assetAddress: string,
-  history: Map<string, YieldHistoryInterval[]>,
-  anchorsMs: number[],
-): string | null {
-  const intervals = history.get(assetAddress);
-  if (!intervals || anchorsMs.length < 2) return null;
-
-  let startRate: bigint | null = null, startMs = 0;
-  let endRate: bigint | null = null, endMs = 0;
-
-  for (const anchorMs of anchorsMs) {
-    const iv = intervals.find(i => i.fromMs <= anchorMs && anchorMs <= i.toMs);
-    if (!iv) continue;
-    const rate = BigInt(iv.value || "0");
-    if (rate <= 0n) continue;
-    if (!startRate) { startRate = rate; startMs = anchorMs; }
-    endRate = rate;
-    endMs = anchorMs;
-  }
-
-  if (!startRate || !endRate || endMs <= startMs) return null;
-  const daysDelta = (endMs - startMs) / (1000 * 60 * 60 * 24);
-  if (daysDelta < 1) return null;
-
-  const growth = Number(endRate) / Number(startRate);
-  if (!isFinite(growth) || growth <= 0) return null;
-  const apy = (Math.pow(growth, 365 / daysDelta) - 1) * 100;
-  return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
 }
 
 function buildVolumeMap(swapEvents: any[], prices: Map<string, string>): Map<string, number> {

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -59,12 +59,12 @@ export const hiddenSwapPools: Set<string> = new Set([
   "9c75280f9e2368005d2b7342f19c59f9176b5962", // sUSDST-USDST swap pool - This is a hot fix to hide the pool from the user
 ]);
 
-// Yield-bearing tokens benchmarked against a base asset. APY from on-chain exchange rate history if available.
+// Yield-bearing tokens. APY computed from on-chain exchange rate history mapping.
 export const yieldBenchmarks = [
-  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
-  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
-  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64", baseAddress: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010" },
-  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca", baseAddress: "6aeacaa19c68e53035bf495d15e0a328fc600ba8" },
+  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925" },
+  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d" },
+  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64" },
+  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca" },
 ];
 
 /*

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -59,13 +59,12 @@ export const hiddenSwapPools: Set<string> = new Set([
   "9c75280f9e2368005d2b7342f19c59f9176b5962", // sUSDST-USDST swap pool - This is a hot fix to hide the pool from the user
 ]);
 
-// Yield-bearing tokens benchmarked against a base asset for ratio-growth APY.
-// exchangeRateTracked: true = use on-chain exchange rate events (preferred); false/missing = fallback to USD price ratio.
+// Yield-bearing tokens benchmarked against a base asset. APY from on-chain exchange rate history if available.
 export const yieldBenchmarks = [
-  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c", exchangeRateTracked: true },
-  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c", exchangeRateTracked: true },
-  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64", baseAddress: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010", exchangeRateTracked: true },
-  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca", baseAddress: "6aeacaa19c68e53035bf495d15e0a328fc600ba8", exchangeRateTracked: true },
+  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
+  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
+  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64", baseAddress: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010" },
+  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca", baseAddress: "6aeacaa19c68e53035bf495d15e0a328fc600ba8" },
 ];
 
 /*

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -60,12 +60,12 @@ export const hiddenSwapPools: Set<string> = new Set([
 ]);
 
 // Yield-bearing tokens benchmarked against a base asset for ratio-growth APY.
-// Verified on both https://app.strato.nexus and https://node1.testnet.strato.nexus (2026-03-26).
+// exchangeRateTracked: true = use on-chain exchange rate events (preferred); false/missing = fallback to USD price ratio.
 export const yieldBenchmarks = [
-  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
-  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c" },
-  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64", baseAddress: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010" },
-  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca", baseAddress: "6aeacaa19c68e53035bf495d15e0a328fc600ba8" },
+  { tokenSymbol: "wstETH", baseSymbol: "ETH", tokenAddress: "f2aa370405030a434ae07e7826178325c675e925", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c", exchangeRateTracked: true },
+  { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d", baseAddress: "93fb7295859b2d70199e0a4883b7c320cf874e6c", exchangeRateTracked: true },
+  { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64", baseAddress: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010", exchangeRateTracked: true },
+  { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca", baseAddress: "6aeacaa19c68e53035bf495d15e0a328fc600ba8", exchangeRateTracked: true },
 ];
 
 /*

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -65,7 +65,21 @@ export const yieldBenchmarks = [
   { tokenSymbol: "rETH", baseSymbol: "ETH", tokenAddress: "2e4789eb7db143576da25990a3c0298917a8a87d" },
   { tokenSymbol: "sUSDS", baseSymbol: "USDST", tokenAddress: "6e2d93d323edf1b3cc4672a909681b6a430cae64" },
   { tokenSymbol: "syrupUSDC", baseSymbol: "USDC", tokenAddress: "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca" },
+  // AAVE aTokens — yield from AAVE V3 liquidity index (getReserveNormalizedIncome)
+  { tokenSymbol: "aWETH", baseSymbol: "ETH", tokenAddress: "6d40952f0895d21d2bf20cd088f0eb9a1574583f" },
+  { tokenSymbol: "aWBTC", baseSymbol: "BTC", tokenAddress: "5f46258f73c405a58331c1a19e54add394637b06" },
+  { tokenSymbol: "aweETH", baseSymbol: "weETH", tokenAddress: "6f247ad55cb444e3e8db0fe225aea2cf1ed62fe1" },
+  { tokenSymbol: "awstETH", baseSymbol: "wstETH", tokenAddress: "2c33aa5f8bbfe3c15e356a5e87464310db1237be" },
+  { tokenSymbol: "aUSDC", baseSymbol: "USDC", tokenAddress: "465c7e3061bc239df88c37d315be52f5487959ec" },
+  { tokenSymbol: "aUSDT", baseSymbol: "USDT", tokenAddress: "7d2a2b963e1fa273b60f9b7891392903de5e66b8" },
 ];
+
+// For AAVE aTokens wrapping yield-bearing LSTs, composite APY = AAVE lending yield + underlying staking yield.
+// Maps aToken address → underlying token's exchange rate address (used to sum APYs).
+export const compositeYieldMap: Record<string, string> = {
+  "2c33aa5f8bbfe3c15e356a5e87464310db1237be": "f2aa370405030a434ae07e7826178325c675e925", // awstETH → wstETH
+  "6f247ad55cb444e3e8db0fe225aea2cf1ed62fe1": "00000000000000000000000000000000deadbeef", // aweETH → weETH
+};
 
 /*
    Network-specific defaults;

--- a/mercata/backend/src/config/constants.ts
+++ b/mercata/backend/src/config/constants.ts
@@ -25,6 +25,7 @@ export const constants = (() => {
   const PriceOracle = `${CONTRACT_PREFIX}PriceOracle`;
   const PriceOracleEvents = `${CONTRACT_PREFIX}PriceOracle-PriceUpdated`;
   const PriceOracleBatchUpdateEvents = `${CONTRACT_PREFIX}PriceOracle-BatchPricesUpdated`;
+  const PriceOracleExchangeRatesEvents = `${CONTRACT_PREFIX}PriceOracle-ExchangeRatesUpdated`;
   const LendingRegistry = `${CONTRACT_PREFIX}LendingRegistry`;
   const PoolConfigurator = `${CONTRACT_PREFIX}PoolConfigurator`;
   const AdminRegistry = `${CONTRACT_PREFIX}AdminRegistry`;
@@ -137,6 +138,7 @@ export const constants = (() => {
     PriceOracle,
     PriceOracleEvents,
     PriceOracleBatchUpdateEvents,
+    PriceOracleExchangeRatesEvents,
     LendingRegistry,
     PoolConfigurator,
     AdminRegistry,

--- a/mercata/backend/src/config/constants.ts
+++ b/mercata/backend/src/config/constants.ts
@@ -25,7 +25,6 @@ export const constants = (() => {
   const PriceOracle = `${CONTRACT_PREFIX}PriceOracle`;
   const PriceOracleEvents = `${CONTRACT_PREFIX}PriceOracle-PriceUpdated`;
   const PriceOracleBatchUpdateEvents = `${CONTRACT_PREFIX}PriceOracle-BatchPricesUpdated`;
-  const PriceOracleExchangeRatesEvents = `${CONTRACT_PREFIX}PriceOracle-ExchangeRatesUpdated`;
   const LendingRegistry = `${CONTRACT_PREFIX}LendingRegistry`;
   const PoolConfigurator = `${CONTRACT_PREFIX}PoolConfigurator`;
   const AdminRegistry = `${CONTRACT_PREFIX}AdminRegistry`;
@@ -138,7 +137,6 @@ export const constants = (() => {
     PriceOracle,
     PriceOracleEvents,
     PriceOracleBatchUpdateEvents,
-    PriceOracleExchangeRatesEvents,
     LendingRegistry,
     PoolConfigurator,
     AdminRegistry,

--- a/mercata/contracts/concrete/Lending/PriceOracle.sol
+++ b/mercata/contracts/concrete/Lending/PriceOracle.sol
@@ -24,6 +24,7 @@ contract record PriceOracle is Ownable {
     mapping(address => uint256) public record lastUpdated;
     mapping(address => OracleState) public record oracleState;
     mapping(address => uint256) public record rebaseFactors;
+    mapping(address => uint256) public record exchangeRates;
 
     uint256 public queueSize = 2;  // Global queue size, synced to per-asset on push
 
@@ -227,8 +228,8 @@ contract record PriceOracle is Ownable {
     }
 
     /**
-     * @dev Emit exchange rates for yield-bearing tokens (e.g. rETH/ETH, wstETH/stETH).
-     *      Event-only — no on-chain storage. The events table provides historical data for APY calculation.
+     * @dev Set exchange rates for yield-bearing tokens (e.g. rETH/ETH, wstETH/stETH).
+     *      Stored in mapping for other contracts to read; history table used for APY calculation.
      */
     function setExchangeRates(address[] calldata assets, uint256[] calldata rates) external onlyOwner {
         require(assets.length == rates.length, "Arrays length mismatch");
@@ -237,6 +238,7 @@ contract record PriceOracle is Ownable {
         for (uint256 i = 0; i < assets.length; i++) {
             require(assets[i] != address(0), "Invalid asset address");
             require(rates[i] > 0, "Rate must be greater than 0");
+            exchangeRates[assets[i]] = rates[i];
         }
 
         emit ExchangeRatesUpdated(assets, rates, block.timestamp);

--- a/mercata/contracts/concrete/Lending/PriceOracle.sol
+++ b/mercata/contracts/concrete/Lending/PriceOracle.sol
@@ -31,6 +31,7 @@ contract record PriceOracle is Ownable {
     event PriceUpdated(address indexed asset, uint256 price, uint256 timestamp);
     event BatchPricesUpdated(address[] assets, uint256[] priceValues, uint256 timestamp);
     event RebaseFactorsUpdated(address[] assets, uint256[] factors, uint256 timestamp);
+    event ExchangeRatesUpdated(address[] assets, uint256[] rates, uint256 timestamp);
 
     constructor(address _owner) Ownable(_owner) {}
 
@@ -223,6 +224,22 @@ contract record PriceOracle is Ownable {
         }
 
         emit RebaseFactorsUpdated(assets, factors, block.timestamp);
+    }
+
+    /**
+     * @dev Emit exchange rates for yield-bearing tokens (e.g. rETH/ETH, wstETH/stETH).
+     *      Event-only — no on-chain storage. The events table provides historical data for APY calculation.
+     */
+    function setExchangeRates(address[] calldata assets, uint256[] calldata rates) external onlyOwner {
+        require(assets.length == rates.length, "Arrays length mismatch");
+        require(assets.length > 0, "Empty arrays");
+
+        for (uint256 i = 0; i < assets.length; i++) {
+            require(assets[i] != address(0), "Invalid asset address");
+            require(rates[i] > 0, "Rate must be greater than 0");
+        }
+
+        emit ExchangeRatesUpdated(assets, rates, block.timestamp);
     }
 
     /**

--- a/mercata/services/oracle/src/adapters/genericRestAdapter.ts
+++ b/mercata/services/oracle/src/adapters/genericRestAdapter.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from '../utils/apiClient';
-import { SourceConfig, BatchPriceResult, Asset, RebaseConfig } from '../types';
+import { SourceConfig, BatchPriceResult, Asset, RebaseConfig, ExchangeRateConfig } from '../types';
 import { logError, logInfo } from '../utils/logger';
 
 function extractNestedProperty(obj: any, path: string): any {
@@ -366,4 +366,70 @@ export async function fetchRebaseFactor(assetKey: string, rebase: RebaseConfig):
 
     logInfo('RebaseFactor', `${assetKey}: factor=${factor} (parse="${rebase.factorParse}")`);
     return factor;
+}
+
+/**
+ * Fetch an on-chain exchange rate for a yield-bearing token (e.g., rETH/ETH via Rocket Pool).
+ * Same mechanism as fetchRebaseFactor but uses ExchangeRateConfig fields.
+ */
+export async function fetchExchangeRate(assetKey: string, config: ExchangeRateConfig): Promise<bigint> {
+    let url = config.rateUrl;
+    const stratoUrl = process.env.STRATO_NODE_URL || '';
+    url = url.replace(/\$\{STRATO_NODE_URL\}/g, stratoUrl);
+
+    const apiKey = config.rateApiKeyEnvVar ? process.env[config.rateApiKeyEnvVar] || '' : '';
+    if (apiKey) {
+        url = url.replace(/\$\{API_KEY\}/g, apiKey);
+    }
+
+    const method = (config.rateMethod || 'GET').toUpperCase();
+    const headers: Record<string, string> = {
+        'Accept': 'application/json',
+        ...(method === 'POST' ? { 'Content-Type': 'application/json' } : {})
+    };
+    if (config.rateHeaders && apiKey) {
+        config.rateHeaders.split(',').forEach(h => {
+            const name = h.trim();
+            headers[name] = name === 'Authorization' ? `Bearer ${apiKey}` : apiKey;
+        });
+    }
+
+    const requestConfig: any = { method, url, headers };
+    if (method === 'POST' && config.rateBody) {
+        requestConfig.data = JSON.parse(config.rateBody);
+    }
+
+    const response = await apiRequest(requestConfig, {
+        logPrefix: 'ExchangeRate',
+        apiUrl: url,
+        method
+    });
+
+    const raw = extractNestedProperty(response.data, config.rateParse);
+    if (raw === undefined || raw === null) {
+        logError('ExchangeRate', new Error(`${assetKey}: no value at path "${config.rateParse}"`));
+        return 0n;
+    }
+
+    let rawStr = String(raw).trim();
+
+    if (rawStr.startsWith('0x') && rawStr.length > 66) {
+        rawStr = rawStr.slice(0, 66);
+    }
+
+    let rate: bigint;
+    try {
+        rate = BigInt(rawStr);
+    } catch {
+        logError('ExchangeRate', new Error(`${assetKey}: invalid rate value "${rawStr}"`));
+        return 0n;
+    }
+
+    if (rate <= 0n) {
+        logError('ExchangeRate', new Error(`${assetKey}: invalid rate value "${rawStr}"`));
+        return 0n;
+    }
+
+    logInfo('ExchangeRate', `${assetKey}: rate=${rate} (parse="${config.rateParse}")`);
+    return rate;
 }

--- a/mercata/services/oracle/src/adapters/genericRestAdapter.ts
+++ b/mercata/services/oracle/src/adapters/genericRestAdapter.ts
@@ -300,136 +300,80 @@ function parseResponse(data: any, sourceConfig: SourceConfig): BatchPriceResult 
 }
 
 /**
- * Fetch a rebase factor from an external source (e.g., Ethereum eth_call via Alchemy).
- * Returns the raw factor as bigint to preserve full uint256 precision.
- * Caller is responsible for normalizing to WAD (1e18) before pushing on-chain.
+ * Shared: fetch a uint256 value from an external RPC/REST endpoint (e.g. Alchemy eth_call).
+ * Handles URL substitution, API key injection, ABI hex truncation, and bigint parsing.
  */
-export async function fetchRebaseFactor(assetKey: string, rebase: RebaseConfig): Promise<bigint> {
-    let url = rebase.factorUrl;
-    const stratoUrl = process.env.STRATO_NODE_URL || '';
-    url = url.replace(/\$\{STRATO_NODE_URL\}/g, stratoUrl);
+async function fetchOnChainValue(
+    assetKey: string,
+    label: string,
+    opts: { url: string; method?: string; body?: string; parse: string; apiKeyEnvVar?: string; headers?: string },
+): Promise<bigint> {
+    let url = opts.url;
+    url = url.replace(/\$\{STRATO_NODE_URL\}/g, process.env.STRATO_NODE_URL || '');
 
-    const apiKey = rebase.factorApiKeyEnvVar ? process.env[rebase.factorApiKeyEnvVar] || '' : '';
-    if (apiKey) {
-        url = url.replace(/\$\{API_KEY\}/g, apiKey);
-    }
+    const apiKey = opts.apiKeyEnvVar ? process.env[opts.apiKeyEnvVar] || '' : '';
+    if (apiKey) url = url.replace(/\$\{API_KEY\}/g, apiKey);
 
-    const method = (rebase.factorMethod || 'GET').toUpperCase();
+    const method = (opts.method || 'GET').toUpperCase();
     const headers: Record<string, string> = {
         'Accept': 'application/json',
         ...(method === 'POST' ? { 'Content-Type': 'application/json' } : {})
     };
-    if (rebase.factorHeaders && apiKey) {
-        rebase.factorHeaders.split(',').forEach(h => {
+    if (opts.headers && apiKey) {
+        opts.headers.split(',').forEach(h => {
             const name = h.trim();
             headers[name] = name === 'Authorization' ? `Bearer ${apiKey}` : apiKey;
         });
     }
 
     const requestConfig: any = { method, url, headers };
-    if (method === 'POST' && rebase.factorBody) {
-        requestConfig.data = JSON.parse(rebase.factorBody);
-    }
+    if (method === 'POST' && opts.body) requestConfig.data = JSON.parse(opts.body);
 
-    const response = await apiRequest(requestConfig, {
-        logPrefix: 'RebaseFactor',
-        apiUrl: url,
-        method
-    });
+    const response = await apiRequest(requestConfig, { logPrefix: label, apiUrl: url, method });
 
-    const raw = extractNestedProperty(response.data, rebase.factorParse);
+    const raw = extractNestedProperty(response.data, opts.parse);
     if (raw === undefined || raw === null) {
-        logError('RebaseFactor', new Error(`${assetKey}: no value at path "${rebase.factorParse}"`));
+        logError(label, new Error(`${assetKey}: no value at path "${opts.parse}"`));
         return 0n;
     }
 
+    // ABI-encoded eth_call responses pack each uint256 as 32 bytes (64 hex chars).
+    // Extract only the first word when result is longer.
     let rawStr = String(raw).trim();
+    if (rawStr.startsWith('0x') && rawStr.length > 66) rawStr = rawStr.slice(0, 66);
 
-    // ABI-encoded eth_call responses with multiple return values pack each uint256
-    // as 32 bytes (64 hex chars). Extract only the first word when result is longer.
-    if (rawStr.startsWith('0x') && rawStr.length > 66) {
-        rawStr = rawStr.slice(0, 66);
+    let value: bigint;
+    try { value = BigInt(rawStr); } catch {
+        logError(label, new Error(`${assetKey}: invalid value "${rawStr}"`));
+        return 0n;
     }
-
-    let factor: bigint;
-    try {
-        factor = rawStr.startsWith('0x') ? BigInt(rawStr) : BigInt(rawStr);
-    } catch {
-        logError('RebaseFactor', new Error(`${assetKey}: invalid factor value "${rawStr}"`));
+    if (value <= 0n) {
+        logError(label, new Error(`${assetKey}: invalid value "${rawStr}"`));
         return 0n;
     }
 
-    if (factor <= 0n) {
-        logError('RebaseFactor', new Error(`${assetKey}: invalid factor value "${rawStr}"`));
-        return 0n;
-    }
-
-    logInfo('RebaseFactor', `${assetKey}: factor=${factor} (parse="${rebase.factorParse}")`);
-    return factor;
+    logInfo(label, `${assetKey}: ${value} (parse="${opts.parse}")`);
+    return value;
 }
 
-/**
- * Fetch an on-chain exchange rate for a yield-bearing token (e.g., rETH/ETH via Rocket Pool).
- * Same mechanism as fetchRebaseFactor but uses ExchangeRateConfig fields.
- */
-export async function fetchExchangeRate(assetKey: string, config: ExchangeRateConfig): Promise<bigint> {
-    let url = config.rateUrl;
-    const stratoUrl = process.env.STRATO_NODE_URL || '';
-    url = url.replace(/\$\{STRATO_NODE_URL\}/g, stratoUrl);
-
-    const apiKey = config.rateApiKeyEnvVar ? process.env[config.rateApiKeyEnvVar] || '' : '';
-    if (apiKey) {
-        url = url.replace(/\$\{API_KEY\}/g, apiKey);
-    }
-
-    const method = (config.rateMethod || 'GET').toUpperCase();
-    const headers: Record<string, string> = {
-        'Accept': 'application/json',
-        ...(method === 'POST' ? { 'Content-Type': 'application/json' } : {})
-    };
-    if (config.rateHeaders && apiKey) {
-        config.rateHeaders.split(',').forEach(h => {
-            const name = h.trim();
-            headers[name] = name === 'Authorization' ? `Bearer ${apiKey}` : apiKey;
-        });
-    }
-
-    const requestConfig: any = { method, url, headers };
-    if (method === 'POST' && config.rateBody) {
-        requestConfig.data = JSON.parse(config.rateBody);
-    }
-
-    const response = await apiRequest(requestConfig, {
-        logPrefix: 'ExchangeRate',
-        apiUrl: url,
-        method
+export function fetchRebaseFactor(assetKey: string, rebase: RebaseConfig): Promise<bigint> {
+    return fetchOnChainValue(assetKey, 'RebaseFactor', {
+        url: rebase.factorUrl,
+        method: rebase.factorMethod,
+        body: rebase.factorBody,
+        parse: rebase.factorParse,
+        apiKeyEnvVar: rebase.factorApiKeyEnvVar,
+        headers: rebase.factorHeaders,
     });
+}
 
-    const raw = extractNestedProperty(response.data, config.rateParse);
-    if (raw === undefined || raw === null) {
-        logError('ExchangeRate', new Error(`${assetKey}: no value at path "${config.rateParse}"`));
-        return 0n;
-    }
-
-    let rawStr = String(raw).trim();
-
-    if (rawStr.startsWith('0x') && rawStr.length > 66) {
-        rawStr = rawStr.slice(0, 66);
-    }
-
-    let rate: bigint;
-    try {
-        rate = BigInt(rawStr);
-    } catch {
-        logError('ExchangeRate', new Error(`${assetKey}: invalid rate value "${rawStr}"`));
-        return 0n;
-    }
-
-    if (rate <= 0n) {
-        logError('ExchangeRate', new Error(`${assetKey}: invalid rate value "${rawStr}"`));
-        return 0n;
-    }
-
-    logInfo('ExchangeRate', `${assetKey}: rate=${rate} (parse="${config.rateParse}")`);
-    return rate;
+export function fetchExchangeRate(assetKey: string, config: ExchangeRateConfig): Promise<bigint> {
+    return fetchOnChainValue(assetKey, 'ExchangeRate', {
+        url: config.rateUrl,
+        method: config.rateMethod,
+        body: config.rateBody,
+        parse: config.rateParse,
+        apiKeyEnvVar: config.rateApiKeyEnvVar,
+        headers: config.rateHeaders,
+    });
 }

--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -99,7 +99,7 @@
       "exchangeRate": {
         "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
         "rateMethod": "POST",
-        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xCd5fE23C85820F7B72D0926FC9b05b43E359b7e0\",\"data\":\"0x679aefce\"},\"latest\"]}",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee\",\"data\":\"0x679aefce\"},\"latest\"]}",
         "rateParse": "result",
         "ratePrecision": "1000000000000000000",
         "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
@@ -113,7 +113,7 @@
         "underlyingAsset": "ETH",
         "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
         "factorMethod": "POST",
-        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A5C4F27eAD9083C756Cc2\"},\"latest\"]}",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\"},\"latest\"]}",
         "factorParse": "result",
         "factorPrecision": "1000000000000000000000000000",
         "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
@@ -121,7 +121,7 @@
       "exchangeRate": {
         "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
         "rateMethod": "POST",
-        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A5C4F27eAD9083C756Cc2\"},\"latest\"]}",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\"},\"latest\"]}",
         "rateParse": "result",
         "ratePrecision": "1000000000000000000000000000",
         "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
@@ -155,7 +155,7 @@
         "underlyingAsset": "WEETH",
         "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
         "factorMethod": "POST",
-        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7e0\"},\"latest\"]}",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7ee\"},\"latest\"]}",
         "factorParse": "result",
         "factorPrecision": "1000000000000000000000000000",
         "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
@@ -163,7 +163,7 @@
       "exchangeRate": {
         "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
         "rateMethod": "POST",
-        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7e0\"},\"latest\"]}",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7ee\"},\"latest\"]}",
         "rateParse": "result",
         "ratePrecision": "1000000000000000000000000000",
         "rateApiKeyEnvVar": "ALCHEMY_API_KEY",

--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -11,13 +11,40 @@
       "targetAssetAddress": "491cdfe98470bfe69b662ab368826dca0fc2f24d"
     },
     "RETH": {
-      "targetAssetAddress": "2e4789eb7db143576da25990a3c0298917a8a87d"
+      "targetAssetAddress": "2e4789eb7db143576da25990a3c0298917a8a87d",
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xae78736Cd615f374D3085123A210448E74Fc6393\",\"data\":\"0xe6aa216c\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "Rocket Pool rETH: getExchangeRate() returns rETH/ETH rate in WAD"
+      }
     },
     "SUSDS": {
-      "targetAssetAddress": "6e2d93d323edf1b3cc4672a909681b6a430cae64"
+      "targetAssetAddress": "6e2d93d323edf1b3cc4672a909681b6a430cae64",
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD\",\"data\":\"0x07a2d13a0000000000000000000000000000000000000000000000000de0b6b3a7640000\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "Sky sUSDS: convertToAssets(1e18) returns sUSDS/USDS rate in WAD"
+      }
     },
     "SYRUPUSDC": {
-      "targetAssetAddress": "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca"
+      "targetAssetAddress": "c6c3e9881665d53ae8c222e24ca7a8d069aa56ca",
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b\",\"data\":\"0x07a2d13a00000000000000000000000000000000000000000000000000000000000f4240\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "Maple syrupUSDC: convertToAssets(1e6) returns syrupUSDC/USDC rate in 6-decimal"
+      }
     },
     "USDC": {
       "targetAssetAddress": "6aeacaa19c68e53035bf495d15e0a328fc600ba8"
@@ -33,7 +60,16 @@
       "targetAssetAddress": "7a99b5ba11ac280cdd5caf52c12fe89fb1b8d2f9"
     },
     "WSTETH":{
-      "targetAssetAddress": "f2aa370405030a434ae07e7826178325c675e925"
+      "targetAssetAddress": "f2aa370405030a434ae07e7826178325c675e925",
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0\",\"data\":\"0x035faf82\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "Lido wstETH: stEthPerToken() returns wstETH/stETH rate in WAD"
+      }
     },
     "XAG": {
       "targetAssetAddress": "2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94",

--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -96,7 +96,142 @@
     "WEETH": {
       "targetAssetAddress": "00000000000000000000000000000000deadbeef",
       "submit": false,
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xCd5fE23C85820F7B72D0926FC9b05b43E359b7e0\",\"data\":\"0x679aefce\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "EtherFi weETH: getRate() returns weETH/eETH rate in WAD"
+      },
       "comment": "weETH price feed for AWEETH rebase. submit=false: only used as underlying, not pushed directly."
+    },
+    "AWETH": {
+      "targetAssetAddress": "6d40952f0895d21d2bf20cd088f0eb9a1574583f",
+      "rebase": {
+        "underlyingAsset": "ETH",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A5C4F27eAD9083C756Cc2\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A5C4F27eAD9083C756Cc2\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 aWETH: getReserveNormalizedIncome(WETH) in RAY"
+      }
+    },
+    "AWBTC": {
+      "targetAssetAddress": "5f46258f73c405a58331c1a19e54add394637b06",
+      "rebase": {
+        "underlyingAsset": "WBTC",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e00530000000000000000000000002260FAC5E5542a773Aa44fBCfeDf7C193bc2C599\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e00530000000000000000000000002260FAC5E5542a773Aa44fBCfeDf7C193bc2C599\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 aWBTC: getReserveNormalizedIncome(WBTC) in RAY"
+      }
+    },
+    "AWEETH": {
+      "targetAssetAddress": "6f247ad55cb444e3e8db0fe225aea2cf1ed62fe1",
+      "rebase": {
+        "underlyingAsset": "WEETH",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7e0\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000Cd5fE23C85820F7B72D0926FC9b05b43E359b7e0\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 aweETH: getReserveNormalizedIncome(weETH) in RAY"
+      }
+    },
+    "AWSTETH": {
+      "targetAssetAddress": "2c33aa5f8bbfe3c15e356a5e87464310db1237be",
+      "rebase": {
+        "underlyingAsset": "WSTETH",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e00530000000000000000000000007f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e00530000000000000000000000007f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 awstETH: getReserveNormalizedIncome(wstETH) in RAY"
+      }
+    },
+    "AUSDC": {
+      "targetAssetAddress": "465c7e3061bc239df88c37d315be52f5487959ec",
+      "rebase": {
+        "underlyingAsset": "USDC",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 aUSDC: getReserveNormalizedIncome(USDC) in RAY"
+      }
+    },
+    "AUSDT": {
+      "targetAssetAddress": "7d2a2b963e1fa273b60f9b7891392903de5e66b8",
+      "rebase": {
+        "underlyingAsset": "USDT",
+        "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "factorMethod": "POST",
+        "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000dAC17F958D2ee523a2206206994597C13D831ec7\"},\"latest\"]}",
+        "factorParse": "result",
+        "factorPrecision": "1000000000000000000000000000",
+        "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+      },
+      "exchangeRate": {
+        "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+        "rateMethod": "POST",
+        "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000dAC17F958D2ee523a2206206994597C13D831ec7\"},\"latest\"]}",
+        "rateParse": "result",
+        "ratePrecision": "1000000000000000000000000000",
+        "rateApiKeyEnvVar": "ALCHEMY_API_KEY",
+        "comment": "AAVE V3 aUSDT: getReserveNormalizedIncome(USDT) in RAY"
+      }
     },
     "WSPYX": {
       "targetAssetAddress": "1ac696799624c75050b10b7ee3e6fcf6f1f39aa1",

--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -7,7 +7,7 @@ import { fetchPreviousPrices } from './utils/priceReader';
 import { withTimeout } from './utils/apiClient';
 import { oauthClient } from './utils/oauth';
 import { ConfigLoader } from './utils/configLoader';
-import { SourceResult, AggregatedPrice, SourceConfig } from './types';
+import { SourceResult, AggregatedPrice, SourceConfig, TransactionResult } from './types';
 import { TIMEOUTS, ORACLE_CONFIG } from './utils/constants';
 
 // ============================================================================
@@ -376,15 +376,11 @@ async function processAllAssets(configLoader: ConfigLoader): Promise<void> {
     const skipped = failedPrices.length ? `. Skipped ${failedPrices.length}: [${failedPrices.map(p => p.assetKey).join(', ')}]` : '';
     logInfo('CronScheduler', `Submitting ${validPrices.length} prices: [${validPrices.map(p => p.assetKey).join(', ')}]${skipped}`);
     
-    const result = await pushAssetPrices(validPrices);
+    const pushes: Promise<TransactionResult>[] = [pushAssetPrices(validPrices)];
+    if (rebaseFactors.length > 0) pushes.push(pushRebaseFactors(rebaseFactors));
+    if (exchangeRates.length > 0) pushes.push(pushExchangeRates(exchangeRates));
 
-    if (rebaseFactors.length > 0) {
-        await pushRebaseFactors(rebaseFactors);
-    }
-
-    if (exchangeRates.length > 0) {
-        await pushExchangeRates(exchangeRates);
-    }
+    const [result] = await Promise.all(pushes);
 
     // Log all prices (including failed ones)
     aggregatedPrices.forEach(p => logFeedUpdate(p.assetKey, p.medianPrice, p.sources, p.expectedSourceCount, result.hash, p.failed, p.error));

--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -1,7 +1,7 @@
 import cron from 'node-cron';
 import { logInfo, logError, logWarning, logFeedUpdate } from './utils/logger';
-import { fetchPrices, generateConstantPrices, fetchRebaseFactor } from './adapters/genericRestAdapter';
-import { pushAssetPrices, pushRebaseFactors } from './utils/oraclePusher';
+import { fetchPrices, generateConstantPrices, fetchRebaseFactor, fetchExchangeRate } from './adapters/genericRestAdapter';
+import { pushAssetPrices, pushRebaseFactors, pushExchangeRates } from './utils/oraclePusher';
 import { checkBalances } from './utils/balanceChecker';
 import { fetchPreviousPrices } from './utils/priceReader';
 import { withTimeout } from './utils/apiClient';
@@ -294,6 +294,44 @@ async function applyRebaseFactors(
 }
 
 // ============================================================================
+// Step 3b: Collect Exchange Rates (yield-bearing tokens)
+// ============================================================================
+
+interface ExchangeRateEntry {
+    targetAddress: string;
+    rate: bigint;
+}
+
+async function collectExchangeRates(configLoader: ConfigLoader): Promise<ExchangeRateEntry[]> {
+    const collected: ExchangeRateEntry[] = [];
+    const allAssets = configLoader.getAllAssets();
+    const entries = Object.entries(allAssets).filter(([_, a]) => a.exchangeRate);
+    if (entries.length === 0) return collected;
+
+    for (const [assetKey, asset] of entries) {
+        try {
+            const rawRate = await withTimeout(
+                fetchExchangeRate(assetKey, asset.exchangeRate!),
+                TIMEOUTS.FETCH
+            );
+            if (rawRate <= 0n) continue;
+
+            const precision = BigInt(asset.exchangeRate!.ratePrecision);
+            const wadRate = rawRate * 1000000000000000000n / precision;
+            if (wadRate <= 0n) continue;
+
+            collected.push({ targetAddress: asset.targetAssetAddress, rate: wadRate });
+            logInfo('CronScheduler', `${assetKey}: exchangeRate=${wadRate} (raw=${rawRate})`);
+        } catch (err) {
+            logError('CronScheduler', new Error(
+                `${assetKey}: exchange rate fetch failed: ${(err as Error).message}`
+            ));
+        }
+    }
+    return collected;
+}
+
+// ============================================================================
 // Main Orchestrator
 // ============================================================================
 
@@ -317,7 +355,8 @@ async function processAllAssets(configLoader: ConfigLoader): Promise<void> {
         configLoader
     );
     const rebaseFactors = await applyRebaseFactors(aggregatedPrices, configLoader, previousPrices);
-    
+    const exchangeRates = await collectExchangeRates(configLoader);
+
     // Partition into valid and failed prices, excluding proxy-only assets (submit: false)
     const allAssets = configLoader.getAllAssets();
     const validPrices: AggregatedPrice[] = [];
@@ -339,7 +378,11 @@ async function processAllAssets(configLoader: ConfigLoader): Promise<void> {
     if (rebaseFactors.length > 0) {
         await pushRebaseFactors(rebaseFactors);
     }
-    
+
+    if (exchangeRates.length > 0) {
+        await pushExchangeRates(exchangeRates);
+    }
+
     // Log all prices (including failed ones)
     aggregatedPrices.forEach(p => logFeedUpdate(p.assetKey, p.medianPrice, p.sources, p.expectedSourceCount, result.hash, p.failed, p.error));
 }

--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -303,32 +303,33 @@ interface ExchangeRateEntry {
 }
 
 async function collectExchangeRates(configLoader: ConfigLoader): Promise<ExchangeRateEntry[]> {
-    const collected: ExchangeRateEntry[] = [];
     const allAssets = configLoader.getAllAssets();
     const entries = Object.entries(allAssets).filter(([_, a]) => a.exchangeRate);
-    if (entries.length === 0) return collected;
+    if (entries.length === 0) return [];
 
-    for (const [assetKey, asset] of entries) {
+    const results = await Promise.all(entries.map(async ([assetKey, asset]) => {
         try {
             const rawRate = await withTimeout(
                 fetchExchangeRate(assetKey, asset.exchangeRate!),
                 TIMEOUTS.FETCH
             );
-            if (rawRate <= 0n) continue;
+            if (rawRate <= 0n) return null;
 
             const precision = BigInt(asset.exchangeRate!.ratePrecision);
             const wadRate = rawRate * 1000000000000000000n / precision;
-            if (wadRate <= 0n) continue;
+            if (wadRate <= 0n) return null;
 
-            collected.push({ targetAddress: asset.targetAssetAddress, rate: wadRate });
             logInfo('CronScheduler', `${assetKey}: exchangeRate=${wadRate} (raw=${rawRate})`);
+            return { targetAddress: asset.targetAssetAddress, rate: wadRate };
         } catch (err) {
             logError('CronScheduler', new Error(
                 `${assetKey}: exchange rate fetch failed: ${(err as Error).message}`
             ));
+            return null;
         }
-    }
-    return collected;
+    }));
+
+    return results.filter((r): r is ExchangeRateEntry => r !== null);
 }
 
 // ============================================================================
@@ -354,8 +355,10 @@ async function processAllAssets(configLoader: ConfigLoader): Promise<void> {
         aggregatePrices(configLoader, sourceResults, marketClosed, previousPrices),
         configLoader
     );
-    const rebaseFactors = await applyRebaseFactors(aggregatedPrices, configLoader, previousPrices);
-    const exchangeRates = await collectExchangeRates(configLoader);
+    const [rebaseFactors, exchangeRates] = await Promise.all([
+        applyRebaseFactors(aggregatedPrices, configLoader, previousPrices),
+        collectExchangeRates(configLoader),
+    ]);
 
     // Partition into valid and failed prices, excluding proxy-only assets (submit: false)
     const allAssets = configLoader.getAllAssets();

--- a/mercata/services/oracle/src/types/index.ts
+++ b/mercata/services/oracle/src/types/index.ts
@@ -9,6 +9,16 @@ export interface RebaseConfig {
     factorHeaders?: string;       // Comma-separated header names that receive the resolved API key
 }
 
+export interface ExchangeRateConfig {
+    rateUrl: string;             // REST endpoint (e.g. Alchemy eth_call)
+    rateMethod?: string;         // HTTP method; defaults to GET. Use POST for JSON-RPC.
+    rateBody?: string;           // JSON body template for POST requests
+    rateParse: string;           // JSON path to extract the rate value (e.g., "result")
+    ratePrecision: string;       // Native precision of the raw value: "1000000000000000000" for WAD, "1000000" for 6-decimal
+    rateApiKeyEnvVar?: string;   // Environment variable for API key
+    rateHeaders?: string;        // Comma-separated header names
+}
+
 export interface Asset {
     targetAssetAddress: string;
     constantPrice?: number;
@@ -16,6 +26,7 @@ export interface Asset {
     equivalentAssets?: string[]; // Assets with equivalent prices (e.g., ["XAUT"] for XAU)
     submit?: boolean; // Whether to submit this asset to blockchain (default: true)
     rebase?: RebaseConfig; // Rebasing token config: price = underlyingPrice × factor / precision
+    exchangeRate?: ExchangeRateConfig; // On-chain exchange rate for yield-bearing tokens (event-only, no storage)
 }
 
 export interface BatchPriceResult {

--- a/mercata/services/oracle/src/types/index.ts
+++ b/mercata/services/oracle/src/types/index.ts
@@ -26,7 +26,7 @@ export interface Asset {
     equivalentAssets?: string[]; // Assets with equivalent prices (e.g., ["XAUT"] for XAU)
     submit?: boolean; // Whether to submit this asset to blockchain (default: true)
     rebase?: RebaseConfig; // Rebasing token config: price = underlyingPrice × factor / precision
-    exchangeRate?: ExchangeRateConfig; // On-chain exchange rate for yield-bearing tokens (event-only, no storage)
+    exchangeRate?: ExchangeRateConfig; // On-chain exchange rate for yield-bearing tokens
 }
 
 export interface BatchPriceResult {

--- a/mercata/services/oracle/src/utils/oraclePusher.ts
+++ b/mercata/services/oracle/src/utils/oraclePusher.ts
@@ -126,6 +126,21 @@ export async function pushRebaseFactors(factors: Array<{ targetAddress: string; 
     return result;
 }
 
+export async function pushExchangeRates(rates: Array<{ targetAddress: string; rate: bigint }>): Promise<TransactionResult> {
+    const callListArgs: CallListArg[] = [{
+        contract: { address: process.env.PRICE_ORACLE_ADDRESS!, name: "PriceOracle" },
+        method: "setExchangeRates",
+        args: {
+            assets: rates.map(r => r.targetAddress),
+            rates: rates.map(r => r.rate.toString())
+        },
+    }];
+
+    const result = await callListAndWait(callListArgs);
+    logInfo('OraclePusher', `Exchange rates pushed for ${rates.length} asset(s)`);
+    return result;
+}
+
 async function waitForTransaction(txHash: string): Promise<TransactionResult> {
     const startTime = Date.now();
 


### PR DESCRIPTION
## Summary
- Adds on-chain exchange rate tracking for yield-bearing tokens (rETH, wstETH, sUSDS, syrupUSDC)
- Oracle fetches protocol exchange rates via Alchemy `eth_call` and stores in `exchangeRates` mapping on PriceOracle
- Backend computes base yield APY from the mapping history table instead of USD price ratios
- Fixes rETH showing 0% base yield due to market noise in USD-derived ratios
- Adds 6 AAVE V3 aTokens (aWETH, aWBTC, aweETH, awstETH, aUSDC, aUSDT) — yield from `getReserveNormalizedIncome()` liquidity index
- For LST-based aTokens (aweETH, awstETH), composite APY = AAVE lending yield + underlying staking yield

## Yield Comparison — DeFiLlama (30-day window, annualized)

| Token | On-chain Rate APY | DeFiLlama | Old Method (USD ratio) |
|-------|-------------------|-----------|----------------------|
| rETH | 2.05% | 2.04% | 0.00% (clamped) |
| wstETH | 2.54% | 2.51% | 0.98% |
| sUSDS | 3.78% | 3.76% | 2.88% |
| syrupUSDC | 4.38% | 4.40% | 3.10% |
| aWETH | 1.71% | 1.75% | N/A |
| aWBTC | 0.00% | 0.005% | N/A |
| aweETH | 2.57% (composite) | 0.0001% + ~2.57% weETH | N/A |
| awstETH | 2.54% (composite) | 0.001% + ~2.54% wstETH | N/A |
| aUSDC | 2.16% | 2.43% | N/A |
| aUSDT | 1.92% | 2.08% | N/A |

Methodology matches DeFiLlama: both derive from on-chain accounting. DeFiLlama uses instantaneous `liquidityRate`; we use realized accumulation via `getReserveNormalizedIncome()` index ratio over 30-day window.

## Changes
- **PriceOracle.sol**: `exchangeRates` mapping, `setExchangeRates()`, `ExchangeRatesUpdated` event
- **Oracle service**: `fetchExchangeRate` via shared `fetchOnChainValue` helper, parallel `collectExchangeRates`, asset configs with Alchemy `eth_call` params
- **Backend**: `computeExchangeRateAPY` in earnYield helper, queries `exchangeRates` history mapping, composite yield for LST-based aTokens
- **Config**: 6 AAVE aToken configs with `rebase` (pricing) + `exchangeRate` (yield), weETH exchange rate via `getRate()`