### PR TITLE
Allow rebasing tokens in DepositRouter

### DIFF
--- a/mercata/ethereum/contracts/bridge/DepositRouter.sol
+++ b/mercata/ethereum/contracts/bridge/DepositRouter.sol
@@ -144,7 +144,8 @@ contract DepositRouter is
         uint256 depositedAmount = IERC20(token).balanceOf(safe) - balanceBefore;
 
         if (depositedAmount == 0) revert ZeroAmount();
-        if (depositedAmount < amount) revert FeesNotSupported();
+        uint256 negligibleAmount = 2;
+        if (depositedAmount + negligibleAmount < amount) revert FeesNotSupported();
 
         emit DepositRouted(
             token,


### PR DESCRIPTION
Fixes #6705

Allow depositedAmount to fall short of amount of transfer by 2 wei, permitting rebasing tokens in DepositRouter.

This requires a smart contract upgrade on Ethereum.

https://cursor.com/dashboard/shared-chats?shareId=deposit-failure-analysis-pmnScE5SDTTv

