### PR TITLE
add live yield vault tooling

### DIFF
--- a/mercata/contracts/scripts/README.md
+++ b/mercata/contracts/scripts/README.md
@@ -4,6 +4,23 @@ This directory contains utility scripts for the Mercata contracts system.
 
 ## Available Scripts
 
+### Yield Vault Live Tools
+**Location**: `yield-vault-live/`
+
+Read-only and direct-call tools for inspecting and exercising deployed
+`YieldVault` contracts on STRATO testnet/mainnet using an authenticated bearer
+token from `strato-auth`.
+
+- **Script**: `inspectLiveVault.js` - Inspect live vault state, mappings, and current recommended next calls
+- **Script**: `vaultDirectFlow.js` - Send direct calls such as strategy approval, deposit, deploy, return, and redeem
+
+**Usage**:
+```bash
+cd yield-vault-live
+node inspectLiveVault.js
+node vaultDirectFlow.js inspect
+```
+
 ### Token Transfer Script
 **Location**: `token-transfer/`
 
@@ -26,10 +43,14 @@ See the `token-transfer/README.md` for detailed documentation.
 ```
 scripts/
 ├── README.md                 # This file
-└── token-transfer/           # Token transfer utilities
-    ├── contestTransfer.js    # Transfer script
-    ├── README.md            # Documentation
-    └── env.example          # Sample environment config
+├── token-transfer/           # Token transfer utilities
+│   ├── contestTransfer.js    # Transfer script
+│   ├── README.md             # Documentation
+│   └── env.example           # Sample environment config
+└── yield-vault-live/         # Live deployed vault inspection/call tools
+    ├── common.js             # Shared auth/query/transaction helpers
+    ├── inspectLiveVault.js   # Read-only live state inspector
+    └── vaultDirectFlow.js    # Direct call CLI for live vault testing
 ```
 
 ## Adding New Scripts

--- a/mercata/contracts/scripts/yield-vault-live/README.md
+++ b/mercata/contracts/scripts/yield-vault-live/README.md
@@ -1,0 +1,43 @@
+# Yield Vault Live Tools
+
+Live inspection and direct-call scripts for deployed `YieldVault` contracts on
+STRATO testnet/mainnet.
+
+These scripts:
+- read a bearer token from `ACCESS_TOKEN` or `~/.secrets/stratoToken`
+- default to the testnet vault address `8c0f17df514efaee2baf1e59923fff700c5ca2b7`
+- talk directly to public STRATO endpoints
+
+## Scripts
+
+### `inspectLiveVault.js`
+
+Read-only inspector for the configured live vault.
+
+```bash
+node inspectLiveVault.js
+```
+
+### `vaultDirectFlow.js`
+
+CLI for direct live calls:
+
+```bash
+node vaultDirectFlow.js inspect
+node vaultDirectFlow.js set-strategy <strategyAddress>
+node vaultDirectFlow.js deposit <humanAmount> [receiverAddress]
+node vaultDirectFlow.js deploy <humanAmount> <strategyAddress>
+node vaultDirectFlow.js approve-return <humanAmount>
+node vaultDirectFlow.js return <humanAmount> <strategyAddress>
+node vaultDirectFlow.js redeem <humanShareAmount> [receiverAddress]
+node vaultDirectFlow.js profit-demo <depositHuman> <deployHuman> <returnHuman>
+```
+
+Useful environment variables:
+
+```bash
+NODE_URL=https://app.testnet.strato.nexus
+VAULT_ADDRESS=8c0f17df514efaee2baf1e59923fff700c5ca2b7
+ACTOR_ADDRESS=<optional-explicit-actor>
+ACCESS_TOKEN=<optional-bearer-token>
+```

--- a/mercata/contracts/scripts/yield-vault-live/README.md
+++ b/mercata/contracts/scripts/yield-vault-live/README.md
@@ -41,3 +41,57 @@ VAULT_ADDRESS=8c0f17df514efaee2baf1e59923fff700c5ca2b7
 ACTOR_ADDRESS=<optional-explicit-actor>
 ACCESS_TOKEN=<optional-bearer-token>
 ```
+
+## Live Test Sequence We Ran
+
+We exercised the live testnet vault at `8c0f17df514efaee2baf1e59923fff700c5ca2b7`
+using direct calls.
+
+### Simple successful flow
+
+Using the admin address as a temporary strategy:
+
+1. approve underlying to vault
+2. deposit `0.01 ETH`
+3. deploy `0.005 ETH`
+4. approve returned underlying
+5. return `0.006 ETH`
+6. redeem `0.01` shares
+
+Observed result:
+- `CapitalReturned` recognized `0.005 ETH` principal repayment and `0.001 ETH`
+  realized profit
+- redeeming `0.01` shares returned `0.011 ETH`
+
+### Multi-depositor / queue flow
+
+We then used a helper depositor contract as a second actor and ran:
+
+1. fund helper with `0.01 ETH`
+2. helper approves vault
+3. helper deposits `0.01 ETH`
+4. admin deposits additional `ETH`
+5. deploy most idle capital away
+6. helper calls `redeemOrQueue(...)`
+7. return liquidity
+8. call `processQueue(...)`
+9. claim processed assets
+
+## Perceived Anomaly
+
+The queue path is not obviously broken for a proper nonzero request id:
+- a later admin withdrawal request was created as `requestId = 1`
+- `processQueue(...)` processed that request
+- `claim(...)` then succeeded
+
+However, state cleanup after queue activity looks suspicious. In live state we
+observed combinations such as:
+
+- stale `requests[0]` / `requestOwner[0]` residue remaining
+- `queueHead = 1` while `queueTail = 0`
+- `totalQueuedShares > 0` after processed-and-claimed activity
+- partially cleared-looking request mapping rows
+
+So the current concern is not simply "queue never works", but rather that queue
+metadata cleanup and invariants may be inconsistent after mixed immediate and
+queued withdrawal activity.

--- a/mercata/contracts/scripts/yield-vault-live/common.js
+++ b/mercata/contracts/scripts/yield-vault-live/common.js
@@ -1,0 +1,163 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const https = require("https");
+
+const DEFAULT_BASE_URL = process.env.NODE_URL || "https://app.testnet.strato.nexus";
+const DEFAULT_VAULT_ADDRESS =
+  (process.env.VAULT_ADDRESS || "8c0f17df514efaee2baf1e59923fff700c5ca2b7")
+    .toLowerCase()
+    .replace(/^0x/, "");
+const WAD = 10n ** 18n;
+
+function normalizeAddress(value) {
+  return String(value || "").toLowerCase().replace(/^0x/, "");
+}
+
+function readToken() {
+  if (process.env.ACCESS_TOKEN) return process.env.ACCESS_TOKEN;
+  const tokenFile = path.join(os.homedir(), ".secrets", "stratoToken");
+  const raw = fs.readFileSync(tokenFile, "utf8");
+  return JSON.parse(raw).access_token;
+}
+
+function requestJson(method, url, token, body) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : null;
+    const req = https.request(
+      url,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          ...(payload ? { "Content-Length": Buffer.byteLength(payload) } : {}),
+        },
+      },
+      (res) => {
+        let responseBody = "";
+        res.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        res.on("end", () => {
+          let parsed = responseBody;
+          try {
+            parsed = responseBody ? JSON.parse(responseBody) : null;
+          } catch {
+            // keep raw text
+          }
+
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            const err = new Error(`HTTP ${res.statusCode}`);
+            err.statusCode = res.statusCode;
+            err.body = parsed;
+            reject(err);
+            return;
+          }
+
+          resolve(parsed);
+        });
+      }
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function buildSearchUrl(baseUrl, table, params = {}) {
+  const base = baseUrl.replace(/\/$/, "");
+  const url = new URL(`${base}/cirrus/search/${table}`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+async function cirrusSearch(baseUrl, token, table, params = {}) {
+  return requestJson("GET", buildSearchUrl(baseUrl, table, params), token);
+}
+
+async function getUser(baseUrl, token) {
+  const base = baseUrl.replace(/\/$/, "");
+  return requestJson("GET", `${base}/api/user/me`, token);
+}
+
+async function getVaultRow(baseUrl, token, vaultAddress = DEFAULT_VAULT_ADDRESS) {
+  const rows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault", {
+    address: `eq.${normalizeAddress(vaultAddress)}`,
+  });
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error(`Vault not found: ${vaultAddress}`);
+  }
+  return rows[0];
+}
+
+async function getTokenBalance(baseUrl, token, tokenAddress, userAddress) {
+  const rows = await cirrusSearch(baseUrl, token, "BlockApps-Token-_balances", {
+    address: `eq.${normalizeAddress(tokenAddress)}`,
+    key: `eq.${normalizeAddress(userAddress)}`,
+  });
+  return rows?.[0]?.value || "0";
+}
+
+async function sendFunctionTx(baseUrl, token, { contractName, contractAddress, method, args }) {
+  const base = baseUrl.replace(/\/$/, "");
+  const body = {
+    txs: [
+      {
+        type: "FUNCTION",
+        payload: {
+          contractName,
+          contractAddress: normalizeAddress(contractAddress),
+          method,
+          args,
+        },
+      },
+    ],
+    txParams: {
+      gasLimit: 32100000000,
+      gasPrice: 1,
+    },
+  };
+
+  return requestJson("POST", `${base}/bloc/v2.2/transaction/parallel?resolve=true`, token, body);
+}
+
+function parseHumanAmount(value) {
+  const [wholeRaw, fracRaw = ""] = String(value).trim().split(".");
+  const whole = wholeRaw || "0";
+  const frac = (fracRaw + "0".repeat(18)).slice(0, 18);
+  return (BigInt(whole) * WAD + BigInt(frac)).toString();
+}
+
+function formatWei(value, decimals = 4) {
+  const v = BigInt(value);
+  const sign = v < 0n ? "-" : "";
+  const abs = v < 0n ? -v : v;
+  const whole = abs / WAD;
+  const frac = (abs % WAD).toString().padStart(18, "0").slice(0, decimals);
+  const trimmed = frac.replace(/0+$/, "");
+  return `${sign}${whole}${trimmed ? "." + trimmed : ""}`;
+}
+
+function printJson(label, value) {
+  console.log(`\n## ${label}`);
+  console.log(JSON.stringify(value, null, 2));
+}
+
+module.exports = {
+  DEFAULT_BASE_URL,
+  DEFAULT_VAULT_ADDRESS,
+  normalizeAddress,
+  readToken,
+  requestJson,
+  cirrusSearch,
+  getUser,
+  getVaultRow,
+  getTokenBalance,
+  sendFunctionTx,
+  parseHumanAmount,
+  formatWei,
+  printJson,
+};

--- a/mercata/contracts/scripts/yield-vault-live/inspectLiveVault.js
+++ b/mercata/contracts/scripts/yield-vault-live/inspectLiveVault.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only inspector for a live YieldVault deployment on STRATO testnet/mainnet.
+ *
+ * Defaults to the live Helium ETH carry vault address:
+ *   0x8c0f17df514efaee2baf1e59923fff700c5ca2b7
+ *
+ * Auth:
+ * - ACCESS_TOKEN env var, or
+ * - ~/.secrets/stratoToken produced by `strato-auth`
+ */
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const https = require("https");
+
+const DEFAULT_BASE_URL = process.env.NODE_URL || "https://app.testnet.strato.nexus";
+const DEFAULT_VAULT = (process.env.VAULT_ADDRESS || "8c0f17df514efaee2baf1e59923fff700c5ca2b7")
+  .toLowerCase()
+  .replace(/^0x/, "");
+
+function readToken() {
+  if (process.env.ACCESS_TOKEN) return process.env.ACCESS_TOKEN;
+  const tokenFile = path.join(os.homedir(), ".secrets", "stratoToken");
+  const raw = fs.readFileSync(tokenFile, "utf8");
+  return JSON.parse(raw).access_token;
+}
+
+function getJson(url, token) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(new Error(`Failed to parse JSON from ${url}: ${error.message}\n${body}`));
+          }
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function pretty(value) {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+async function main() {
+  const token = readToken();
+  const base = DEFAULT_BASE_URL.replace(/\/$/, "");
+  const vault = DEFAULT_VAULT;
+
+  const vaultUrl = `${base}/cirrus/search/BlockApps-YieldVault?address=eq.${vault}`;
+  const strategyUrl = `${base}/cirrus/search/BlockApps-YieldVault-approvedStrategies?address=eq.${vault}`;
+  const debtUrl = `${base}/cirrus/search/BlockApps-YieldVault-strategyDebt?address=eq.${vault}`;
+  const queueUrl = `${base}/cirrus/search/BlockApps-YieldVault-requests?address=eq.${vault}`;
+  const ownerUrl = `${base}/cirrus/search/BlockApps-YieldVault-requestOwner?address=eq.${vault}`;
+  const claimUrl = `${base}/cirrus/search/BlockApps-YieldVault-claimableAssets?address=eq.${vault}`;
+  const shareBalUrl = `${base}/cirrus/search/BlockApps-YieldVault-_balances?address=eq.${vault}`;
+
+  const [vaultRows, strategyRows, debtRows, queueRows, ownerRows, claimRows, shareRows] =
+    await Promise.all([
+      getJson(vaultUrl, token),
+      getJson(strategyUrl, token),
+      getJson(debtUrl, token),
+      getJson(queueUrl, token),
+      getJson(ownerUrl, token),
+      getJson(claimUrl, token),
+      getJson(shareBalUrl, token),
+    ]);
+
+  if (!Array.isArray(vaultRows) || vaultRows.length === 0) {
+    console.error(`Vault ${vault} not found`);
+    process.exit(1);
+  }
+
+  const row = vaultRows[0];
+  const asset = row._asset;
+  const assetRows = await getJson(`${base}/cirrus/search/BlockApps-Token?address=eq.${asset}`, token);
+  const assetBalRows = await getJson(
+    `${base}/cirrus/search/BlockApps-Token-_balances?address=eq.${asset}&key=eq.${vault}`,
+    token
+  );
+
+  console.log("## Live Vault");
+  console.log(`address: ${row.address}`);
+  console.log(`name: ${row._name}`);
+  console.log(`symbol: ${row._symbol}`);
+  console.log(`asset: ${asset}`);
+  console.log(`asset_symbol: ${assetRows?.[0]?._symbol || "unknown"}`);
+  console.log(`owner: ${row._owner}`);
+  console.log(`paused: ${row._paused}`);
+  console.log(`vaultInitialized: ${row.vaultInitialized}`);
+  console.log(`underlyingDecimals: ${row._underlyingDecimals}`);
+  console.log(`totalSupply: ${row._totalSupply}`);
+  console.log(`deployedAssets: ${row.deployedAssets}`);
+  console.log(`minIdleBps: ${row.minIdleBps}`);
+  console.log(`queueHead: ${row.queueHead}`);
+  console.log(`queueTail: ${row.queueTail}`);
+  console.log(`nextRequestId: ${row.nextRequestId}`);
+  console.log(`totalQueuedShares: ${row.totalQueuedShares}`);
+  console.log(`totalClaimableAssets: ${row.totalClaimableAssets}`);
+  console.log(`idleAssetBalance: ${assetBalRows?.[0]?.value || "0"}`);
+  console.log("");
+
+  console.log("## Mappings");
+  console.log(`approvedStrategies: ${pretty(strategyRows)}`);
+  console.log(`strategyDebt: ${pretty(debtRows)}`);
+  console.log(`requests: ${pretty(queueRows)}`);
+  console.log(`requestOwner: ${pretty(ownerRows)}`);
+  console.log(`claimableAssets: ${pretty(claimRows)}`);
+  console.log(`shareBalances: ${pretty(shareRows)}`);
+  console.log("");
+
+  console.log("## Suggested Next Calls");
+  if (!strategyRows.length) {
+    console.log("- `setStrategyApproval(strategyAddress, true)`");
+  }
+  if ((row.minIdleBps || 0) === 0) {
+    console.log("- `setMinIdleBps(<bufferBps>)`");
+  }
+  if (String(row._totalSupply) === "0") {
+    console.log("- first depositor(s): `deposit(assets, receiver)`");
+    console.log("- after deposits and strategy approval: owner `deployCapital(strategy, assets)`");
+  } else {
+    if (String(row.totalQueuedShares) !== "0") {
+      console.log("- queue exists: return liquidity, then `processQueue(maxRequests, maxAssets)`");
+      console.log("- queued users then call `claim(receiver)`");
+    } else if (strategyRows.length && String(row.deployedAssets) === "0") {
+      console.log("- if there is idle to deploy: owner `deployCapital(strategy, assets)`");
+    } else if (String(row.deployedAssets) !== "0") {
+      console.log("- strategy running: later `returnCapital(strategy, assetsReturned)`");
+      console.log("- if assetsReturned > strategyDebt[strategy], excess is realized profit");
+      console.log("- if strategy under-returns, use `reportStrategyLoss(strategy, loss)`");
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/mercata/contracts/scripts/yield-vault-live/vaultDirectFlow.js
+++ b/mercata/contracts/scripts/yield-vault-live/vaultDirectFlow.js
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const {
+  DEFAULT_BASE_URL,
+  DEFAULT_VAULT_ADDRESS,
+  normalizeAddress,
+  readToken,
+  cirrusSearch,
+  getUser,
+  getVaultRow,
+  getTokenBalance,
+  sendFunctionTx,
+  parseHumanAmount,
+  formatWei,
+  printJson,
+} = require("./common");
+
+function usage() {
+  console.log(`
+Usage:
+  node scripts/yield-vault-live/vaultDirectFlow.js inspect
+  node scripts/yield-vault-live/vaultDirectFlow.js set-strategy <strategyAddress>
+  node scripts/yield-vault-live/vaultDirectFlow.js deposit <humanAmount> [receiverAddress]
+  node scripts/yield-vault-live/vaultDirectFlow.js deploy <humanAmount> <strategyAddress>
+  node scripts/yield-vault-live/vaultDirectFlow.js approve-return <humanAmount>
+  node scripts/yield-vault-live/vaultDirectFlow.js return <humanAmount> <strategyAddress>
+  node scripts/yield-vault-live/vaultDirectFlow.js redeem <humanShareAmount> [receiverAddress]
+  node scripts/yield-vault-live/vaultDirectFlow.js demo <depositHuman> <deployHuman> <returnHuman>
+  node scripts/yield-vault-live/vaultDirectFlow.js profit-demo <depositHuman> <deployHuman> <returnHuman>
+
+Notes:
+  - Defaults to vault ${DEFAULT_VAULT_ADDRESS}
+  - Reads bearer token from ~/.secrets/stratoToken unless ACCESS_TOKEN is set
+  - Uses ACTOR_ADDRESS if provided, otherwise tries /api/user/me
+  - 'approve-return' approves the vault to pull underlying back from the current actor
+  - 'demo' assumes strategyAddress == current actor address
+  - 'profit-demo' also assumes strategyAddress == current actor address and saves state after each step
+`);
+}
+
+async function resolveActorAddress(baseUrl, token) {
+  if (process.env.ACTOR_ADDRESS) {
+    return normalizeAddress(process.env.ACTOR_ADDRESS);
+  }
+  const user = await getUser(baseUrl, token);
+  return normalizeAddress(user.userAddress);
+}
+
+async function fetchState(baseUrl, token, actorAddress, vaultAddress) {
+  const vault = await getVaultRow(baseUrl, token, vaultAddress);
+  const strategyRows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault-approvedStrategies", {
+    address: `eq.${vaultAddress}`,
+  });
+  const debtRows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault-strategyDebt", {
+    address: `eq.${vaultAddress}`,
+  });
+  const claimRows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault-claimableAssets", {
+    address: `eq.${vaultAddress}`,
+  });
+  const shareRows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault-_balances", {
+    address: `eq.${vaultAddress}`,
+  });
+  const assetToken = await cirrusSearch(baseUrl, token, "BlockApps-Token", {
+    address: `eq.${vault._asset}`,
+  });
+  const vaultAssetBalance = await getTokenBalance(baseUrl, token, vault._asset, vaultAddress);
+  const actorAssetBalance = await getTokenBalance(baseUrl, token, vault._asset, actorAddress);
+  const actorShareBalanceRows = await cirrusSearch(baseUrl, token, "BlockApps-YieldVault-_balances", {
+    address: `eq.${vaultAddress}`,
+    key: `eq.${actorAddress}`,
+  });
+
+  return {
+    capturedAt: new Date().toISOString(),
+    actor: {
+      address: actorAddress,
+      assetBalance: actorAssetBalance,
+      assetBalanceHuman: formatWei(actorAssetBalance),
+      shareBalance: actorShareBalanceRows?.[0]?.value || "0",
+      shareBalanceHuman: actorShareBalanceRows?.[0]?.value ? formatWei(actorShareBalanceRows[0].value) : "0",
+    },
+    vault,
+    approvedStrategies: strategyRows,
+    strategyDebt: debtRows,
+    claimableAssets: claimRows,
+    shareBalances: shareRows,
+    assetToken,
+    vaultAssetBalance,
+    vaultAssetBalanceHuman: formatWei(vaultAssetBalance),
+  };
+}
+
+function printState(state) {
+  printJson("vault", state.vault);
+  printJson("approvedStrategies", state.approvedStrategies);
+  printJson("strategyDebt", state.strategyDebt);
+  printJson("claimableAssets", state.claimableAssets);
+  printJson("shareBalances", state.shareBalances);
+  printJson("assetToken", state.assetToken);
+
+  console.log("\n## actor");
+  console.log(`address: ${state.actor.address}`);
+  console.log(`assetBalance: ${state.actor.assetBalanceHuman}`);
+  console.log(`shareBalance: ${state.actor.shareBalanceHuman}`);
+  console.log(`vaultAssetBalance: ${state.vaultAssetBalanceHuman}`);
+}
+
+async function inspect(baseUrl, token, actorAddress, vaultAddress) {
+  const state = await fetchState(baseUrl, token, actorAddress, vaultAddress);
+  printState(state);
+}
+
+function makeRunDir() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const dir = path.join(process.cwd(), "scripts", "yield-vault-live", "runs", stamp);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, step, extra = {}) {
+  const state = await fetchState(baseUrl, token, actorAddress, vaultAddress);
+  const payload = { step, ...extra, state };
+  const file = path.join(runDir, `${String(step).padStart(2, "0")}.json`);
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2));
+  console.log(`Saved snapshot: ${file}`);
+  return payload;
+}
+
+async function setStrategy(baseUrl, token, vaultAddress, strategyAddress) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "YieldVault",
+    contractAddress: vaultAddress,
+    method: "setStrategyApproval",
+    args: { strategy: strategyAddress, approved: true },
+  });
+  printJson("setStrategyApproval result", res);
+}
+
+async function deposit(baseUrl, token, actorAddress, vaultAddress, humanAmount, receiverAddress) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "YieldVault",
+    contractAddress: vaultAddress,
+    method: "deposit",
+    args: {
+      assets: parseHumanAmount(humanAmount),
+      receiver: receiverAddress || actorAddress,
+    },
+  });
+  printJson("deposit result", res);
+}
+
+async function deploy(baseUrl, token, vaultAddress, humanAmount, strategyAddress) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "YieldVault",
+    contractAddress: vaultAddress,
+    method: "deployCapital",
+    args: {
+      to: strategyAddress,
+      assets: parseHumanAmount(humanAmount),
+    },
+  });
+  printJson("deployCapital result", res);
+}
+
+async function approveReturn(baseUrl, token, vaultAddress, assetAddress, humanAmount) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "Token",
+    contractAddress: assetAddress,
+    method: "approve",
+    args: {
+      spender: vaultAddress,
+      value: parseHumanAmount(humanAmount),
+    },
+  });
+  printJson("asset approve result", res);
+}
+
+async function returnCapital(baseUrl, token, vaultAddress, humanAmount, strategyAddress) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "YieldVault",
+    contractAddress: vaultAddress,
+    method: "returnCapital",
+    args: {
+      from: strategyAddress,
+      assets: parseHumanAmount(humanAmount),
+    },
+  });
+  printJson("returnCapital result", res);
+}
+
+async function redeem(baseUrl, token, actorAddress, vaultAddress, humanShareAmount, receiverAddress) {
+  const res = await sendFunctionTx(baseUrl, token, {
+    contractName: "YieldVault",
+    contractAddress: vaultAddress,
+    method: "redeem",
+    args: {
+      shares: parseHumanAmount(humanShareAmount),
+      receiver: receiverAddress || actorAddress,
+      owner_: actorAddress,
+    },
+  });
+  printJson("redeem result", res);
+}
+
+async function profitDemo(baseUrl, token, actorAddress, vaultAddress, vault, depositHuman, deployHuman, returnHuman) {
+  const strategy = actorAddress;
+  const runDir = makeRunDir();
+  console.log(`Using actor as temporary strategy: ${strategy}`);
+  console.log(`Saving snapshots under: ${runDir}`);
+
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 0, { label: "before" });
+
+  await setStrategy(baseUrl, token, vaultAddress, strategy);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 1, {
+    label: "after setStrategyApproval",
+    action: { method: "setStrategyApproval", strategy, approved: true },
+  });
+
+  await approveReturn(baseUrl, token, vaultAddress, normalizeAddress(vault._asset), depositHuman);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 2, {
+    label: "after deposit approve",
+    action: { method: "Token.approve", valueHuman: depositHuman },
+  });
+
+  await deposit(baseUrl, token, actorAddress, vaultAddress, depositHuman, actorAddress);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 3, {
+    label: "after deposit",
+    action: { method: "deposit", assetsHuman: depositHuman },
+  });
+
+  await deploy(baseUrl, token, vaultAddress, deployHuman, strategy);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 4, {
+    label: "after deployCapital",
+    action: { method: "deployCapital", assetsHuman: deployHuman, strategy },
+  });
+
+  await approveReturn(baseUrl, token, vaultAddress, normalizeAddress(vault._asset), returnHuman);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 5, {
+    label: "after return approve",
+    action: { method: "Token.approve", valueHuman: returnHuman },
+  });
+
+  await returnCapital(baseUrl, token, vaultAddress, returnHuman, strategy);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 6, {
+    label: "after returnCapital",
+    action: { method: "returnCapital", assetsHuman: returnHuman, strategy },
+  });
+
+  await redeem(baseUrl, token, actorAddress, vaultAddress, depositHuman, actorAddress);
+  await saveSnapshot(baseUrl, token, actorAddress, vaultAddress, runDir, 7, {
+    label: "after redeem",
+    action: { method: "redeem", sharesHuman: depositHuman },
+  });
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (!command) {
+    usage();
+    process.exit(1);
+  }
+
+  const baseUrl = DEFAULT_BASE_URL;
+  const vaultAddress = DEFAULT_VAULT_ADDRESS;
+  const token = readToken();
+  const actorAddress = await resolveActorAddress(baseUrl, token);
+  const vault = await getVaultRow(baseUrl, token, vaultAddress);
+
+  switch (command) {
+    case "inspect":
+      await inspect(baseUrl, token, actorAddress, vaultAddress);
+      break;
+
+    case "set-strategy":
+      if (!args[0]) throw new Error("strategyAddress required");
+      await setStrategy(baseUrl, token, vaultAddress, normalizeAddress(args[0]));
+      break;
+
+    case "deposit":
+      if (!args[0]) throw new Error("humanAmount required");
+      await deposit(baseUrl, token, actorAddress, vaultAddress, args[0], normalizeAddress(args[1] || actorAddress));
+      break;
+
+    case "deploy":
+      if (!args[0] || !args[1]) throw new Error("humanAmount and strategyAddress required");
+      await deploy(baseUrl, token, vaultAddress, args[0], normalizeAddress(args[1]));
+      break;
+
+    case "approve-return":
+      if (!args[0]) throw new Error("humanAmount required");
+      await approveReturn(baseUrl, token, vaultAddress, normalizeAddress(vault._asset), args[0]);
+      break;
+
+    case "return":
+      if (!args[0] || !args[1]) throw new Error("humanAmount and strategyAddress required");
+      await returnCapital(baseUrl, token, vaultAddress, args[0], normalizeAddress(args[1]));
+      break;
+
+    case "redeem":
+      if (!args[0]) throw new Error("humanShareAmount required");
+      await redeem(baseUrl, token, actorAddress, vaultAddress, args[0], normalizeAddress(args[1] || actorAddress));
+      break;
+
+    case "demo": {
+      if (!args[0] || !args[1] || !args[2]) {
+        throw new Error("demo requires depositHuman deployHuman returnHuman");
+      }
+      const strategy = actorAddress;
+      console.log(`Using actor as temporary strategy: ${strategy}`);
+      await setStrategy(baseUrl, token, vaultAddress, strategy);
+      await deposit(baseUrl, token, actorAddress, vaultAddress, args[0], actorAddress);
+      await deploy(baseUrl, token, vaultAddress, args[1], strategy);
+      await approveReturn(baseUrl, token, vaultAddress, normalizeAddress(vault._asset), args[2]);
+      await returnCapital(baseUrl, token, vaultAddress, args[2], strategy);
+      await redeem(baseUrl, token, actorAddress, vaultAddress, args[0], actorAddress);
+      break;
+    }
+
+    case "profit-demo": {
+      if (!args[0] || !args[1] || !args[2]) {
+        throw new Error("profit-demo requires depositHuman deployHuman returnHuman");
+      }
+      await profitDemo(baseUrl, token, actorAddress, vaultAddress, vault, args[0], args[1], args[2]);
+      break;
+    }
+
+    default:
+      usage();
+      process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  const message = error?.body ? JSON.stringify(error.body, null, 2) : error.message || String(error);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add read-only tooling to inspect a deployed YieldVault on testnet/mainnet
- add direct-call tooling to run deposits, deploys, returns, and redeems against a live vault
- document the new scripts under mercata/contracts/scripts

## Test plan
- node mercata/contracts/scripts/yield-vault-live/inspectLiveVault.js
- node --check mercata/contracts/scripts/yield-vault-live/common.js
- node --check mercata/contracts/scripts/yield-vault-live/inspectLiveVault.js
- node --check mercata/contracts/scripts/yield-vault-live/vaultDirectFlow.js

Made with [Cursor](https://cursor.com)