### PR TITLE
feat(earn): background cache for token-apys endpoint

### DIFF
--- a/mercata/backend/src/api/controllers/earn.controller.ts
+++ b/mercata/backend/src/api/controllers/earn.controller.ts
@@ -1,9 +1,15 @@
 import { Request, Response, NextFunction } from "express";
 import { getTokenApys } from "../services/earn.service";
+import { getCachedTokenApys } from "../services/earn.cache";
 
 export default class EarnController {
   static async getTokenApys(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const cached = getCachedTokenApys();
+      if (cached) {
+        res.json(cached);
+        return;
+      }
       const result = await getTokenApys(req.accessToken);
       res.json(result);
     } catch (error: any) {

--- a/mercata/backend/src/api/services/earn.cache.ts
+++ b/mercata/backend/src/api/services/earn.cache.ts
@@ -1,0 +1,40 @@
+import { TokenApyEntry } from "@mercata/shared-types";
+import { getServiceToken } from "../../utils/authHelper";
+import { getTokenApys } from "./earn.service";
+
+let cachedApys: TokenApyEntry[] | null = null;
+let refreshTimer: NodeJS.Timeout | null = null;
+let refreshInFlight: Promise<void> | null = null;
+
+const REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+export const getCachedTokenApys = (): TokenApyEntry[] | null => cachedApys;
+
+async function refreshTokenApysCache(): Promise<void> {
+  if (refreshInFlight) return;
+  refreshInFlight = (async () => {
+    try {
+      const token = await getServiceToken();
+      cachedApys = await getTokenApys(token);
+      console.log(`[earn-cache] Refreshed token-apys cache (${cachedApys.length} tokens) at ${new Date().toISOString()}`);
+    } catch (error) {
+      console.error("[earn-cache] Failed to refresh token-apys cache:", error);
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
+export function startTokenApysRefresh(intervalMs: number = REFRESH_INTERVAL_MS): void {
+  if (refreshTimer) return;
+  refreshTokenApysCache();
+  refreshTimer = setInterval(refreshTokenApysCache, intervalMs);
+}
+
+export function stopTokenApysRefresh(): void {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}

--- a/mercata/backend/src/app.ts
+++ b/mercata/backend/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import routes from "./api/routes";
 import { initOpenIdConfig, initNetworkConfig } from "./config/config";
 import { errorHandler, notFoundHandler } from "./api/middleware/errorHandler";
+import { startTokenApysRefresh } from "./api/services/earn.cache";
 
 const PORT = process.env.PORT || 3001;
 
@@ -32,6 +33,7 @@ app.use(errorHandler);
     await initNetworkConfig();
     app.listen(PORT, () => {
       console.log(`Server running at http://localhost:${PORT}`);
+      startTokenApysRefresh();
     });
   } catch (error) {
     console.error("Failed to initialize server:", error);


### PR DESCRIPTION
## Summary
- Adds 30-minute background refresh cache for `earn/token-apys`
- After server boot, a background job populates the cache using a service token — all requests served instantly from memory
- If a refresh fails, stale data keeps being served
- Supersedes #6720 (parallelization approach)

## Benchmark results

Both servers pointed at mainnet (`NODE_URL=https://app.strato.nexus`), output identical (25 tokens, diff verified).

| | Pre-cache (develop) | Post-cache (this PR) |
|---|---|---|
| Run 1 | 5.36s | 0.003s |
| Run 2 | 2.91s | 0.002s |
| Run 3 | 4.33s | 0.002s |
| Run 4 | 3.03s | 0.002s |
| **Median** | **3.68s** | **0.002s** |

**~1800x faster** — requests served from in-memory cache, refreshed every 30 minutes.