### PR TITLE
Show "-" instead of "$0.00" for unpriced tokens

### DIFF
--- a/mercata/ui/src/components/dashboard/AssetCard.tsx
+++ b/mercata/ui/src/components/dashboard/AssetCard.tsx
@@ -21,7 +21,7 @@ interface AssetCardProps {
 const AssetCard = ({ id, name, symbol, price, deposit, collateralBalance, image, customDecimals }: AssetCardProps) => {
   // Helper function to safely format Wei values
   const formatWeiValue = (value: string, decimals: number, isPrice = false): string => {
-    if (!value || value === "0") return isPrice ? "$0.00" : "0.00";
+    if (!value || value === "0") return isPrice ? "-" : "0.00";
     
     try {
       if (isPrice) {
@@ -31,14 +31,14 @@ const AssetCard = ({ id, name, symbol, price, deposit, collateralBalance, image,
         const priceInWei = BigInt(priceString);
         const priceInEther = formatUnits(priceInWei, 18);
         const finalPrice = parseFloat(priceInEther);
-        return finalPrice > 0 ? `$${finalPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "$0.00";
+        return finalPrice > 0 ? `$${finalPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "-";
       } else {
         // Handle regular Wei values
         const formatted = formatUnits(BigInt(value), decimals);
         return formatNumberForMobile(formatted);
       }
     } catch (error) {
-      return isPrice ? "$0.00" : "0.00";
+      return isPrice ? "-" : "0.00";
     }
   };
 

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -187,7 +187,7 @@ const AssetsList = ({
                       </td>
                       <td className="hidden md:table-cell py-4 px-4 whitespace-nowrap text-right">
                         <p className="font-medium text-foreground">
-                          {!asset?.price
+                          {!asset?.price || asset.price === "0"
                             ? "-"
                             : formatBalance(asset.price, undefined, 18, 2, 2, true)}
                         </p>


### PR DESCRIPTION
## Summary

Tokens like BOOE that have no price in the oracle were showing `$0.00` on the portfolio page. Now they show `-` instead.

### Where it applies
- **Price column** in the Earning Assets table (`AssetsList.tsx`) — treats `price === "0"` as no price
- **Price row** in the asset card view (`AssetCard.tsx`) — all zero/missing price paths now return `-`

### Not changed
- Backend still defaults missing oracle prices to `"0"` — this is correct for value calculations
- Value column already shows `-` for zero values
- `formatBalance` utility unchanged

https://claude.ai/code/session_01X1DfRLt1AJ4hTMc6tfbNUU