### PR TITLE
Warning for transfers to external addresses

### DIFF
--- a/mercata/backend/src/api/controllers/tokens.controller.ts
+++ b/mercata/backend/src/api/controllers/tokens.controller.ts
@@ -12,6 +12,7 @@ import {
   getVoucherBalance,
   getTransferableTokens,
   getTokenStats,
+  getAccountNonce,
 } from "../services/tokens.service";
 import {
   validateAddressArgs,
@@ -211,6 +212,27 @@ class TokensController {
 
       const stats = await getTokenStats(accessToken);
       res.status(RestStatus.OK).json(stats);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async checkRecipient(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+      const address = req.query.address as string;
+
+      if (!address) {
+        res.status(400).json({ error: "address query parameter is required" });
+        return;
+      }
+
+      const nonce = await getAccountNonce(accessToken, address);
+      res.status(RestStatus.OK).json({ nonce });
     } catch (error) {
       next(error);
     }

--- a/mercata/backend/src/api/routes/tokens.routes.ts
+++ b/mercata/backend/src/api/routes/tokens.routes.ts
@@ -93,6 +93,31 @@ router.get("/stats", authHandler.authorizeRequest(true), TokensController.getSta
 
 /**
  * @openapi
+ * /tokens/check-recipient:
+ *   get:
+ *     summary: Check whether a recipient address has activity on STRATO
+ *     tags: [Tokens]
+ *     parameters:
+ *       - name: address
+ *         in: query
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Recipient account nonce (0 = no activity)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 nonce:
+ *                   type: integer
+ */
+router.get("/check-recipient", authHandler.authorizeRequest(), TokensController.checkRecipient);
+
+/**
+ * @openapi
  * /tokens/{address}:
  *   get:
  *     summary: Fetch token metadata by address

--- a/mercata/backend/src/api/services/tokens.service.ts
+++ b/mercata/backend/src/api/services/tokens.service.ts
@@ -1,4 +1,4 @@
-import { cirrus, strato } from "../../utils/mercataApiHelper";
+import { cirrus, strato, eth } from "../../utils/mercataApiHelper";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
 import { usc } from "../../utils/importer";
@@ -402,6 +402,23 @@ export const getVoucherBalance = async (
   const rawValue = response.data?.[0]?.balance ?? "0";
   const voucherAsUsdstWei = (BigInt(rawValue) * 100n).toString();
   return voucherAsUsdstWei;
+};
+
+/**
+ * Check whether a recipient address exists on the STRATO network.
+ * Returns the account nonce (0 = no activity).
+ */
+export const getAccountNonce = async (
+  accessToken: string,
+  recipientAddress: string
+): Promise<number> => {
+  const normalizedAddr = recipientAddress.toLowerCase().replace(/^0x/, "");
+  const result = await eth.get(accessToken, "/account", {
+    params: { address: normalizedAddr },
+  }).catch(() => ({ data: [] }));
+
+  const accounts = Array.isArray(result.data) ? result.data : [];
+  return accounts[0]?.nonce ?? 0;
 };
 
 /**

--- a/mercata/ui/src/pages/Transfer.tsx
+++ b/mercata/ui/src/pages/Transfer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { Link } from "react-router-dom";
 import DashboardSidebar from "../components/dashboard/DashboardSidebar";
 import DashboardHeader from "../components/dashboard/DashboardHeader";
@@ -50,8 +50,6 @@ const Transfer = () => {
   const [showInactiveTokens, setShowInactiveTokens] = useState(false);
   const [nonceWarning, setNonceWarning] = useState(false);
   const [nonceOverride, setNonceOverride] = useState(false);
-  const [checkingNonce, setCheckingNonce] = useState(false);
-  const nonceAbortRef = useRef<AbortController | null>(null);
 
   const maxAmount = useMemo(() => {
     if (!fromAsset) return "0";
@@ -99,29 +97,18 @@ const Transfer = () => {
   useEffect(() => {
     setNonceWarning(false);
     setNonceOverride(false);
-
     if (!recipient || recipientError || !isLoggedIn) return;
 
-    nonceAbortRef.current?.abort();
     const controller = new AbortController();
-    nonceAbortRef.current = controller;
-
-    setCheckingNonce(true);
     api
       .get<{ nonce: number }>("/tokens/check-recipient", {
         params: { address: recipient },
         signal: controller.signal,
       })
       .then(({ data }) => {
-        if (!controller.signal.aborted && data.nonce === 0) {
-          setNonceWarning(true);
-        }
+        if (data.nonce === 0) setNonceWarning(true);
       })
-      .catch(() => {})
-      .finally(() => {
-        if (!controller.signal.aborted) setCheckingNonce(false);
-      });
-
+      .catch(() => {});
     return () => controller.abort();
   }, [recipient, recipientError, isLoggedIn]);
 
@@ -429,11 +416,10 @@ const Transfer = () => {
                 !!recipientError ||
                 !!feeError ||
                 swapLoading ||
-                checkingNonce ||
-                (!!nonceWarning && !nonceOverride)
+                (nonceWarning && !nonceOverride)
               }
             >
-              {swapLoading ? <span>Processing…</span> : checkingNonce ? "Checking recipient…" : "Transfer"}
+              {swapLoading ? <span>Processing…</span> : "Transfer"}
             </Button>
           </div>
 

--- a/mercata/ui/src/pages/Transfer.tsx
+++ b/mercata/ui/src/pages/Transfer.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { Link } from "react-router-dom";
 import DashboardSidebar from "../components/dashboard/DashboardSidebar";
 import DashboardHeader from "../components/dashboard/DashboardHeader";
 import MobileBottomNav from "../components/dashboard/MobileBottomNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Token } from "@/interface";
 
 import { useUser } from "@/context/UserContext";
@@ -14,13 +16,14 @@ import TransferConfirmationModal from "../components/TransferConfirmationModal";
 import BulkTransferModal from "../components/BulkTransferModal";
 import { safeParseUnits, roundToDecimals, addCommasToInput, formatBalance, formatUnits } from "@/utils/numberUtils";
 import GuestSignInBanner from "@/components/ui/GuestSignInBanner";
+import { api } from "@/lib/axios";
 
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
-import { ChevronDown, Upload } from "lucide-react";
+import { ChevronDown, Upload, AlertTriangle } from "lucide-react";
 import { handleRecipientAddress, handleAmountInputChange, computeMaxTransferable } from "@/utils/transferValidation";
 import { sortTokensCompareFn } from "@/lib/tokenPriority";
 
@@ -45,6 +48,10 @@ const Transfer = () => {
   const [recipientError, setRecipientError] = useState("");
   const [feeError, setFeeError] = useState("");
   const [showInactiveTokens, setShowInactiveTokens] = useState(false);
+  const [nonceWarning, setNonceWarning] = useState(false);
+  const [nonceOverride, setNonceOverride] = useState(false);
+  const [checkingNonce, setCheckingNonce] = useState(false);
+  const nonceAbortRef = useRef<AbortController | null>(null);
 
   const maxAmount = useMemo(() => {
     if (!fromAsset) return "0";
@@ -87,6 +94,36 @@ const Transfer = () => {
       fetchUsdstBalance();
     }
   }, [isLoggedIn, fetchUserTokens, fetchUsdstBalance]);
+
+  // Check recipient nonce when a valid address is entered
+  useEffect(() => {
+    setNonceWarning(false);
+    setNonceOverride(false);
+
+    if (!recipient || recipientError || !isLoggedIn) return;
+
+    nonceAbortRef.current?.abort();
+    const controller = new AbortController();
+    nonceAbortRef.current = controller;
+
+    setCheckingNonce(true);
+    api
+      .get<{ nonce: number }>("/tokens/check-recipient", {
+        params: { address: recipient },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (!controller.signal.aborted && data.nonce === 0) {
+          setNonceWarning(true);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!controller.signal.aborted) setCheckingNonce(false);
+      });
+
+    return () => controller.abort();
+  }, [recipient, recipientError, isLoggedIn]);
 
   const handleConfirmTransfer = async () => {
     if (!fromAsset || !recipient || !fromAmount) return;
@@ -292,6 +329,31 @@ const Transfer = () => {
                 disabled={guestMode}
               />
               {recipientError && <span className="text-red-600 text-sm">{recipientError}</span>}
+              {nonceWarning && !recipientError && (
+                <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-3">
+                  <div className="flex items-start gap-2 text-amber-800 dark:text-amber-300 text-sm">
+                    <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                    <div>
+                      <p>
+                        This address has no transaction history on the STRATO network.
+                        If you are trying to withdraw to an external chain (e.g. Ethereum),
+                        please use the{" "}
+                        <Link to="/dashboard/withdrawals?tab=bridge-out" className="font-medium underline">
+                          Withdraw page
+                        </Link>{" "}
+                        instead.
+                      </p>
+                      <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
+                        <Checkbox
+                          checked={nonceOverride}
+                          onCheckedChange={(v) => setNonceOverride(v === true)}
+                        />
+                        <span>I understand — proceed with this transfer</span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Amount */}
@@ -366,10 +428,12 @@ const Transfer = () => {
                 !!amountError ||
                 !!recipientError ||
                 !!feeError ||
-                swapLoading
+                swapLoading ||
+                checkingNonce ||
+                (!!nonceWarning && !nonceOverride)
               }
             >
-              {swapLoading ? <span>Processing…</span> : "Transfer"}
+              {swapLoading ? <span>Processing…</span> : checkingNonce ? "Checking recipient…" : "Transfer"}
             </Button>
           </div>
 


### PR DESCRIPTION
Fixes #6730 

A warning for the Transfer page when the recipient address has no STRATO transactions on this network (account nonce=0). Links to the suggested Withdraw tab, as this is what the affected users were trying to accomplish.

<img width="3188" height="1548" alt="image" src="https://github.com/user-attachments/assets/5565f076-59e5-4c28-b7ec-4ec8832b7dd9" />