### PR TITLE
perf(earn): reduce API calls in getTokenApys

### DIFF
--- a/mercata/backend/src/api/helpers/earnRewards.helper.ts
+++ b/mercata/backend/src/api/helpers/earnRewards.helper.ts
@@ -1,0 +1,177 @@
+import stakeSemanticsConfig from "../services/rewardsStakeSemantics.json";
+import { safeBigInt } from "./vaultPerformance.helper";
+import { constants } from "../../config/constants";
+
+const { DECIMALS, BPS_DIVISOR } = constants;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const APY_UNAVAILABLE = "-";
+const CATA_PRICE_USD = 0.25;
+const SECONDS_PER_YEAR = 86400 * 365;
+
+const STAKE_SEMANTICS = stakeSemanticsConfig as any;
+const toAddressSet = (keys: string[]) => new Set(keys.map(normalizeAddress));
+const USD_NOTIONAL_SWAP_SOURCES = toAddressSet(STAKE_SEMANTICS.usd_notional.swapSources);
+const USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES = toAddressSet(STAKE_SEMANTICS.usd_notional.depositCompletedSources);
+const USD_NOTIONAL_AMOUNT_USD_SOURCES = toAddressSet(STAKE_SEMANTICS.usd_notional.amountUsdSources);
+const TOKEN_UNITS_SOURCES = toAddressSet(STAKE_SEMANTICS.token_units.lpMintBurnSources);
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+export function normalizeAddress(value?: string | null): string {
+  return (value ?? "").toLowerCase().replace(/^0x/, "");
+}
+
+export function isPositiveApy(s: string | null | undefined): s is string {
+  return !!s && s !== APY_UNAVAILABLE && parseFloat(s) > 0;
+}
+
+function getPriceForAddress(priceMap: Map<string, string>, address?: string | null): string | null {
+  if (!address) return null;
+  return priceMap.get(address) ?? priceMap.get(normalizeAddress(address)) ?? null;
+}
+
+export function toUsdValue(amountWei: string, priceWei: string): string {
+  const amount = BigInt(amountWei || "0");
+  const price = BigInt(priceWei || "0");
+  if (amount === 0n || price === 0n) return "0";
+  return ((amount * price) / DECIMALS).toString();
+}
+
+export function parseMappingValue(raw: string): any | null {
+  try {
+    const parsed = JSON.parse(raw || "{}");
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Reward activity builders ──────────────────────────────────────────────────
+
+export function buildRewardActivitiesFromMappings(
+  activityCfgById: Map<string, any>,
+  activityStateById: Map<string, any>,
+  pricingCtx: {
+    priceMap: Map<string, string>;
+    mTokenAddress: string | null;
+    sTokenAddress: string | null;
+    vaultShareTokenAddress: string | null;
+    saveUsdstVaultAddress: string | null;
+  },
+): any[] {
+  const saveUsdstSource = normalizeAddress(pricingCtx.saveUsdstVaultAddress);
+  const activities: any[] = [];
+  for (const [activityId, activity] of activityCfgById.entries()) {
+    const state = activityStateById.get(activityId);
+    const sourceContract = String(activity?.sourceContract ?? "");
+    const totalStake = String(state?.totalStake ?? "0");
+    const name = String(activity?.name ?? "");
+    const emissionRate = String(activity?.emissionRate ?? "0");
+
+    const { stakeAssetAddress, totalStakeUsd } = computeRewardStakeUsd(sourceContract, name, totalStake, pricingCtx, saveUsdstSource);
+
+    activities.push({
+      activityId: Number(activityId), name, emissionRate, sourceContract, stakeAssetAddress, totalStake, totalStakeUsd,
+      _srcNorm: normalizeAddress(sourceContract),
+      _stakeNorm: normalizeAddress(stakeAssetAddress),
+    });
+  }
+  return activities;
+}
+
+function computeRewardStakeUsd(
+  sourceContractRaw: string, name: string, totalStake: string,
+  ctx: { priceMap: Map<string, string>; mTokenAddress: string | null; sTokenAddress: string | null; vaultShareTokenAddress: string | null },
+  saveUsdstSource: string,
+): { stakeAssetAddress: string | null; totalStakeUsd: string | null } {
+  const sourceContract = normalizeAddress(sourceContractRaw);
+
+  if (USD_NOTIONAL_SWAP_SOURCES.has(sourceContract) || USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES.has(sourceContract) || USD_NOTIONAL_AMOUNT_USD_SOURCES.has(sourceContract))
+    return { stakeAssetAddress: null, totalStakeUsd: totalStake || "0" };
+
+  const stakeAssetAddress = TOKEN_UNITS_SOURCES.has(sourceContract) || (saveUsdstSource && sourceContract === saveUsdstSource)
+    ? sourceContract : null;
+
+  const directStakePrice = stakeAssetAddress ? getPriceForAddress(ctx.priceMap, stakeAssetAddress) : null;
+  if (directStakePrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, directStakePrice) };
+
+  const lower = name.toLowerCase();
+  if (lower.includes("safety")) {
+    const p = getPriceForAddress(ctx.priceMap, ctx.sTokenAddress);
+    if (p) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, p) };
+  }
+  if (lower.includes("lending pool liquidity")) {
+    const p = getPriceForAddress(ctx.priceMap, ctx.mTokenAddress);
+    if (p) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, p) };
+  }
+  if (lower.includes("borrow")) return { stakeAssetAddress, totalStakeUsd: totalStake || "0" };
+  if (lower.includes("vault")) {
+    const p = getPriceForAddress(ctx.priceMap, ctx.vaultShareTokenAddress);
+    if (p) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, p) };
+  }
+
+  return { stakeAssetAddress, totalStakeUsd: null };
+}
+
+// ── Reward APY computation ────────────────────────────────────────────────────
+
+export function computeRewardsApy(emissionRateRaw?: string, totalStakeUsdRaw?: string | null): string | null {
+  try {
+    if (!emissionRateRaw || !totalStakeUsdRaw) return null;
+    const emissionRate = BigInt(emissionRateRaw);
+    const totalStakeUsd = BigInt(totalStakeUsdRaw);
+    if (emissionRate <= 0n || totalStakeUsd <= 0n) return null;
+
+    const tvlUsd = Number(totalStakeUsd) / 1e18;
+    const annualCata = (Number(emissionRate) / 1e18) * SECONDS_PER_YEAR;
+    if (!isFinite(tvlUsd) || tvlUsd <= 0 || !isFinite(annualCata) || annualCata <= 0) return null;
+
+    const apy = ((annualCata * CATA_PRICE_USD) / tvlUsd) * 100;
+    return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Reward activity finders (use pre-normalized _srcNorm / _stakeNorm) ────────
+
+export function findRewardActivity(
+  activities: any[],
+  options: { sourceContract?: string | null; stakeAssetAddress?: string | null; nameIncludes?: string[] },
+): any | null {
+  const src = normalizeAddress(options.sourceContract);
+  const stake = normalizeAddress(options.stakeAssetAddress);
+  const nameMatchers = (options.nameIncludes ?? []).map(n => n.toLowerCase());
+
+  const matches = activities.filter(a => {
+    if (src && a._srcNorm !== src) return false;
+    if (stake && a._stakeNorm && a._stakeNorm !== stake) return false;
+    if (nameMatchers.length > 0 && !nameMatchers.some(m => String(a?.name ?? "").toLowerCase().includes(m))) return false;
+    return true;
+  });
+
+  if (matches.length === 0) return null;
+  return matches.find(a => stake && a._stakeNorm === stake)
+    ?? matches.find(a => safeBigInt(a?.totalStakeUsd ?? "0") > 0n)
+    ?? matches[0];
+}
+
+export function findPoolRewardActivity(
+  activities: any[],
+  options: { poolAddress?: string | null; lpTokenAddress?: string | null },
+): any | null {
+  const pool = normalizeAddress(options.poolAddress);
+  const lp = normalizeAddress(options.lpTokenAddress);
+
+  const matches = activities.filter(a =>
+    (pool && a._srcNorm === pool) || (lp && a._srcNorm === lp) || (lp && a._stakeNorm === lp)
+  );
+
+  if (matches.length === 0) return null;
+  return matches.find(a => lp && a._stakeNorm === lp)
+    ?? matches.find(a => pool && a._srcNorm === pool)
+    ?? matches.find(a => safeBigInt(a?.totalStakeUsd ?? "0") > 0n)
+    ?? matches[0];
+}

--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -1,9 +1,16 @@
 import backfillRows from "../../config/exchangeRateBackfill.json";
+import { constants } from "../../config/constants";
+import { totalDebtFromScaled, calculateAPYs } from "./lending.helper";
+import { safeBigInt } from "./vaultPerformance.helper";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const { DECIMALS, DAY_MS, BPS_DIVISOR } = constants;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
 const YIELD_ANCHOR_STEP_DAYS = 1;
+
+export const ZERO_APY = "0.00";
+export const DEFAULT_SWAP_FEE_BPS = 30;
+export const DEFAULT_LP_SHARE_BPS = 7000;
 
 export interface YieldHistoryInterval {
   fromMs: number;
@@ -47,7 +54,7 @@ export function indexYieldHistoryRows(rows: any[]): Map<string, YieldHistoryInte
   return byKey;
 }
 
-export function buildYieldAnchors(
+function buildYieldAnchors(
   nowMs: number,
   days: number = DEFAULT_YIELD_WINDOW_DAYS,
   stepDays: number = YIELD_ANCHOR_STEP_DAYS,
@@ -121,11 +128,84 @@ export function computeExchangeRateAPY(
   }
 
   if (!startRate || !endRate || endMs <= startMs) return null;
-  const daysDelta = (endMs - startMs) / (1000 * 60 * 60 * 24);
+  const daysDelta = (endMs - startMs) / DAY_MS;
   if (daysDelta < 1) return null;
 
   const growth = Number(endRate) / Number(startRate);
   if (!isFinite(growth) || growth <= 0) return null;
   const apy = (Math.pow(growth, 365 / daysDelta) - 1) * 100;
   return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
+}
+
+// ── APY computation helpers ───────────────────────────────────────────────────
+
+export function computeLendingAPY(lp: any, cfg: any, availableLiquidity: string): string | null {
+  const { supplyAPY: maxSupplyAPY } = calculateAPYs(cfg.interestRate ?? 0, cfg.reserveFactor ?? 1000);
+  const debt = BigInt(totalDebtFromScaled(lp.totalScaledDebt ?? "0", lp.borrowIndex ?? "0"));
+  const cash = BigInt(availableLiquidity);
+  const reserves = BigInt(lp.reservesAccrued ?? "0");
+  const total = cash + debt;
+  const denom = total - (reserves < total ? reserves : total);
+  const util = denom > 0n ? Number(debt * BigInt(BPS_DIVISOR) / denom) / 100 : 0;
+  const apy = maxSupplyAPY * (util / 100);
+  return apy > 0 ? apy.toFixed(2) : null;
+}
+
+export function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null {
+  const totalAssetsNow = BigInt(smRow?._managedAssets ?? "0");
+  const totalSharesNow = BigInt(stRow?._totalSupply ?? "0");
+  if (totalSharesNow <= 0n) return null;
+
+  let assetsDelta = 0n, sharesDelta = 0n;
+  for (const e of events) {
+    const a = e.attributes;
+    switch (e.event_name) {
+      case "Staked":          assetsDelta += BigInt(a.assetsIn ?? "0"); sharesDelta += BigInt(a.sharesOut ?? "0"); break;
+      case "Redeemed":        assetsDelta -= BigInt(a.assetsOut ?? "0"); sharesDelta -= BigInt(a.sharesIn ?? "0"); break;
+      case "RewardNotified":  assetsDelta += BigInt(a.amount ?? "0"); break;
+      case "ShortfallCovered": assetsDelta -= BigInt(a.amount ?? "0"); break;
+    }
+  }
+
+  const totalAssetsStart = totalAssetsNow - assetsDelta;
+  const totalSharesStart = totalSharesNow - sharesDelta;
+  if (totalSharesStart <= 0n || totalAssetsStart <= 0n) return null;
+
+  const periodReturn = Number(totalAssetsNow) / Number(totalSharesNow) / (Number(totalAssetsStart) / Number(totalSharesStart)) - 1;
+  if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
+
+  return ((Math.pow(1 + periodReturn, 365 / 30) - 1) * 100).toFixed(2);
+}
+
+export function computePoolAPY(pool: any, prices: Map<string, string>, volumeMap: Map<string, number>): string {
+  const vol = volumeMap.get(pool.address) || 0;
+  const feeRate = pool.swapFeeRate || DEFAULT_SWAP_FEE_BPS;
+  const lpShare = pool.lpSharePercent || DEFAULT_LP_SHARE_BPS;
+  const lpFees = vol * (feeRate / BPS_DIVISOR) * (lpShare / BPS_DIVISOR);
+  const priceA = BigInt(prices.get(pool.tokenA.address) || "0");
+  const priceB = BigInt(prices.get(pool.tokenB.address) || "0");
+  const tvl = Number((BigInt(pool.tokenABalance || "0") * priceA + BigInt(pool.tokenBBalance || "0") * priceB) / DECIMALS) / 1e18;
+  return (tvl > 0 ? (lpFees / tvl) * 365 * 100 : 0).toFixed(2);
+}
+
+export function weightedBaseYield(addrs: string[], bals: string[], prices: Map<string, string>, baseYields: Map<string, number>): string | null {
+  let ws = 0, total = 0;
+  for (let i = 0; i < addrs.length; i++) {
+    const usd = Number((safeBigInt(bals[i]) * safeBigInt(prices.get(addrs[i]))) / DECIMALS) / 1e18;
+    total += usd;
+    ws += usd * (baseYields.get(addrs[i]) ?? 0);
+  }
+  return total > 0 && ws > 0 ? (ws / total).toFixed(2) : null;
+}
+
+export function buildVolumeMap(swapEvents: any[], prices: Map<string, string>): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const e of swapEvents) {
+    const tokenIn = e.attributes?.tokenIn || e.tokenIn;
+    const amountIn = e.attributes?.amountIn || e.amountIn || "0";
+    const price = BigInt(prices.get(tokenIn) || "0");
+    const volUSD = Number((BigInt(amountIn) * price) / DECIMALS) / 1e18;
+    map.set(e.address, (map.get(e.address) || 0) + volUSD);
+  }
+  return map;
 }

--- a/mercata/backend/src/api/helpers/earnYield.helper.ts
+++ b/mercata/backend/src/api/helpers/earnYield.helper.ts
@@ -1,5 +1,6 @@
 import backfillRows from "../../config/exchangeRateBackfill.json";
 import { constants } from "../../config/constants";
+import { cirrus } from "../../utils/mercataApiHelper";
 import { totalDebtFromScaled, calculateAPYs } from "./lending.helper";
 import { safeBigInt } from "./vaultPerformance.helper";
 
@@ -7,6 +8,7 @@ const { DECIMALS, DAY_MS, BPS_DIVISOR } = constants;
 const YIELD_ANCHOR_UTC_HOUR = 12;
 const DEFAULT_YIELD_WINDOW_DAYS = 30;
 const YIELD_ANCHOR_STEP_DAYS = 1;
+const MAX_YIELD_HISTORY_CACHE_KEYS = 8;
 
 export const ZERO_APY = "0.00";
 export const DEFAULT_SWAP_FEE_BPS = 30;
@@ -17,6 +19,29 @@ export interface YieldHistoryInterval {
   toMs: number;
   value: string;
 }
+
+type YieldHistoryCacheEntry = {
+  rows: YieldHistoryRow[];
+};
+
+const yieldHistoryCache = new Map<string, YieldHistoryCacheEntry>();
+// Dedupes concurrent refreshes for the same cache key.
+const pendingYieldHistoryFetches = new Map<string, Promise<YieldHistoryRow[]>>();
+
+type YieldHistoryRow = {
+  key?: string;
+  value?: string;
+  valid_from?: string;
+  valid_to?: string;
+};
+
+type YieldExchangeRateQuery = {
+  priceOracle: string;
+  exchangeRateAddrs: string[];
+  windowStart: string;
+  windowEndExclusive: string;
+  anchorsMs: number[];
+};
 
 function parseCirrusTimestamp(ts?: string): number {
   if (!ts) return Number.NaN;
@@ -77,13 +102,91 @@ function toCirrusUtcTime(d: Date): string {
   return d.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC");
 }
 
-export function buildYieldAnchorOverlapFilter(anchorsMs: number[]): string {
+function buildYieldAnchorOverlapFilter(anchorsMs: number[]): string {
   return `(${anchorsMs
     .map((ms) => {
       const anchor = toCirrusUtcTime(new Date(ms));
       return `and(valid_from.lte.${anchor},valid_to.gte.${anchor})`;
     })
     .join(",")})`;
+}
+
+function normalizeAddresses(addresses: string[]): string[] {
+  const out = new Set<string>();
+  for (const address of addresses) if (address) out.add(address.toLowerCase());
+  return [...out].sort();
+}
+
+function buildYieldCacheKey(
+  query: YieldExchangeRateQuery,
+  addresses: string[],
+): string {
+  const { priceOracle, windowStart, windowEndExclusive } = query;
+  return `${priceOracle.toLowerCase()}|${windowStart}|${windowEndExclusive}|${addresses.join(",")}`;
+}
+
+function setYieldHistoryCacheEntry(cacheKey: string, entry: YieldHistoryCacheEntry): void {
+  if (yieldHistoryCache.has(cacheKey)) yieldHistoryCache.delete(cacheKey);
+  yieldHistoryCache.set(cacheKey, entry);
+
+  if (yieldHistoryCache.size > MAX_YIELD_HISTORY_CACHE_KEYS) {
+    const oldestKey = yieldHistoryCache.keys().next().value;
+    if (oldestKey) yieldHistoryCache.delete(oldestKey);
+  }
+}
+
+async function fetchYieldExchangeRateRows(
+  accessToken: string,
+  query: YieldExchangeRateQuery,
+  normalizedAddrs: string[],
+): Promise<YieldHistoryRow[]> {
+  const { priceOracle, windowStart, windowEndExclusive, anchorsMs } = query;
+  const { data } = await cirrus.get(accessToken, "/history@mapping", {
+    params: {
+      address: `eq.${priceOracle}`,
+      collection_name: "eq.exchangeRates",
+      "key->>key": `in.(${normalizedAddrs.join(",")})`,
+      select: "key->>key,value::text,valid_from,valid_to",
+      and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
+      or: buildYieldAnchorOverlapFilter(anchorsMs),
+    },
+  });
+  return data ?? [];
+}
+
+export async function getYieldExchangeRateRowsCached(
+  accessToken: string,
+  query: YieldExchangeRateQuery,
+): Promise<YieldHistoryRow[]> {
+  const { exchangeRateAddrs } = query;
+  const normalizedAddrs = normalizeAddresses(exchangeRateAddrs);
+  if (normalizedAddrs.length === 0) return [];
+
+  const cacheKey = buildYieldCacheKey(query, normalizedAddrs);
+  const cached = yieldHistoryCache.get(cacheKey);
+  const staleRows = cached?.rows ?? [];
+  if (cached) {
+    setYieldHistoryCacheEntry(cacheKey, cached);
+    return cached.rows;
+  }
+
+  const pending = pendingYieldHistoryFetches.get(cacheKey);
+  if (pending) return pending;
+
+  const fetchPromise = (async () => {
+    try {
+      const rows = await fetchYieldExchangeRateRows(accessToken, query, normalizedAddrs);
+      setYieldHistoryCacheEntry(cacheKey, { rows });
+      return rows;
+    } catch {
+      return staleRows;
+    } finally {
+      pendingYieldHistoryFetches.delete(cacheKey);
+    }
+  })();
+
+  pendingYieldHistoryFetches.set(cacheKey, fetchPromise);
+  return fetchPromise;
 }
 
 export function getYieldWindowBounds(

--- a/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
+++ b/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
@@ -115,10 +115,15 @@ const getHistoricalAssetPrices = async (
   }
 };
 
+const firstDepositCache = new Map<string, { date: string; timestamp: Date } | null>();
+
 const getFirstDepositDate = async (
   accessToken: string,
   vaultAddress: string
 ): Promise<{ date: string; timestamp: Date } | null> => {
+  const cached = firstDepositCache.get(vaultAddress);
+  if (cached !== undefined) return cached;
+
   try {
     const { data: depositEvents } = await cirrus.get(accessToken, `/${Vault}-Deposited`, {
       params: {
@@ -130,12 +135,15 @@ const getFirstDepositDate = async (
     });
 
     if (!depositEvents?.length || !depositEvents[0]?.block_timestamp) {
+      firstDepositCache.set(vaultAddress, null);
       return null;
     }
 
     const timestamp = new Date(depositEvents[0].block_timestamp);
     const date = timestamp.toISOString().split("T")[0];
-    return { date, timestamp };
+    const result = { date, timestamp };
+    firstDepositCache.set(vaultAddress, result);
+    return result;
   } catch {
     return null;
   }

--- a/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
+++ b/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
@@ -1,7 +1,7 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 
-const { Vault, Token } = constants;
+const { Vault } = constants;
 const WAD = BigInt(10) ** BigInt(18);
 
 export interface VaultPerformanceMetrics {
@@ -51,35 +51,20 @@ export const computeEquityFromMaps = (
   0n
 );
 
-const getTokenTotalSupply = async (
+const getHistoricalTokenBalances = async (
   accessToken: string,
-  tokenAddress: string
-): Promise<string> => {
-  try {
-    const { data } = await cirrus.get(accessToken, `/${Token}`, {
-      params: {
-        select: "_totalSupply::text",
-        address: `eq.${tokenAddress}`,
-      },
-    });
-
-    return data?.[0]?._totalSupply || "0";
-  } catch {
-    return "0";
-  }
-};
-
-const getHistoricalTokenBalance = async (
-  accessToken: string,
-  tokenAddress: string,
+  tokenAddresses: string[],
   holderAddress: string,
   date: string
-): Promise<string> => {
+): Promise<Map<string, string>> => {
+  const balances = new Map<string, string>();
+  if (tokenAddresses.length === 0) return balances;
+
   try {
     const { data } = await cirrus.get(accessToken, "/history@mapping", {
       params: {
-        select: "value::text",
-        address: `eq.${tokenAddress}`,
+        select: "address,value::text",
+        address: `in.(${tokenAddresses.join(",")})`,
         collection_name: "eq._balances",
         "key->>key": `eq.${holderAddress}`,
         valid_from: `lte.${date}`,
@@ -87,37 +72,46 @@ const getHistoricalTokenBalance = async (
       },
     });
 
-    const value = data?.[0]?.value;
-    if (!value || value === "") return "0";
-    return value;
+    for (const row of data || []) {
+      const address = String(row?.address || "").toLowerCase();
+      if (!address || balances.has(address)) continue;
+      balances.set(address, row?.value || "0");
+    }
+    return balances;
   } catch {
-    return "0";
+    return balances;
   }
 };
 
-const getHistoricalAssetPrice = async (
+const getHistoricalAssetPrices = async (
   accessToken: string,
   oracleAddress: string,
-  assetAddress: string,
+  assetAddresses: string[],
   date: string
-): Promise<string> => {
+): Promise<Map<string, string>> => {
+  const prices = new Map<string, string>();
+  if (assetAddresses.length === 0) return prices;
+
   try {
     const { data } = await cirrus.get(accessToken, "/history@mapping", {
       params: {
-        select: "value::text",
+        select: "key->>key,value::text",
         address: `eq.${oracleAddress}`,
         collection_name: "eq.prices",
-        "key->>key": `eq.${assetAddress}`,
+        "key->>key": `in.(${assetAddresses.join(",")})`,
         valid_from: `lte.${date}`,
         valid_to: `gte.${date}`,
       },
     });
 
-    const value = data?.[0]?.value;
-    if (!value || value === "") return "0";
-    return value;
+    for (const row of data || []) {
+      const asset = String(row?.key || "").toLowerCase();
+      if (!asset || prices.has(asset)) continue;
+      prices.set(asset, row?.value || "0");
+    }
+    return prices;
   } catch {
-    return "0";
+    return prices;
   }
 };
 
@@ -191,11 +185,19 @@ export const computeVaultPerformanceMetrics = async (
     const histTotalSupply = safeBigInt(histStorage?.[0]?.data?._totalSupply);
     if (histTotalSupply <= 0n) return noData;
 
+    const [histBalances, histPrices] = await Promise.all([
+      getHistoricalTokenBalances(accessToken, supportedAssets, botExecutor, startDate),
+      getHistoricalAssetPrices(accessToken, priceOracleAddress, supportedAssets, startDate),
+    ]);
+
     let histEquity = 0n;
     let hodlEquity = 0n;
     for (const assetAddress of supportedAssets) {
-      const histBalanceBN = safeBigInt(await getHistoricalTokenBalance(accessToken, assetAddress, botExecutor, startDate));
-      const histPriceBN = safeBigInt(await getHistoricalAssetPrice(accessToken, priceOracleAddress, assetAddress, startDate));
+      const assetKey = assetAddress.toLowerCase();
+      const histBalanceRaw = histBalances.get(assetKey) || "0";
+      const histPriceRaw = histPrices.get(assetKey) || "0";
+      const histBalanceBN = safeBigInt(histBalanceRaw);
+      const histPriceBN = safeBigInt(histPriceRaw);
 
       if (histPriceBN > 0n) {
         histEquity += (histBalanceBN * histPriceBN) / WAD;

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -119,6 +119,30 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       else if (r.collection_name === "activityStates") rewardActivityStateById.set(activityId, parsed);
     }
   }
+  const filteredVaultAssets = vaultAssets.filter(a => a !== "0000000000000000000000000000000000000000");
+
+  // Phase 1b: dependent reads that can run in parallel once Phase 1 context is known.
+  const [stablePools, shareTokenTotalSupply, vaultBalanceRows] = await Promise.all([
+    fetchMultiTokenStablePools(accessToken).catch(() => []),
+    shareTokenAddress
+      ? (async () => {
+          const { data: shareTokenStorageRows } = await cirrus.get(accessToken, "/storage", { params: {
+            address: `eq.${shareTokenAddress}`,
+            select: "data->>_totalSupply",
+          }}).catch(() => ({ data: [] as any[] }));
+          const fromStorage = shareTokenStorageRows?.[0]?._totalSupply || "";
+          return fromStorage || await getTokenTotalSupply(accessToken, shareTokenAddress);
+        })()
+      : Promise.resolve("0"),
+    (vaultAddr && shareTokenAddress && botExecutor && filteredVaultAssets.length)
+      ? cirrus.get(accessToken, "/mapping", { params: {
+          address: `in.(${filteredVaultAssets.join(",")})`,
+          collection_name: "eq._balances",
+          "key->>key": `eq.${botExecutor}`,
+          select: "address,value::text",
+        }}).then((res) => res.data || []).catch(() => [])
+      : Promise.resolve([] as any[]),
+  ]);
 
   // Parse events (single pass)
   const swapEvents: any[] = [], smEvents: any[] = [];
@@ -151,20 +175,18 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     vaultShareTokenAddress: shareTokenAddress || null,
     saveUsdstVaultAddress: appConfig.saveUsdstVault || null,
   });
-  const stablePools = await fetchMultiTokenStablePools(accessToken).catch(() => []);
 
   // Phase 2: vault APY needs current balances + historical NAV context
   let vaultAPY: string | null = null;
   let vaultRewardApy: string | null = null;
-  const filteredVaultAssets = vaultAssets.filter(a => a !== "0000000000000000000000000000000000000000");
   const vaultOracle = vaultStorage?.priceOracle || constants.priceOracle;
   const currentVaultBalances = new Map<string, string>();
+  for (const row of vaultBalanceRows || []) {
+    currentVaultBalances.set(row.address, row.value || "0");
+  }
   if (vaultAddr && shareTokenAddress && botExecutor && filteredVaultAssets.length) {
-    const balances = await getCurrentVaultBalances(accessToken, filteredVaultAssets, botExecutor);
-    balances.forEach((value, key) => currentVaultBalances.set(key, value));
-
     const vaultEquity = computeEquityFromMaps(filteredVaultAssets, currentVaultBalances, prices);
-    const vaultTotalShares = safeBigInt(await getTokenTotalSupply(accessToken, shareTokenAddress));
+    const vaultTotalShares = safeBigInt(shareTokenTotalSupply || "0");
 
     const vaultMetrics = await computeVaultPerformanceMetrics(
       accessToken,
@@ -490,21 +512,6 @@ function weightedBaseYield(addrs: string[], bals: string[], prices: Map<string, 
     ws += usd * (baseYields.get(addrs[i]) || 0);
   }
   return total > 0 && ws > 0 ? (ws / total).toFixed(2) : null;
-}
-
-async function getCurrentVaultBalances(
-  accessToken: string,
-  assets: string[],
-  botExecutor: string,
-): Promise<Map<string, string>> {
-  if (assets.length === 0) return new Map();
-  const { data } = await cirrus.get(accessToken, "/mapping", { params: {
-    address: `in.(${assets.join(",")})`,
-    collection_name: "eq._balances",
-    "key->>key": `eq.${botExecutor}`,
-    select: "address,value::text",
-  }});
-  return new Map((data || []).map((row: any) => [row.address, row.value || "0"]));
 }
 
 async function getTokenTotalSupply(accessToken: string, tokenAddress: string): Promise<string> {

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -12,7 +12,7 @@ import {
   computeVaultPerformanceMetrics,
   safeBigInt,
 } from "../helpers/vaultPerformance.helper";
-import { getSaveUsdstInfo } from "./saveUsdst.service";
+
 import { ApySource, TokenApyEntry } from "@mercata/shared-types";
 
 const { Pool, DECIMALS, Token } = constants;
@@ -40,7 +40,8 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const vaultAddr = constants.vault;
   const rewardsAddr = appConfig.rewards;
 
-  const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""}${rewardsAddr ? `,and(address.eq.${rewardsAddr},collection_name.in.(activities,activityStates))` : ""})`;
+  const saveUsdstVault = appConfig.saveUsdstVault;
+  const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""}${rewardsAddr ? `,and(address.eq.${rewardsAddr},collection_name.in.(activities,activityStates))` : ""}${saveUsdstVault ? `,and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${saveUsdstVault})` : ""})`;
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
 
   // Phase 1: parallel calls
@@ -54,12 +55,11 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     { data: mappingRows },
     { data: eventRows },
     { data: pools },
-    saveUsdstInfo,
     { data: exchangeRateRows },
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
-      address: `in.(${constants.lendingPool},${constants.safetyModule},${constants.sToken}${vaultAddr ? `,${vaultAddr}` : ""})`,
-      select: "address,data->>borrowableAsset,data->>mToken,data->>totalScaledDebt,data->>borrowIndex,data->>reservesAccrued,data->>_managedAssets,data->>_totalSupply,data->>botExecutor,data->>priceOracle,data->>shareToken",
+      address: `in.(${constants.lendingPool},${constants.safetyModule},${constants.sToken}${vaultAddr ? `,${vaultAddr}` : ""}${saveUsdstVault ? `,${saveUsdstVault}` : ""})`,
+      select: "address,data->>borrowableAsset,data->>mToken,data->>totalScaledDebt,data->>borrowIndex,data->>reservesAccrued,data->>_managedAssets,data->>_totalSupply,data->>botExecutor,data->>priceOracle,data->>shareToken,data->>assetToken",
     }}),
     cirrus.get(accessToken, "/mapping", { params: { select: "address,collection_name,key->>key,value::text", or: mappingOr } }),
     cirrus.get(accessToken, `/${constants.Event}`, { params: { select: "address,event_name,attributes,block_timestamp", or: eventOr } }),
@@ -67,7 +67,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol,_totalSupply::text),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
-    getSaveUsdstInfo(accessToken).catch(() => null),
     exchangeRateAddrs.length
       ? cirrus.get(accessToken, "/history@mapping", { params: {
         address: `eq.${constants.priceOracle}`,
@@ -89,17 +88,22 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const botExecutor = vaultStorage?.botExecutor;
   const shareTokenAddress = vaultStorage?.shareToken || "";
 
+  // Parse saveUSDST storage
+  const saveUsdstStorage: any = saveUsdstVault ? storageByAddr.get(saveUsdstVault) : null;
+
   // Parse mapping
   const prices = new Map<string, string>();
   let lendingCfg: any = null;
   let liqBalance: string | null = null;
+  let saveUsdstBalance: string | null = null;
   const vaultAssets: string[] = [];
   const rewardActivityCfgById = new Map<string, any>();
   const rewardActivityStateById = new Map<string, any>();
   for (const r of mappingRows || []) {
     if (r.collection_name === "prices") prices.set(r.key, r.value);
     else if (r.collection_name === "assetConfigs") lendingCfg = JSON.parse(r.value);
-    else if (r.collection_name === "_balances") liqBalance = r.value;
+    else if (r.collection_name === "_balances" && r.key === constants.liquidityPool) liqBalance = r.value;
+    else if (r.collection_name === "_balances" && saveUsdstVault && r.key === saveUsdstVault) saveUsdstBalance = r.value;
     else if (r.collection_name === "supportedAssets" && r.value) {
       const addr = r.value.replace(/"/g, "");
       if (addr) vaultAssets.push(addr);
@@ -115,7 +119,11 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const filteredVaultAssets = vaultAssets.filter(a => a !== "0000000000000000000000000000000000000000");
 
   // Phase 1b: dependent reads that can run in parallel once Phase 1 context is known.
-  const [stablePools, shareTokenTotalSupply, vaultBalanceRows] = await Promise.all([
+  const saveUsdstAsset = saveUsdstStorage?.assetToken || constants.USDST;
+  const saveUsdstManagedAssets = safeBigInt(saveUsdstStorage?._managedAssets);
+  const saveUsdstTotalShares = safeBigInt(saveUsdstStorage?._totalSupply);
+
+  const [stablePools, shareTokenTotalSupply, vaultBalanceRows, saveUsdstApyResult] = await Promise.all([
     fetchMultiTokenStablePools(accessToken).catch(() => []),
     shareTokenAddress
       ? (async () => {
@@ -135,6 +143,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
           select: "address,value::text",
         }}).then((res) => res.data || []).catch(() => [])
       : Promise.resolve([] as any[]),
+    computeSaveUsdstApy(accessToken, saveUsdstVault, saveUsdstAsset, safeBigInt(saveUsdstBalance), saveUsdstManagedAssets, saveUsdstTotalShares),
   ]);
 
   // Parse events (single pass)
@@ -241,16 +250,16 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     add(constants.USDST, { source: "rewards", apy: directMintRewardsApy, meta: "direct_mint" });
   }
 
-  const saveUsdstAddress = normalizeAddress(saveUsdstInfo?.vaultAddress);
+  const saveUsdstAddress = normalizeAddress(saveUsdstVault);
   const saveUsdstNativeApy =
-    saveUsdstInfo?.apy && saveUsdstInfo.apy !== "-" && parseFloat(saveUsdstInfo.apy) > 0
-      ? saveUsdstInfo.apy
+    saveUsdstApyResult && saveUsdstApyResult !== "-" && parseFloat(saveUsdstApyResult) > 0
+      ? saveUsdstApyResult
       : null;
-  const saveUsdstStakeUsd =
-    saveUsdstInfo?.tvlUsd ||
-    saveUsdstInfo?.pricingAssets ||
-    saveUsdstInfo?.totalAssets ||
-    null;
+  const saveUsdstLiveBalance = safeBigInt(saveUsdstBalance);
+  const saveUsdstPricingAssets = saveUsdstLiveBalance < saveUsdstManagedAssets ? saveUsdstLiveBalance : saveUsdstManagedAssets;
+  const saveUsdstAssetPrice = safeBigInt(prices.get(saveUsdstAsset) || prices.get(constants.USDST));
+  const saveUsdstTvlUsd = saveUsdstAssetPrice > 0n ? (saveUsdstPricingAssets * saveUsdstAssetPrice) / DECIMALS : 0n;
+  const saveUsdstStakeUsd = saveUsdstTvlUsd > 0n ? saveUsdstTvlUsd.toString() : saveUsdstPricingAssets > 0n ? saveUsdstPricingAssets.toString() : null;
   const saveUsdstRewardsActivity = saveUsdstAddress
     ? findRewardActivity(rewardActivities, {
         sourceContract: saveUsdstAddress,
@@ -263,7 +272,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     saveUsdstRewardsActivity?.totalStakeUsd ?? saveUsdstStakeUsd
   );
   if (saveUsdstAddress) {
-    // Reuse the native-yield source bucket so generic lookup surfaces still label it as Native APY.
     if (saveUsdstNativeApy) {
       add(saveUsdstAddress, { source: "lending", apy: saveUsdstNativeApy, meta: "save_usdst" });
     }
@@ -725,4 +733,77 @@ function findPoolRewardActivity(
 
   const withUsdStake = matches.find((activity) => safeBigInt(activity?.totalStakeUsd || "0") > 0n);
   return withUsdStake || matches[0];
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const firstSaveUsdstDepositCache = new Map<string, { timestamp: Date } | null>();
+
+async function computeSaveUsdstApy(
+  accessToken: string,
+  vaultAddress: string | undefined,
+  assetAddress: string,
+  liveBalance: bigint,
+  managedAssets: bigint,
+  totalShares: bigint,
+): Promise<string> {
+  if (!vaultAddress || totalShares <= 0n) return "0.00";
+  const pricingAssets = liveBalance < managedAssets ? liveBalance : managedAssets;
+  if (pricingAssets <= 0n) return "0.00";
+
+  try {
+    let firstDeposit = firstSaveUsdstDepositCache.get(vaultAddress);
+    if (firstDeposit === undefined) {
+      const { data } = await cirrus.get(accessToken, "/event", { params: {
+        address: `eq.${vaultAddress}`,
+        event_name: "eq.Deposit",
+        select: "block_timestamp",
+        order: "block_timestamp.asc",
+        limit: "1",
+      }}).catch(() => ({ data: [] as any[] }));
+      firstDeposit = data?.[0]?.block_timestamp ? { timestamp: new Date(data[0].block_timestamp) } : null;
+      firstSaveUsdstDepositCache.set(vaultAddress, firstDeposit);
+    }
+    if (!firstDeposit?.timestamp) return "0.00";
+
+    const nowMs = Date.now();
+    const startMs = Math.max(nowMs - 30 * DAY_MS, firstDeposit.timestamp.getTime());
+    const lookbackDays = Math.max(1, (nowMs - startMs) / DAY_MS);
+    const startTimestamp = new Date(startMs + 1).toISOString();
+
+    const [{ data: histStorageRows }, { data: histBalanceRows }] = await Promise.all([
+      cirrus.get(accessToken, "/history@storage", { params: {
+        address: `eq.${vaultAddress}`,
+        valid_from: `lte.${startTimestamp}`,
+        valid_to: `gte.${startTimestamp}`,
+        select: "data",
+      }}).catch(() => ({ data: [] as any[] })),
+      cirrus.get(accessToken, "/history@mapping", { params: {
+        select: "value::text",
+        address: `eq.${assetAddress}`,
+        collection_name: "eq._balances",
+        "key->>key": `eq.${vaultAddress}`,
+        valid_from: `lte.${startTimestamp}`,
+        valid_to: `gte.${startTimestamp}`,
+      }}).catch(() => ({ data: [] as any[] })),
+    ]);
+
+    const histManagedAssets = safeBigInt(histStorageRows?.[0]?.data?._managedAssets);
+    const histTotalShares = safeBigInt(histStorageRows?.[0]?.data?._totalSupply);
+    const histBalance = safeBigInt(histBalanceRows?.[0]?.value);
+    if (histTotalShares <= 0n) return "-";
+
+    const histPricingAssets = histBalance < histManagedAssets ? histBalance : histManagedAssets;
+    const rateNow = totalShares > 0n ? (pricingAssets * DECIMALS) / totalShares : DECIMALS;
+    const rateStart = histTotalShares > 0n && histPricingAssets > 0n ? (histPricingAssets * DECIMALS) / histTotalShares : 0n;
+    if (rateStart <= 0n) return "0.00";
+
+    const periodReturn = Number(((rateNow - rateStart) * DECIMALS) / rateStart) / 1e18;
+    if (!isFinite(periodReturn) || periodReturn <= -1) return "-";
+
+    const annualizationDays = Math.max(30, lookbackDays);
+    const apy = (Math.pow(1 + periodReturn, 365 / annualizationDays) - 1) * 100;
+    return isFinite(apy) ? apy.toFixed(2) : "-";
+  } catch {
+    return "-";
+  }
 }

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -15,7 +15,7 @@ import {
 import { getSaveUsdstInfo } from "./saveUsdst.service";
 import { ApySource, TokenApyEntry } from "@mercata/shared-types";
 
-const { Pool, DECIMALS, Vault, Token } = constants;
+const { Pool, DECIMALS, Token } = constants;
 const ZERO_APY = "0.00";
 const CATA_PRICE_USD = 0.25;
 const STAKE_SEMANTICS = stakeSemanticsConfig as any;
@@ -54,13 +54,12 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     { data: mappingRows },
     { data: eventRows },
     { data: pools },
-    { data: vaultRows },
     saveUsdstInfo,
     { data: exchangeRateRows },
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
       address: `in.(${constants.lendingPool},${constants.safetyModule},${constants.sToken}${vaultAddr ? `,${vaultAddr}` : ""})`,
-      select: "address,data->>borrowableAsset,data->>mToken,data->>totalScaledDebt,data->>borrowIndex,data->>reservesAccrued,data->>_managedAssets,data->>_totalSupply,data->>botExecutor,data->>priceOracle",
+      select: "address,data->>borrowableAsset,data->>mToken,data->>totalScaledDebt,data->>borrowIndex,data->>reservesAccrued,data->>_managedAssets,data->>_totalSupply,data->>botExecutor,data->>priceOracle,data->>shareToken",
     }}),
     cirrus.get(accessToken, "/mapping", { params: { select: "address,collection_name,key->>key,value::text", or: mappingOr } }),
     cirrus.get(accessToken, `/${constants.Event}`, { params: { select: "address,event_name,attributes,block_timestamp", or: eventOr } }),
@@ -68,12 +67,6 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol,_totalSupply::text),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
-    vaultAddr
-      ? cirrus.get(accessToken, `/${Vault}`, { params: {
-        address: `eq.${vaultAddr}`,
-        select: "shareToken",
-      }})
-      : Promise.resolve({ data: [] as any[] }),
     getSaveUsdstInfo(accessToken).catch(() => null),
     exchangeRateAddrs.length
       ? cirrus.get(accessToken, "/history@mapping", { params: {
@@ -94,7 +87,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const stRow = storageByAddr.get(constants.sToken);
   const vaultStorage: any = vaultAddr ? storageByAddr.get(vaultAddr) : null;
   const botExecutor = vaultStorage?.botExecutor;
-  const shareTokenAddress = vaultRows?.[0]?.shareToken || "";
+  const shareTokenAddress = vaultStorage?.shareToken || "";
 
   // Parse mapping
   const prices = new Map<string, string>();

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -151,15 +151,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     vaultShareTokenAddress: shareTokenAddress || null,
     saveUsdstVaultAddress: appConfig.saveUsdstVault || null,
   });
-  const [{ data: poolFactoryRows }, stablePools] = await Promise.all([
-    cirrus.get(accessToken, `/${constants.PoolFactory}`, {
-      params: {
-        address: `eq.${constants.poolFactory}`,
-        select: "swapFeeRate,lpSharePercent",
-      },
-    }).catch(() => ({ data: [] as any[] })),
-    fetchMultiTokenStablePools(accessToken).catch(() => []),
-  ]);
+  const stablePools = await fetchMultiTokenStablePools(accessToken).catch(() => []);
 
   // Phase 2: vault APY needs current balances + historical NAV context
   let vaultAPY: string | null = null;
@@ -289,9 +281,9 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     : null;
 
   const volumeMap = buildVolumeMap(swapEvents, prices);
-  const poolFactoryData = poolFactoryRows?.[0] || null;
-  const factorySwapFeeRate = Number(poolFactoryData?.swapFeeRate || 30);
-  const factoryLpSharePercent = Number(poolFactoryData?.lpSharePercent || 7000);
+  const firstPool = (pools || [])[0];
+  const factorySwapFeeRate = Number(firstPool?.swapFeeRate || 30);
+  const factoryLpSharePercent = Number(firstPool?.lpSharePercent || 7000);
   const stablePoolAddresses = new Set(
     (stablePools || []).map((pool: any) => normalizeAddress(pool?.address)).filter(Boolean)
   );

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -616,14 +616,7 @@ function computeRewardStakeUsd(
 
 function getPriceForAddress(priceMap: Map<string, string>, address?: string | null): string | null {
   if (!address) return null;
-  const normalized = normalizeAddress(address);
-  const raw = String(address);
-  return (
-    priceMap.get(raw) ||
-    priceMap.get(normalized) ||
-    priceMap.get(raw.toLowerCase()) ||
-    null
-  );
+  return priceMap.get(address) || priceMap.get(normalizeAddress(address)) || null;
 }
 
 function toUsdValue(amountWei: string, priceWei: string): string {

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -3,7 +3,7 @@ import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks, compositeYieldMap, rewards as rewardsAddr, saveUsdstVault as saveUsdstVaultAddr } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
 import {
-  buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds,
+  computeExchangeRateAPY, getYieldWindowBounds, getYieldExchangeRateRowsCached,
   indexYieldHistoryRows, mergeBackfillRows,
   ZERO_APY, DEFAULT_SWAP_FEE_BPS, DEFAULT_LP_SHARE_BPS,
   computeLendingAPY, computeSafetyAPY, computePoolAPY, weightedBaseYield, buildVolumeMap,
@@ -112,17 +112,17 @@ async function fetchPhase1(
 
   const storageAddrs = [constants.lendingPool, constants.safetyModule, constants.sToken, vaultAddr, saveUsdstVault].filter(Boolean);
 
-  const exchangeRateAddrs = [...new Set([
+  const exchangeRateAddrs = [
     ...yieldBenchmarks.map(b => b.tokenAddress),
     ...Object.values(compositeYieldMap),
-  ])];
+  ];
 
   const [
     { data: storageRows },
     { data: mappingRows },
     { data: eventRows },
     { data: pools },
-    { data: exchangeRateRows },
+    exchangeRateRows,
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
       address: `in.(${storageAddrs.join(",")})`,
@@ -134,19 +134,13 @@ async function fetchPhase1(
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol,_totalSupply::text),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
-    // TODO: Cache the 30-day exchange rate window as a sliding cache — keep anchors in memory,
-    // pop the earliest anchor and append the new day's anchor on each calendar-day rollover
-    // instead of re-fetching the full 30-day history@mapping on every request.
-    exchangeRateAddrs.length
-      ? cirrus.get(accessToken, "/history@mapping", { params: {
-          address: `eq.${constants.priceOracle}`,
-          collection_name: "eq.exchangeRates",
-          "key->>key": `in.(${exchangeRateAddrs.join(",")})`,
-          select: "key->>key,value::text,valid_from,valid_to",
-          and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
-          or: buildYieldAnchorOverlapFilter(anchorsMs),
-        }}).catch(() => ({ data: [] as any[] }))
-      : Promise.resolve({ data: [] as any[] }),
+    getYieldExchangeRateRowsCached(accessToken, {
+      priceOracle: constants.priceOracle,
+      exchangeRateAddrs,
+      windowStart,
+      windowEndExclusive,
+      anchorsMs,
+    }),
   ]);
 
   return { storageRows, mappingRows, eventRows, pools, exchangeRateRows };

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -1,52 +1,119 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
-import { hiddenSwapPools, yieldBenchmarks, compositeYieldMap } from "../../config/config";
-import * as appConfig from "../../config/config";
+import { hiddenSwapPools, yieldBenchmarks, compositeYieldMap, rewards as rewardsAddr, saveUsdstVault as saveUsdstVaultAddr } from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
-import { buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds, indexYieldHistoryRows, mergeBackfillRows } from "../helpers/earnYield.helper";
-import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
-import { calculateLPTokenPrice, fetchMultiTokenStablePools } from "../helpers/swapping.helper";
-import stakeSemanticsConfig from "./rewardsStakeSemantics.json";
 import {
-  computeEquityFromMaps,
-  computeVaultPerformanceMetrics,
-  safeBigInt,
-} from "../helpers/vaultPerformance.helper";
-
+  buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds,
+  indexYieldHistoryRows, mergeBackfillRows,
+  ZERO_APY, DEFAULT_SWAP_FEE_BPS, DEFAULT_LP_SHARE_BPS,
+  computeLendingAPY, computeSafetyAPY, computePoolAPY, weightedBaseYield, buildVolumeMap,
+} from "../helpers/earnYield.helper";
+import { calculateLPTokenPrice, fetchMultiTokenStablePools } from "../helpers/swapping.helper";
+import {
+  normalizeAddress, isPositiveApy, parseMappingValue, toUsdValue, APY_UNAVAILABLE,
+  buildRewardActivitiesFromMappings, computeRewardsApy,
+  findRewardActivity, findPoolRewardActivity,
+} from "../helpers/earnRewards.helper";
+import { computeEquityFromMaps, computeVaultPerformanceMetrics, safeBigInt } from "../helpers/vaultPerformance.helper";
 import { ApySource, TokenApyEntry } from "@mercata/shared-types";
 
-const { Pool, DECIMALS, Token } = constants;
-const ZERO_APY = "0.00";
-const CATA_PRICE_USD = 0.25;
-const STAKE_SEMANTICS = stakeSemanticsConfig as any;
-const USD_NOTIONAL_SWAP_SOURCES = new Set<string>(
-  STAKE_SEMANTICS.usd_notional.swapSources.map((source: string) => normalizeAddress(source))
-);
-const USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES = new Set<string>(
-  STAKE_SEMANTICS.usd_notional.depositCompletedSources.map((source: string) => normalizeAddress(source))
-);
-const USD_NOTIONAL_AMOUNT_USD_SOURCES = new Set<string>(
-  STAKE_SEMANTICS.usd_notional.amountUsdSources.map((source: string) => normalizeAddress(source))
-);
-const TOKEN_UNITS_SOURCES = new Set<string>(
-  STAKE_SEMANTICS.token_units.lpMintBurnSources.map((source: string) => normalizeAddress(source))
-);
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const { Pool, DECIMALS, Token, ZERO_ADDRESS, DAY_MS, BPS_DIVISOR } = constants;
+const SAVE_USDST_APY_TTL_MS = 60_000;
+
+const firstSaveUsdstDepositCache = new Map<string, { timestamp: Date } | null>();
+const saveUsdstApyCache = new Map<string, { value: string; expiry: number }>();
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Phase1Data = Awaited<ReturnType<typeof fetchPhase1>>;
+type Phase1Ctx = ReturnType<typeof parsePhase1>;
+type Phase1bData = Awaited<ReturnType<typeof fetchPhase1b>>;
+type AddFn = (token: string, entry: ApySource) => void;
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 
 export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]> => {
   const now = Date.now();
-  const twentyFourHoursAgo = toUTCTime(new Date(now - 24 * 60 * 60 * 1000));
-  const thirtyDaysAgo = toUTCTime(new Date(now - 30 * 24 * 60 * 60 * 1000));
   const { windowStart, windowEndExclusive, anchorsMs } = getYieldWindowBounds(now);
-  const vaultAddr = constants.vault;
-  const rewardsAddr = appConfig.rewards;
+  const vaultAddr = constants.vault ?? "";
+  const rewAddr = rewardsAddr ?? "";
+  const saveUsdstVault = saveUsdstVaultAddr ?? "";
 
-  const saveUsdstVault = appConfig.saveUsdstVault;
-  const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""}${rewardsAddr ? `,and(address.eq.${rewardsAddr},collection_name.in.(activities,activityStates))` : ""}${saveUsdstVault ? `,and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${saveUsdstVault})` : ""})`;
-  const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
+  const phase1 = await fetchPhase1(accessToken, now, windowStart, windowEndExclusive, anchorsMs, vaultAddr, rewAddr, saveUsdstVault);
+  const ctx = parsePhase1(phase1, vaultAddr, rewAddr, saveUsdstVault);
+  const phase1b = await fetchPhase1b(accessToken, ctx, saveUsdstVault);
 
-  // Phase 1: parallel calls
+  const rewardActivities = buildRewardActivitiesFromMappings(
+    ctx.rewardActivityCfgById, ctx.rewardActivityStateById, {
+      priceMap: ctx.prices,
+      mTokenAddress: ctx.lpData?.mToken ?? null,
+      sTokenAddress: constants.sToken ?? null,
+      vaultShareTokenAddress: ctx.shareTokenAddress || null,
+      saveUsdstVaultAddress: saveUsdstVault || null,
+    },
+  );
+
+  const { vaultAPY, vaultRewardApy, currentVaultBalances } = await computeVaultApys(
+    accessToken, vaultAddr, ctx, phase1b, rewardActivities,
+  );
+
+  const map = new Map<string, ApySource[]>();
+  const add: AddFn = (t, e) => { const arr = map.get(t); if (arr) arr.push(e); else map.set(t, [e]); };
+
+  addLendingApys(add, ctx, rewardActivities);
+  addDirectMintRewards(add, rewardActivities);
+  addSaveUsdstApys(add, ctx, phase1b, rewardActivities, saveUsdstVault);
+
+  const exchangeRateHistory = indexYieldHistoryRows(mergeBackfillRows(phase1.exchangeRateRows ?? []));
+  const baseYieldByAddr = addBaseYieldApys(add, exchangeRateHistory, anchorsMs);
+
+  const vaultWeightedApy = currentVaultBalances.size > 0 && baseYieldByAddr.size > 0
+    ? weightedBaseYield(
+        ctx.filteredVaultAssets,
+        ctx.filteredVaultAssets.map(a => currentVaultBalances.get(a) ?? "0"),
+        ctx.prices, baseYieldByAddr,
+      )
+    : null;
+
+  addPoolApys(add, phase1.pools, phase1b.stablePools, ctx, rewardActivities, baseYieldByAddr);
+
+  if (ctx.shareTokenAddress) {
+    if (isPositiveApy(vaultAPY)) add(ctx.shareTokenAddress, { source: "vault", apy: vaultAPY });
+    if (isPositiveApy(vaultWeightedApy)) add(ctx.shareTokenAddress, { source: "vault_weighted", apy: vaultWeightedApy });
+    if (isPositiveApy(vaultRewardApy)) add(ctx.shareTokenAddress, { source: "rewards", apy: vaultRewardApy, meta: "vault" });
+  }
+
+  const safetyAPY = computeSafetyAPY(ctx.smRow, ctx.stRow, ctx.smEvents);
+  if (safetyAPY) add(constants.USDST, { source: "safety", apy: safetyAPY });
+
+  return [...map.entries()].map(([token, apys]) => ({ token, apys }));
+};
+
+// ── Phase 1: parallel Cirrus queries ──────────────────────────────────────────
+
+async function fetchPhase1(
+  accessToken: string, now: number,
+  windowStart: string, windowEndExclusive: string, anchorsMs: number[],
+  vaultAddr: string, rewardsAddr: string, saveUsdstVault: string,
+) {
+  const twentyFourHoursAgo = toUTCTime(new Date(now - DAY_MS));
+  const thirtyDaysAgo = toUTCTime(new Date(now - 30 * DAY_MS));
+
+  const mappingFilters = [
+    `and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST})`,
+    `and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool})`,
+    `and(address.eq.${constants.priceOracle},collection_name.eq.prices)`,
+  ];
+  if (vaultAddr) mappingFilters.push(`and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)`);
+  if (rewardsAddr) mappingFilters.push(`and(address.eq.${rewardsAddr},collection_name.in.(activities,activityStates))`);
+  if (saveUsdstVault) mappingFilters.push(`and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${saveUsdstVault})`);
+
+  const storageAddrs = [constants.lendingPool, constants.safetyModule, constants.sToken, vaultAddr, saveUsdstVault].filter(Boolean);
+
   const exchangeRateAddrs = [...new Set([
-    ...yieldBenchmarks.map((b) => b.tokenAddress),
+    ...yieldBenchmarks.map(b => b.tokenAddress),
     ...Object.values(compositeYieldMap),
   ])];
 
@@ -58,40 +125,45 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     { data: exchangeRateRows },
   ] = await Promise.all([
     cirrus.get(accessToken, "/storage", { params: {
-      address: `in.(${constants.lendingPool},${constants.safetyModule},${constants.sToken}${vaultAddr ? `,${vaultAddr}` : ""}${saveUsdstVault ? `,${saveUsdstVault}` : ""})`,
+      address: `in.(${storageAddrs.join(",")})`,
       select: "address,data->>borrowableAsset,data->>mToken,data->>totalScaledDebt,data->>borrowIndex,data->>reservesAccrued,data->>_managedAssets,data->>_totalSupply,data->>botExecutor,data->>priceOracle,data->>shareToken,data->>assetToken",
     }}),
-    cirrus.get(accessToken, "/mapping", { params: { select: "address,collection_name,key->>key,value::text", or: mappingOr } }),
-    cirrus.get(accessToken, `/${constants.Event}`, { params: { select: "address,event_name,attributes,block_timestamp", or: eventOr } }),
+    cirrus.get(accessToken, "/mapping", { params: { select: "address,collection_name,key->>key,value::text", or: `(${mappingFilters.join(",")})` } }),
+    cirrus.get(accessToken, `/${constants.Event}`, { params: { select: "address,event_name,attributes,block_timestamp", or: `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))` } }),
     cirrus.get(accessToken, `/${Pool}`, { params: {
       poolFactory: `eq.${constants.poolFactory}`,
       select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol,_totalSupply::text),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
+    // TODO: Cache the 30-day exchange rate window as a sliding cache — keep anchors in memory,
+    // pop the earliest anchor and append the new day's anchor on each calendar-day rollover
+    // instead of re-fetching the full 30-day history@mapping on every request.
     exchangeRateAddrs.length
       ? cirrus.get(accessToken, "/history@mapping", { params: {
-        address: `eq.${constants.priceOracle}`,
-        collection_name: "eq.exchangeRates",
-        "key->>key": `in.(${exchangeRateAddrs.join(",")})`,
-        select: "key->>key,value::text,valid_from,valid_to",
-        and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
-        or: buildYieldAnchorOverlapFilter(anchorsMs),
-      }}).catch(() => ({ data: [] as any[] }))
+          address: `eq.${constants.priceOracle}`,
+          collection_name: "eq.exchangeRates",
+          "key->>key": `in.(${exchangeRateAddrs.join(",")})`,
+          select: "key->>key,value::text,valid_from,valid_to",
+          and: `(block_timestamp.gte.${windowStart},block_timestamp.lt.${windowEndExclusive})`,
+          or: buildYieldAnchorOverlapFilter(anchorsMs),
+        }}).catch(() => ({ data: [] as any[] }))
       : Promise.resolve({ data: [] as any[] }),
   ]);
 
-  // Parse storage
-  const storageByAddr = new Map((storageRows || []).map((r: any) => [r.address, r]));
+  return { storageRows, mappingRows, eventRows, pools, exchangeRateRows };
+}
+
+// ── Parse Phase 1 ─────────────────────────────────────────────────────────────
+
+function parsePhase1(phase1: Phase1Data, vaultAddr: string, rewardsAddr: string, saveUsdstVault: string) {
+  const storageByAddr = new Map((phase1.storageRows ?? []).map((r: any) => [r.address, r]));
   const lpData: any = storageByAddr.get(constants.lendingPool);
   const smRow = storageByAddr.get(constants.safetyModule);
   const stRow = storageByAddr.get(constants.sToken);
   const vaultStorage: any = vaultAddr ? storageByAddr.get(vaultAddr) : null;
   const botExecutor = vaultStorage?.botExecutor;
-  const shareTokenAddress = vaultStorage?.shareToken || "";
-
-  // Parse saveUSDST storage
+  const shareTokenAddress = vaultStorage?.shareToken ?? "";
   const saveUsdstStorage: any = saveUsdstVault ? storageByAddr.get(saveUsdstVault) : null;
 
-  // Parse mapping
   const prices = new Map<string, string>();
   let lendingCfg: any = null;
   let liqBalance: string | null = null;
@@ -99,7 +171,9 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const vaultAssets: string[] = [];
   const rewardActivityCfgById = new Map<string, any>();
   const rewardActivityStateById = new Map<string, any>();
-  for (const r of mappingRows || []) {
+  const rewardsAddrNorm = rewardsAddr ? normalizeAddress(rewardsAddr) : "";
+
+  for (const r of phase1.mappingRows ?? []) {
     if (r.collection_name === "prices") prices.set(r.key, r.value);
     else if (r.collection_name === "assetConfigs") lendingCfg = JSON.parse(r.value);
     else if (r.collection_name === "_balances" && r.key === constants.liquidityPool) liqBalance = r.value;
@@ -107,183 +181,163 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     else if (r.collection_name === "supportedAssets" && r.value) {
       const addr = r.value.replace(/"/g, "");
       if (addr) vaultAssets.push(addr);
-    } else if (rewardsAddr && normalizeAddress(r.address) === normalizeAddress(rewardsAddr) && r.value) {
+    } else if (rewardsAddrNorm && normalizeAddress(r.address) === rewardsAddrNorm && r.value) {
       const parsed = parseMappingValue(r.value);
       if (!parsed) continue;
-      const activityId = String(r.key || "");
+      const activityId = String(r.key ?? "");
       if (!activityId) continue;
       if (r.collection_name === "activities") rewardActivityCfgById.set(activityId, parsed);
       else if (r.collection_name === "activityStates") rewardActivityStateById.set(activityId, parsed);
     }
   }
-  const filteredVaultAssets = vaultAssets.filter(a => a !== "0000000000000000000000000000000000000000");
 
-  // Phase 1b: dependent reads that can run in parallel once Phase 1 context is known.
-  const saveUsdstAsset = saveUsdstStorage?.assetToken || constants.USDST;
-  const saveUsdstManagedAssets = safeBigInt(saveUsdstStorage?._managedAssets);
-  const saveUsdstTotalShares = safeBigInt(saveUsdstStorage?._totalSupply);
+  const filteredVaultAssets = vaultAssets.filter(a => a !== ZERO_ADDRESS);
 
-  const [stablePools, shareTokenTotalSupply, vaultBalanceRows, saveUsdstApyResult] = await Promise.all([
-    fetchMultiTokenStablePools(accessToken).catch(() => []),
-    shareTokenAddress
-      ? (async () => {
-          const { data: shareTokenStorageRows } = await cirrus.get(accessToken, "/storage", { params: {
-            address: `eq.${shareTokenAddress}`,
-            select: "data->>_totalSupply",
-          }}).catch(() => ({ data: [] as any[] }));
-          const fromStorage = shareTokenStorageRows?.[0]?._totalSupply || "";
-          return fromStorage || await getTokenTotalSupply(accessToken, shareTokenAddress);
-        })()
-      : Promise.resolve("0"),
-    (vaultAddr && shareTokenAddress && botExecutor && filteredVaultAssets.length)
-      ? cirrus.get(accessToken, "/mapping", { params: {
-          address: `in.(${filteredVaultAssets.join(",")})`,
-          collection_name: "eq._balances",
-          "key->>key": `eq.${botExecutor}`,
-          select: "address,value::text",
-        }}).then((res) => res.data || []).catch(() => [])
-      : Promise.resolve([] as any[]),
-    computeSaveUsdstApy(accessToken, saveUsdstVault, saveUsdstAsset, safeBigInt(saveUsdstBalance), saveUsdstManagedAssets, saveUsdstTotalShares),
-  ]);
-
-  // Parse events (single pass)
   const swapEvents: any[] = [], smEvents: any[] = [];
-  for (const e of eventRows || []) {
+  for (const e of phase1.eventRows ?? []) {
     switch (e.event_name) {
       case "Swap": swapEvents.push(e); break;
       case "Staked": case "Redeemed": case "RewardNotified": case "ShortfallCovered": smEvents.push(e); break;
     }
   }
 
-  // Enrich prices with LP token prices from Phase 1 pool data (needed for reward stake USD)
-  for (const p of pools || []) {
+  for (const p of phase1.pools ?? []) {
     if (p.lpToken?.address && p.lpToken._totalSupply) {
       const lpPrice = calculateLPTokenPrice(
-        p.tokenABalance || "0", p.tokenBBalance || "0",
-        prices.get(p.tokenA?.address) || "0", prices.get(p.tokenB?.address) || "0",
-        p.lpToken._totalSupply
+        p.tokenABalance ?? "0", p.tokenBBalance ?? "0",
+        prices.get(p.tokenA?.address) ?? "0", prices.get(p.tokenB?.address) ?? "0",
+        p.lpToken._totalSupply,
       );
       if (lpPrice !== "0") prices.set(p.lpToken.address, lpPrice);
     }
   }
 
-  const rewardActivities = buildRewardActivitiesFromMappings(
-    rewardActivityCfgById,
-    rewardActivityStateById,
-    {
-    priceMap: prices,
-    mTokenAddress: lpData?.mToken || null,
-    sTokenAddress: constants.sToken || null,
-    vaultShareTokenAddress: shareTokenAddress || null,
-    saveUsdstVaultAddress: appConfig.saveUsdstVault || null,
-  });
+  return {
+    lpData, smRow, stRow, vaultStorage, botExecutor, shareTokenAddress,
+    saveUsdstStorage, saveUsdstBalance,
+    prices, lendingCfg, liqBalance, filteredVaultAssets,
+    rewardActivityCfgById, rewardActivityStateById,
+    swapEvents, smEvents,
+  };
+}
 
-  // Phase 2: vault APY needs current balances + historical NAV context
+// ── Phase 1b: dependent parallel reads ────────────────────────────────────────
+
+async function fetchPhase1b(accessToken: string, ctx: Phase1Ctx, saveUsdstVault: string) {
+  const saveUsdstAsset = ctx.saveUsdstStorage?.assetToken ?? constants.USDST;
+  const saveUsdstManagedAssets = safeBigInt(ctx.saveUsdstStorage?._managedAssets);
+  const saveUsdstTotalShares = safeBigInt(ctx.saveUsdstStorage?._totalSupply);
+  const vaultAddr = constants.vault;
+
+  const [stablePools, shareTokenTotalSupply, vaultBalanceRows, saveUsdstApyResult] = await Promise.all([
+    fetchMultiTokenStablePools(accessToken).catch(() => []),
+    ctx.shareTokenAddress
+      ? (async () => {
+          const { data: rows } = await cirrus.get(accessToken, "/storage", { params: {
+            address: `eq.${ctx.shareTokenAddress}`,
+            select: "data->>_totalSupply",
+          }}).catch(() => ({ data: [] as any[] }));
+          return rows?.[0]?._totalSupply || await getTokenTotalSupply(accessToken, ctx.shareTokenAddress);
+        })()
+      : Promise.resolve("0"),
+    (vaultAddr && ctx.shareTokenAddress && ctx.botExecutor && ctx.filteredVaultAssets.length)
+      ? cirrus.get(accessToken, "/mapping", { params: {
+          address: `in.(${ctx.filteredVaultAssets.join(",")})`,
+          collection_name: "eq._balances",
+          "key->>key": `eq.${ctx.botExecutor}`,
+          select: "address,value::text",
+        }}).then(res => res.data ?? []).catch(() => [])
+      : Promise.resolve([] as any[]),
+    computeSaveUsdstApy(accessToken, saveUsdstVault, saveUsdstAsset, safeBigInt(ctx.saveUsdstBalance), saveUsdstManagedAssets, saveUsdstTotalShares),
+  ]);
+
+  return { stablePools, shareTokenTotalSupply, vaultBalanceRows, saveUsdstApyResult, saveUsdstManagedAssets, saveUsdstTotalShares, saveUsdstAsset };
+}
+
+// ── Phase 2: vault APY ────────────────────────────────────────────────────────
+
+async function computeVaultApys(
+  accessToken: string, vaultAddr: string, ctx: Phase1Ctx, phase1b: Phase1bData, rewardActivities: any[],
+) {
   let vaultAPY: string | null = null;
   let vaultRewardApy: string | null = null;
-  const vaultOracle = vaultStorage?.priceOracle || constants.priceOracle;
   const currentVaultBalances = new Map<string, string>();
-  for (const row of vaultBalanceRows || []) {
-    currentVaultBalances.set(row.address, row.value || "0");
-  }
-  if (vaultAddr && shareTokenAddress && botExecutor && filteredVaultAssets.length) {
-    const vaultEquity = computeEquityFromMaps(filteredVaultAssets, currentVaultBalances, prices);
-    const vaultTotalShares = safeBigInt(shareTokenTotalSupply || "0");
+  for (const row of phase1b.vaultBalanceRows ?? []) currentVaultBalances.set(row.address, row.value ?? "0");
+
+  if (vaultAddr && ctx.shareTokenAddress && ctx.botExecutor && ctx.filteredVaultAssets.length) {
+    const vaultEquity = computeEquityFromMaps(ctx.filteredVaultAssets, currentVaultBalances, ctx.prices);
+    const vaultTotalShares = safeBigInt(phase1b.shareTokenTotalSupply ?? "0");
 
     const vaultMetrics = await computeVaultPerformanceMetrics(
-      accessToken,
-      vaultAddr,
-      vaultEquity,
-      vaultTotalShares,
-      shareTokenAddress,
-      botExecutor,
-      vaultOracle,
-      filteredVaultAssets,
-      prices
+      accessToken, vaultAddr, vaultEquity, vaultTotalShares, ctx.shareTokenAddress,
+      ctx.botExecutor, ctx.vaultStorage?.priceOracle ?? constants.priceOracle,
+      ctx.filteredVaultAssets, ctx.prices,
     );
 
-    vaultAPY = vaultMetrics.alpha !== "-" ? vaultMetrics.alpha : null;
+    vaultAPY = vaultMetrics.alpha !== APY_UNAVAILABLE ? vaultMetrics.alpha : null;
     const vaultRewardsActivity = findRewardActivity(rewardActivities, {
-      sourceContract: shareTokenAddress,
-      stakeAssetAddress: shareTokenAddress,
+      sourceContract: ctx.shareTokenAddress,
+      stakeAssetAddress: ctx.shareTokenAddress,
       nameIncludes: ["vault"],
     });
     if (vaultRewardsActivity && !vaultRewardsActivity.totalStakeUsd && vaultTotalShares > 0n && vaultEquity > 0n) {
       const sharePrice = ((vaultEquity * DECIMALS) / vaultTotalShares).toString();
-      vaultRewardsActivity.totalStakeUsd = toUsdValue(vaultRewardsActivity.totalStake || "0", sharePrice);
+      vaultRewardsActivity.totalStakeUsd = toUsdValue(vaultRewardsActivity.totalStake ?? "0", sharePrice);
     }
     vaultRewardApy = computeRewardsApy(vaultRewardsActivity?.emissionRate, vaultRewardsActivity?.totalStakeUsd);
   }
 
-  // Build result
-  const map = new Map<string, ApySource[]>();
-  const add = (t: string, e: ApySource) => { if (!map.has(t)) map.set(t, []); map.get(t)!.push(e); };
+  return { vaultAPY, vaultRewardApy, currentVaultBalances };
+}
 
-  if (lpData?.borrowableAsset && lendingCfg && liqBalance) {
-    const lendingAPY = computeLendingAPY(lpData, lendingCfg, liqBalance);
-    if (lendingAPY) {
-      add(lpData.borrowableAsset, { source: "lending", apy: lendingAPY });
-      if (lpData.mToken) add(lpData.mToken, { source: "lending", apy: lendingAPY });
-    }
-  }
+// ── APY assembly helpers ──────────────────────────────────────────────────────
 
-  const lendingRewardsActivity = rewardActivities.find((activity) => {
-    const name = String(activity?.name || "").toLowerCase();
-    const source = normalizeAddress(activity?.sourceContract);
-    const mTokenAddress = normalizeAddress(lpData?.mToken);
-    return name.includes("lending pool liquidity") || (!!mTokenAddress && source === mTokenAddress);
-  }) || null;
+function addLendingApys(add: AddFn, ctx: Phase1Ctx, rewardActivities: any[]) {
+  const { lpData, lendingCfg, liqBalance } = ctx;
+  if (!lpData?.borrowableAsset || !lendingCfg || !liqBalance) return;
+
+  const targets = [lpData.borrowableAsset, lpData.mToken].filter(Boolean);
+
+  const lendingAPY = computeLendingAPY(lpData, lendingCfg, liqBalance);
+  if (lendingAPY) for (const t of targets) add(t, { source: "lending", apy: lendingAPY });
+
+  const mTokenNorm = normalizeAddress(lpData.mToken);
+  const lendingRewardsActivity = rewardActivities.find(a => {
+    const name = String(a?.name ?? "").toLowerCase();
+    return name.includes("lending pool liquidity") || (!!mTokenNorm && a._srcNorm === mTokenNorm);
+  }) ?? null;
   const lendingRewardsApy = computeRewardsApy(lendingRewardsActivity?.emissionRate, lendingRewardsActivity?.totalStakeUsd);
-  if (lendingRewardsApy && lpData?.borrowableAsset) {
-    add(lpData.borrowableAsset, { source: "rewards", apy: lendingRewardsApy, meta: "lending" });
-    if (lpData.mToken) add(lpData.mToken, { source: "rewards", apy: lendingRewardsApy, meta: "lending" });
-  }
+  if (lendingRewardsApy) for (const t of targets) add(t, { source: "rewards", apy: lendingRewardsApy, meta: "lending" });
+}
 
-  const directMintRewardsActivity = findRewardActivity(rewardActivities, {
-    sourceContract: constants.mercataBridge,
+function addDirectMintRewards(add: AddFn, rewardActivities: any[]) {
+  const activity = findRewardActivity(rewardActivities, { sourceContract: constants.mercataBridge });
+  const apy = computeRewardsApy(activity?.emissionRate, activity?.totalStakeUsd);
+  if (apy) add(constants.USDST, { source: "rewards", apy, meta: "direct_mint" });
+}
+
+function addSaveUsdstApys(add: AddFn, ctx: Phase1Ctx, phase1b: Phase1bData, rewardActivities: any[], saveUsdstVault: string) {
+  const addr = normalizeAddress(saveUsdstVault);
+  if (!addr) return;
+
+  const nativeApy = isPositiveApy(phase1b.saveUsdstApyResult) ? phase1b.saveUsdstApyResult : null;
+
+  const liveBalance = safeBigInt(ctx.saveUsdstBalance);
+  const pricingAssets = liveBalance < phase1b.saveUsdstManagedAssets ? liveBalance : phase1b.saveUsdstManagedAssets;
+  const assetPrice = safeBigInt(ctx.prices.get(phase1b.saveUsdstAsset) ?? ctx.prices.get(constants.USDST));
+  const tvlUsd = assetPrice > 0n ? (pricingAssets * assetPrice) / DECIMALS : 0n;
+  const stakeUsd = tvlUsd > 0n ? tvlUsd.toString() : pricingAssets > 0n ? pricingAssets.toString() : null;
+
+  const rewardsActivity = findRewardActivity(rewardActivities, {
+    sourceContract: addr, stakeAssetAddress: addr, nameIncludes: ["save usdst", "saveusdst"],
   });
-  const directMintRewardsApy = computeRewardsApy(
-    directMintRewardsActivity?.emissionRate,
-    directMintRewardsActivity?.totalStakeUsd
-  );
-  if (directMintRewardsApy) {
-    add(constants.USDST, { source: "rewards", apy: directMintRewardsApy, meta: "direct_mint" });
-  }
+  const rewardsApy = computeRewardsApy(rewardsActivity?.emissionRate, rewardsActivity?.totalStakeUsd ?? stakeUsd);
 
-  const saveUsdstAddress = normalizeAddress(saveUsdstVault);
-  const saveUsdstNativeApy =
-    saveUsdstApyResult && saveUsdstApyResult !== "-" && parseFloat(saveUsdstApyResult) > 0
-      ? saveUsdstApyResult
-      : null;
-  const saveUsdstLiveBalance = safeBigInt(saveUsdstBalance);
-  const saveUsdstPricingAssets = saveUsdstLiveBalance < saveUsdstManagedAssets ? saveUsdstLiveBalance : saveUsdstManagedAssets;
-  const saveUsdstAssetPrice = safeBigInt(prices.get(saveUsdstAsset) || prices.get(constants.USDST));
-  const saveUsdstTvlUsd = saveUsdstAssetPrice > 0n ? (saveUsdstPricingAssets * saveUsdstAssetPrice) / DECIMALS : 0n;
-  const saveUsdstStakeUsd = saveUsdstTvlUsd > 0n ? saveUsdstTvlUsd.toString() : saveUsdstPricingAssets > 0n ? saveUsdstPricingAssets.toString() : null;
-  const saveUsdstRewardsActivity = saveUsdstAddress
-    ? findRewardActivity(rewardActivities, {
-        sourceContract: saveUsdstAddress,
-        stakeAssetAddress: saveUsdstAddress,
-        nameIncludes: ["save usdst", "saveusdst"],
-      })
-    : null;
-  const saveUsdstRewardsApy = computeRewardsApy(
-    saveUsdstRewardsActivity?.emissionRate,
-    saveUsdstRewardsActivity?.totalStakeUsd ?? saveUsdstStakeUsd
-  );
-  if (saveUsdstAddress) {
-    if (saveUsdstNativeApy) {
-      add(saveUsdstAddress, { source: "lending", apy: saveUsdstNativeApy, meta: "save_usdst" });
-    }
-    if (saveUsdstRewardsApy) {
-      add(saveUsdstAddress, { source: "rewards", apy: saveUsdstRewardsApy, meta: "save_usdst" });
-    }
-  }
+  if (nativeApy) add(addr, { source: "lending", apy: nativeApy, meta: "save_usdst" });
+  if (rewardsApy) add(addr, { source: "rewards", apy: rewardsApy, meta: "save_usdst" });
+}
 
-  // Build per-asset exchange rate APY from exchangeRates history mapping.
-  // Requires 2+ oracle data points on different calendar days before APY appears (see computeExchangeRateAPY).
-  const exchangeRateHistory = indexYieldHistoryRows(mergeBackfillRows(exchangeRateRows || []));
-
+function addBaseYieldApys(add: AddFn, exchangeRateHistory: any, anchorsMs: number[]): Map<string, number> {
   const baseYieldByAddr = new Map<string, number>();
   for (const { tokenAddress, tokenSymbol, baseSymbol } of yieldBenchmarks) {
     const apy = computeExchangeRateAPY(tokenAddress, exchangeRateHistory, anchorsMs);
@@ -294,226 +348,98 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     add(tokenAddress, { source: "base", apy: totalApy.toFixed(2), meta: `${tokenSymbol}/${baseSymbol}` });
     baseYieldByAddr.set(tokenAddress, totalApy);
   }
-  const vaultWeightedApy = currentVaultBalances.size > 0 && baseYieldByAddr.size > 0
-    ? weightedBaseYield(
-        filteredVaultAssets,
-        filteredVaultAssets.map((addr) => currentVaultBalances.get(addr) || "0"),
-        prices,
-        baseYieldByAddr
-      )
-    : null;
+  return baseYieldByAddr;
+}
 
-  const volumeMap = buildVolumeMap(swapEvents, prices);
-  const firstPool = (pools || [])[0];
-  const factorySwapFeeRate = Number(firstPool?.swapFeeRate || 30);
-  const factoryLpSharePercent = Number(firstPool?.lpSharePercent || 7000);
+function addPoolApys(
+  add: AddFn, pools: any[], stablePools: any[],
+  ctx: Phase1Ctx, rewardActivities: any[], baseYieldByAddr: Map<string, number>,
+) {
+  const volumeMap = buildVolumeMap(ctx.swapEvents, ctx.prices);
+  const firstPool = (pools ?? [])[0];
+  const factorySwapFeeRate = Number(firstPool?.swapFeeRate || DEFAULT_SWAP_FEE_BPS);
+  const factoryLpSharePercent = Number(firstPool?.lpSharePercent || DEFAULT_LP_SHARE_BPS);
   const stablePoolAddresses = new Set(
-    (stablePools || []).map((pool: any) => normalizeAddress(pool?.address)).filter(Boolean)
+    (stablePools ?? []).map((pool: any) => normalizeAddress(pool?.address)).filter(Boolean),
   );
-  const activePools = (pools || []).filter((p: any) =>
+
+  const tokenSymbolMap = new Map<string, string>();
+  for (const p of pools ?? []) {
+    if (p.tokenA?.address) tokenSymbolMap.set(normalizeAddress(p.tokenA.address), p.tokenA._symbol);
+    if (p.tokenB?.address) tokenSymbolMap.set(normalizeAddress(p.tokenB.address), p.tokenB._symbol);
+  }
+
+  const activePools = (pools ?? []).filter((p: any) =>
     p.tokenA?.address && p.tokenB?.address && p.lpToken?.address &&
     !p.isPaused && !p.isDisabled &&
     !(p.tokenABalance === "0" && p.tokenBBalance === "0") &&
     !hiddenSwapPools.has(p.address) &&
     !stablePoolAddresses.has(normalizeAddress(p.address))
   );
-  for (const p of activePools) {
-    const meta = `${p.tokenA._symbol}-${p.tokenB._symbol}`;
-    const poolAddress = String(p.address ?? "").toLowerCase().replace(/^0x/, "");
-    const lpTokenAddress = p.lpToken.address;
-    const swapApy = computePoolAPY(p, prices, volumeMap);
-    const tokenABaseApy = baseYieldByAddr.get(p.tokenA.address);
-    const tokenBBaseApy = baseYieldByAddr.get(p.tokenB.address);
-    const poolRewardActivity = findPoolRewardActivity(rewardActivities, {
-      poolAddress,
-      lpTokenAddress,
-    });
-    const poolRewardApy = computeRewardsApy(poolRewardActivity?.emissionRate, poolRewardActivity?.totalStakeUsd);
 
-    if (swapApy !== ZERO_APY) {
-      const row = { source: "swap" as const, apy: swapApy, meta, ...(poolAddress ? { poolAddress } : {}) };
-      add(lpTokenAddress, row);
-      add(p.tokenA.address, row);
-      add(p.tokenB.address, row);
-    }
-    if (baseYieldByAddr.size > 0) {
-      const wApy = weightedBaseYield([p.tokenA.address, p.tokenB.address], [p.tokenABalance || "0", p.tokenBBalance || "0"], prices, baseYieldByAddr);
-      if (wApy) {
-        add(lpTokenAddress, { source: "weighted_swap", apy: wApy, meta, ...(poolAddress ? { poolAddress } : {}) });
-      }
-    }
-    if (tokenABaseApy && tokenABaseApy > 0) {
-      add(p.tokenA.address, { source: "base", apy: tokenABaseApy.toFixed(2), meta, ...(poolAddress ? { poolAddress } : {}) });
-    }
-    if (tokenBBaseApy && tokenBBaseApy > 0) {
-      add(p.tokenB.address, { source: "base", apy: tokenBBaseApy.toFixed(2), meta, ...(poolAddress ? { poolAddress } : {}) });
-    }
-    if (poolRewardApy) {
-      const rewardRow = { source: "rewards" as const, apy: poolRewardApy, meta, ...(poolAddress ? { poolAddress } : {}) };
-      add(lpTokenAddress, rewardRow);
-      add(p.tokenA.address, rewardRow);
-      add(p.tokenB.address, rewardRow);
-    }
+  for (const p of activePools) {
+    const { tokenA, tokenB, lpToken, tokenABalance, tokenBBalance, address } = p;
+    const meta = `${tokenA._symbol}-${tokenB._symbol}`;
+    const poolAddress = normalizeAddress(address);
+    const lpTokenAddress = lpToken.address;
+    const tokenAddrs = [tokenA.address, tokenB.address];
+    const swapApy = computePoolAPY(p, ctx.prices, volumeMap);
+    const rewardActivity = findPoolRewardActivity(rewardActivities, { poolAddress, lpTokenAddress });
+    const poolRewardApy = computeRewardsApy(rewardActivity?.emissionRate, rewardActivity?.totalStakeUsd);
+    const wApy = baseYieldByAddr.size > 0
+      ? weightedBaseYield(tokenAddrs, [tokenABalance ?? "0", tokenBBalance ?? "0"], ctx.prices, baseYieldByAddr)
+      : null;
+
+    emitPoolApys(add, poolAddress, lpTokenAddress, meta, tokenAddrs, swapApy, poolRewardApy, wApy, baseYieldByAddr);
   }
 
-  for (const stablePool of stablePools || []) {
+  for (const stablePool of stablePools ?? []) {
     const poolAddress = normalizeAddress(stablePool?.address);
     const lpTokenAddress = stablePool?.lpToken;
-    const coinAddresses = (stablePool?.coins || []).map((coin: any) => coin?.tokenAddress).filter(Boolean);
-    if (!poolAddress || !lpTokenAddress || coinAddresses.length === 0 || hiddenSwapPools.has(poolAddress)) continue;
+    const tokenAddrs: string[] = (stablePool?.coins ?? []).map((coin: any) => coin?.tokenAddress).filter(Boolean);
+    if (!poolAddress || !lpTokenAddress || tokenAddrs.length === 0 || hiddenSwapPools.has(poolAddress)) continue;
 
-    const meta = coinAddresses
-      .map((address: string) => {
-        const poolRow = (pools || []).find((pool: any) =>
-          normalizeAddress(pool?.tokenA?.address) === normalizeAddress(address) ||
-          normalizeAddress(pool?.tokenB?.address) === normalizeAddress(address)
-        );
-        if (normalizeAddress(poolRow?.tokenA?.address) === normalizeAddress(address)) return poolRow?.tokenA?._symbol;
-        if (normalizeAddress(poolRow?.tokenB?.address) === normalizeAddress(address)) return poolRow?.tokenB?._symbol;
-        return null;
-      })
-      .filter(Boolean)
-      .join("-");
+    const meta = tokenAddrs.map(a => tokenSymbolMap.get(normalizeAddress(a))).filter(Boolean).join("-");
 
     let totalTvlUsd = 0;
-    for (const address of coinAddresses) {
-      const balanceRaw = stablePool?.tokenBalances?.get?.(address) || stablePool?.tokenBalances?.get?.(normalizeAddress(address)) || "0";
-      const priceRaw = prices.get(address) || prices.get(normalizeAddress(address)) || "0";
-      totalTvlUsd += Number((BigInt(balanceRaw) * BigInt(priceRaw)) / DECIMALS) / 1e18;
+    const balances: string[] = [];
+    for (const address of tokenAddrs) {
+      const addrNorm = normalizeAddress(address);
+      const bal = stablePool?.tokenBalances?.get?.(address) ?? stablePool?.tokenBalances?.get?.(addrNorm) ?? "0";
+      balances.push(bal);
+      const priceRaw = ctx.prices.get(address) ?? ctx.prices.get(addrNorm) ?? "0";
+      totalTvlUsd += Number((BigInt(bal) * BigInt(priceRaw)) / DECIMALS) / 1e18;
     }
 
-    const volume24h = volumeMap.get(stablePool.address) || volumeMap.get(poolAddress) || 0;
+    const volume24h = volumeMap.get(stablePool.address) ?? volumeMap.get(poolAddress) ?? 0;
     const swapApyValue = totalTvlUsd > 0
-      ? (volume24h * (factorySwapFeeRate / 10000) * (factoryLpSharePercent / 10000) / totalTvlUsd) * 365 * 100
+      ? (volume24h * (factorySwapFeeRate / BPS_DIVISOR) * (factoryLpSharePercent / BPS_DIVISOR) / totalTvlUsd) * 365 * 100
       : 0;
     const swapApy = swapApyValue > 0 ? swapApyValue.toFixed(2) : ZERO_APY;
+    const rewardActivity = findPoolRewardActivity(rewardActivities, { poolAddress, lpTokenAddress });
+    const poolRewardApy = computeRewardsApy(rewardActivity?.emissionRate, rewardActivity?.totalStakeUsd);
+    const wApy = weightedBaseYield(tokenAddrs, balances, ctx.prices, baseYieldByAddr);
 
-    const poolRewardActivity = findPoolRewardActivity(rewardActivities, {
-      poolAddress,
-      lpTokenAddress,
-    });
-    const poolRewardApy = computeRewardsApy(poolRewardActivity?.emissionRate, poolRewardActivity?.totalStakeUsd);
-    const weightedApy = weightedBaseYield(
-      coinAddresses,
-      coinAddresses.map((address: string) =>
-        stablePool?.tokenBalances?.get?.(address) || stablePool?.tokenBalances?.get?.(normalizeAddress(address)) || "0"
-      ),
-      prices,
-      baseYieldByAddr
-    );
-
-    if (swapApy !== ZERO_APY) {
-      const row = { source: "swap" as const, apy: swapApy, meta, poolAddress };
-      add(lpTokenAddress, row);
-      coinAddresses.forEach((address: string) => add(address, row));
-    }
-    if (weightedApy) {
-      add(lpTokenAddress, { source: "weighted_swap", apy: weightedApy, meta, poolAddress });
-    }
-    coinAddresses.forEach((address: string) => {
-      const tokenBaseApy = baseYieldByAddr.get(address);
-      if (tokenBaseApy && tokenBaseApy > 0) {
-        add(address, { source: "base", apy: tokenBaseApy.toFixed(2), meta, poolAddress });
-      }
-    });
-    if (poolRewardApy) {
-      const rewardRow = { source: "rewards" as const, apy: poolRewardApy, meta, poolAddress };
-      add(lpTokenAddress, rewardRow);
-      coinAddresses.forEach((address: string) => add(address, rewardRow));
-    }
+    emitPoolApys(add, poolAddress, lpTokenAddress, meta, tokenAddrs, swapApy, poolRewardApy, wApy, baseYieldByAddr);
   }
-
-  if (shareTokenAddress) {
-    if (vaultAPY && vaultAPY !== "-" && parseFloat(vaultAPY) > 0) {
-      add(shareTokenAddress, { source: "vault", apy: vaultAPY });
-    }
-    if (vaultWeightedApy && parseFloat(vaultWeightedApy) > 0) {
-      add(shareTokenAddress, { source: "vault_weighted", apy: vaultWeightedApy });
-    }
-    if (vaultRewardApy && parseFloat(vaultRewardApy) > 0) {
-      add(shareTokenAddress, { source: "rewards", apy: vaultRewardApy, meta: "vault" });
-    }
-  }
-
-  const safetyAPY = computeSafetyAPY(smRow, stRow, smEvents);
-  if (safetyAPY) add(constants.USDST, { source: "safety", apy: safetyAPY });
-
-  return [...map.entries()].map(([token, apys]) => ({ token, apys }));
-};
-
-function computeLendingAPY(lp: any, cfg: any, availableLiquidity: string): string | null {
-  const { supplyAPY: maxSupplyAPY } = calculateAPYs(cfg.interestRate ?? 0, cfg.reserveFactor ?? 1000);
-  const debt = BigInt(totalDebtFromScaled(lp.totalScaledDebt || "0", lp.borrowIndex || "0"));
-  const cash = BigInt(availableLiquidity);
-  const reserves = BigInt(lp.reservesAccrued || "0");
-  const total = cash + debt;
-  const denom = total - (reserves < total ? reserves : total);
-  const util = denom > 0n ? Number(debt * 10000n / denom) / 100 : 0;
-  const apy = maxSupplyAPY * (util / 100);
-  return apy > 0 ? apy.toFixed(2) : null;
 }
 
-function computeSafetyAPY(smRow: any, stRow: any, events: any[]): string | null {
-  const totalAssetsNow = BigInt(smRow?._managedAssets || "0");
-  const totalSharesNow = BigInt(stRow?._totalSupply || "0");
-  if (totalSharesNow <= 0n) return null;
+function emitPoolApys(
+  add: AddFn, poolAddress: string, lpTokenAddress: string, meta: string, tokenAddrs: string[],
+  swapApy: string, poolRewardApy: string | null, wApy: string | null, baseYieldByAddr: Map<string, number>,
+) {
+  const broadcast = (row: ApySource) => { add(lpTokenAddress, row); for (const t of tokenAddrs) add(t, row); };
 
-  let assetsDelta = 0n, sharesDelta = 0n;
-  for (const e of events) {
-    const a = e.attributes;
-    switch (e.event_name) {
-      case "Staked":          assetsDelta += BigInt(a.assetsIn || "0"); sharesDelta += BigInt(a.sharesOut || "0"); break;
-      case "Redeemed":        assetsDelta -= BigInt(a.assetsOut || "0"); sharesDelta -= BigInt(a.sharesIn || "0"); break;
-      case "RewardNotified":  assetsDelta += BigInt(a.amount || "0"); break;
-      case "ShortfallCovered": assetsDelta -= BigInt(a.amount || "0"); break;
-    }
+  if (swapApy !== ZERO_APY) broadcast({ source: "swap", apy: swapApy, meta, poolAddress });
+  if (wApy) add(lpTokenAddress, { source: "weighted_swap", apy: wApy, meta, poolAddress });
+  for (const addr of tokenAddrs) {
+    const base = baseYieldByAddr.get(addr);
+    if (base && base > 0) add(addr, { source: "base", apy: base.toFixed(2), meta, poolAddress });
   }
-
-  const totalAssetsStart = totalAssetsNow - assetsDelta;
-  const totalSharesStart = totalSharesNow - sharesDelta;
-  if (totalSharesStart <= 0n || totalAssetsStart <= 0n) return null;
-
-  const rateNow = Number(totalAssetsNow) / Number(totalSharesNow);
-  const rateStart = Number(totalAssetsStart) / Number(totalSharesStart);
-  const periodReturn = rateNow / rateStart - 1;
-  if (periodReturn <= -1 || !isFinite(periodReturn)) return null;
-
-  return ((Math.pow(1 + periodReturn, 365 / 30) - 1) * 100).toFixed(2);
+  if (poolRewardApy) broadcast({ source: "rewards", apy: poolRewardApy, meta, poolAddress });
 }
 
-function buildVolumeMap(swapEvents: any[], prices: Map<string, string>): Map<string, number> {
-  const map = new Map<string, number>();
-  for (const e of swapEvents) {
-    const tokenIn = e.attributes?.tokenIn || e.tokenIn;
-    const amountIn = e.attributes?.amountIn || e.amountIn || "0";
-    const price = BigInt(prices.get(tokenIn) || "0");
-    const volUSD = Number((BigInt(amountIn) * price) / DECIMALS) / 1e18;
-    map.set(e.address, (map.get(e.address) || 0) + volUSD);
-  }
-  return map;
-}
-
-function computePoolAPY(pool: any, prices: Map<string, string>, volumeMap: Map<string, number>): string {
-  const vol = volumeMap.get(pool.address) || 0;
-  const feeRate = pool.swapFeeRate || 30;
-  const lpShare = pool.lpSharePercent || 7000;
-  const lpFees = vol * (feeRate / 10000) * (lpShare / 10000);
-  const priceA = BigInt(prices.get(pool.tokenA.address) || "0");
-  const priceB = BigInt(prices.get(pool.tokenB.address) || "0");
-  const tvl = Number((BigInt(pool.tokenABalance || "0") * priceA + BigInt(pool.tokenBBalance || "0") * priceB) / DECIMALS) / 1e18;
-  const apy = tvl > 0 ? (lpFees / tvl) * 365 * 100 : 0;
-  return apy.toFixed(2);
-}
-
-function weightedBaseYield(addrs: string[], bals: string[], prices: Map<string, string>, baseYields: Map<string, number>): string | null {
-  let ws = 0, total = 0;
-  for (let i = 0; i < addrs.length; i++) {
-    const usd = Number((safeBigInt(bals[i]) * safeBigInt(prices.get(addrs[i]))) / DECIMALS) / 1e18;
-    total += usd;
-    ws += usd * (baseYields.get(addrs[i]) || 0);
-  }
-  return total > 0 && ws > 0 ? (ws / total).toFixed(2) : null;
-}
+// ── Cirrus helpers ────────────────────────────────────────────────────────────
 
 async function getTokenTotalSupply(accessToken: string, tokenAddress: string): Promise<string> {
   try {
@@ -521,234 +447,25 @@ async function getTokenTotalSupply(accessToken: string, tokenAddress: string): P
       select: "_totalSupply::text",
       address: `eq.${tokenAddress}`,
     }});
-    return data?.[0]?._totalSupply || "0";
+    return data?.[0]?._totalSupply ?? "0";
   } catch {
     return "0";
   }
 }
 
-function buildRewardActivitiesFromMappings(
-  activityCfgById: Map<string, any>,
-  activityStateById: Map<string, any>,
-  pricingCtx: {
-    priceMap: Map<string, string>;
-    mTokenAddress: string | null;
-    sTokenAddress: string | null;
-    vaultShareTokenAddress: string | null;
-    saveUsdstVaultAddress: string | null;
-  }
-): any[] {
-  const activities: any[] = [];
-  for (const [activityId, activity] of activityCfgById.entries()) {
-    const state = activityStateById.get(activityId);
-    const sourceContract = String(activity?.sourceContract || "");
-    const totalStake = String(state?.totalStake || "0");
-    const name = String(activity?.name || "");
-    const emissionRate = String(activity?.emissionRate || "0");
-
-    const { stakeAssetAddress, totalStakeUsd } = computeRewardStakeUsd(
-      sourceContract,
-      name,
-      totalStake,
-      pricingCtx
-    );
-
-    activities.push({
-      activityId: Number(activityId),
-      name,
-      emissionRate,
-      sourceContract,
-      stakeAssetAddress,
-      totalStake,
-      totalStakeUsd,
-    });
-  }
-  return activities;
-}
-
-function computeRewardStakeUsd(
-  sourceContractRaw: string,
-  name: string,
-  totalStake: string,
-  ctx: {
-    priceMap: Map<string, string>;
-    mTokenAddress: string | null;
-    sTokenAddress: string | null;
-    vaultShareTokenAddress: string | null;
-    saveUsdstVaultAddress: string | null;
-  }
-): { stakeAssetAddress: string | null; totalStakeUsd: string | null } {
-  const sourceContract = normalizeAddress(sourceContractRaw);
-  const saveUsdstSource = normalizeAddress(ctx.saveUsdstVaultAddress);
-
-  const isUsdNotional =
-    USD_NOTIONAL_SWAP_SOURCES.has(sourceContract) ||
-    USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES.has(sourceContract) ||
-    USD_NOTIONAL_AMOUNT_USD_SOURCES.has(sourceContract);
-  if (isUsdNotional) {
-    return { stakeAssetAddress: null, totalStakeUsd: totalStake || "0" };
-  }
-
-  const stakeAssetAddress =
-    TOKEN_UNITS_SOURCES.has(sourceContract) || (saveUsdstSource && sourceContract === saveUsdstSource)
-      ? sourceContract
-      : null;
-
-  const directStakePrice = stakeAssetAddress ? getPriceForAddress(ctx.priceMap, stakeAssetAddress) : null;
-  if (directStakePrice) {
-    return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, directStakePrice) };
-  }
-
-  const lower = (name || "").toLowerCase();
-  if (lower.includes("safety")) {
-    const sTokenPrice = getPriceForAddress(ctx.priceMap, ctx.sTokenAddress);
-    if (sTokenPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, sTokenPrice) };
-  }
-
-  if (lower.includes("lending pool liquidity")) {
-    const mTokenPrice = getPriceForAddress(ctx.priceMap, ctx.mTokenAddress);
-    if (mTokenPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, mTokenPrice) };
-  }
-
-  if (lower.includes("borrow")) {
-    return { stakeAssetAddress, totalStakeUsd: totalStake || "0" };
-  }
-
-  if (lower.includes("vault")) {
-    const vaultPrice = getPriceForAddress(ctx.priceMap, ctx.vaultShareTokenAddress);
-    if (vaultPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, vaultPrice) };
-  }
-
-  return { stakeAssetAddress, totalStakeUsd: null };
-}
-
-function getPriceForAddress(priceMap: Map<string, string>, address?: string | null): string | null {
-  if (!address) return null;
-  return priceMap.get(address) || priceMap.get(normalizeAddress(address)) || null;
-}
-
-function toUsdValue(amountWei: string, priceWei: string): string {
-  const amount = BigInt(amountWei || "0");
-  const price = BigInt(priceWei || "0");
-  if (amount === 0n || price === 0n) return "0";
-  return ((amount * price) / DECIMALS).toString();
-}
-
-function parseMappingValue(raw: string): any | null {
-  try {
-    const parsed = JSON.parse(raw || "{}");
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function computeRewardsApy(emissionRateRaw?: string, totalStakeUsdRaw?: string | null): string | null {
-  try {
-    if (!emissionRateRaw || !totalStakeUsdRaw) return null;
-    const emissionRate = BigInt(emissionRateRaw);
-    const totalStakeUsd = BigInt(totalStakeUsdRaw);
-    if (emissionRate <= 0n || totalStakeUsd <= 0n) return null;
-
-    const tvlUsd = Number(totalStakeUsd) / 1e18;
-    const annualCata = (Number(emissionRate) / 1e18) * 86400 * 365;
-    if (!isFinite(tvlUsd) || tvlUsd <= 0 || !isFinite(annualCata) || annualCata <= 0) return null;
-
-    const apy = ((annualCata * CATA_PRICE_USD) / tvlUsd) * 100;
-    return apy > 0 && isFinite(apy) ? apy.toFixed(2) : null;
-  } catch {
-    return null;
-  }
-}
-
-function normalizeAddress(value?: string | null): string {
-  return (value || "").toLowerCase().replace(/^0x/, "");
-}
-
-function findRewardActivity(
-  activities: any[],
-  options: {
-    sourceContract?: string | null;
-    stakeAssetAddress?: string | null;
-    nameIncludes?: string[];
-  }
-): any | null {
-  const normalizedSource = normalizeAddress(options.sourceContract);
-  const normalizedStakeAsset = normalizeAddress(options.stakeAssetAddress);
-  const nameMatchers = (options.nameIncludes || []).map((name) => name.toLowerCase());
-
-  const matches = activities.filter((activity) => {
-    const source = normalizeAddress(activity?.sourceContract);
-    const stakeAsset = normalizeAddress(activity?.stakeAssetAddress);
-    const name = String(activity?.name || "").toLowerCase();
-
-    if (normalizedSource && source !== normalizedSource) return false;
-    if (normalizedStakeAsset && stakeAsset && stakeAsset !== normalizedStakeAsset) return false;
-    if (nameMatchers.length > 0 && !nameMatchers.some((matcher) => name.includes(matcher))) return false;
-    return true;
-  });
-
-  if (matches.length === 0) return null;
-
-  const exactStakeAssetMatch = matches.find(
-    (activity) => normalizedStakeAsset && normalizeAddress(activity?.stakeAssetAddress) === normalizedStakeAsset
-  );
-  if (exactStakeAssetMatch) return exactStakeAssetMatch;
-
-  const withUsdStake = matches.find((activity) => safeBigInt(activity?.totalStakeUsd || "0") > 0n);
-  return withUsdStake || matches[0];
-}
-
-function findPoolRewardActivity(
-  activities: any[],
-  options: {
-    poolAddress?: string | null;
-    lpTokenAddress?: string | null;
-  }
-): any | null {
-  const normalizedPool = normalizeAddress(options.poolAddress);
-  const normalizedLpToken = normalizeAddress(options.lpTokenAddress);
-
-  const matches = activities.filter((activity) => {
-    const source = normalizeAddress(activity?.sourceContract);
-    const stakeAsset = normalizeAddress(activity?.stakeAssetAddress);
-    return (
-      (normalizedPool && source === normalizedPool) ||
-      (normalizedLpToken && source === normalizedLpToken) ||
-      (normalizedLpToken && stakeAsset === normalizedLpToken)
-    );
-  });
-
-  if (matches.length === 0) return null;
-
-  const exactLpStakeMatch = matches.find(
-    (activity) => normalizedLpToken && normalizeAddress(activity?.stakeAssetAddress) === normalizedLpToken
-  );
-  if (exactLpStakeMatch) return exactLpStakeMatch;
-
-  const exactPoolSourceMatch = matches.find(
-    (activity) => normalizedPool && normalizeAddress(activity?.sourceContract) === normalizedPool
-  );
-  if (exactPoolSourceMatch) return exactPoolSourceMatch;
-
-  const withUsdStake = matches.find((activity) => safeBigInt(activity?.totalStakeUsd || "0") > 0n);
-  return withUsdStake || matches[0];
-}
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-const firstSaveUsdstDepositCache = new Map<string, { timestamp: Date } | null>();
+// ── SaveUSDST APY (with 60s TTL cache) ───────────────────────────────────────
 
 async function computeSaveUsdstApy(
-  accessToken: string,
-  vaultAddress: string | undefined,
-  assetAddress: string,
-  liveBalance: bigint,
-  managedAssets: bigint,
-  totalShares: bigint,
+  accessToken: string, vaultAddress: string | undefined, assetAddress: string,
+  liveBalance: bigint, managedAssets: bigint, totalShares: bigint,
 ): Promise<string> {
-  if (!vaultAddress || totalShares <= 0n) return "0.00";
+  if (!vaultAddress || totalShares <= 0n) return ZERO_APY;
+
+  const cached = saveUsdstApyCache.get(vaultAddress);
+  if (cached && cached.expiry > Date.now()) return cached.value;
+
   const pricingAssets = liveBalance < managedAssets ? liveBalance : managedAssets;
-  if (pricingAssets <= 0n) return "0.00";
+  if (pricingAssets <= 0n) return ZERO_APY;
 
   try {
     let firstDeposit = firstSaveUsdstDepositCache.get(vaultAddress);
@@ -763,7 +480,7 @@ async function computeSaveUsdstApy(
       firstDeposit = data?.[0]?.block_timestamp ? { timestamp: new Date(data[0].block_timestamp) } : null;
       firstSaveUsdstDepositCache.set(vaultAddress, firstDeposit);
     }
-    if (!firstDeposit?.timestamp) return "0.00";
+    if (!firstDeposit?.timestamp) return ZERO_APY;
 
     const nowMs = Date.now();
     const startMs = Math.max(nowMs - 30 * DAY_MS, firstDeposit.timestamp.getTime());
@@ -790,20 +507,26 @@ async function computeSaveUsdstApy(
     const histManagedAssets = safeBigInt(histStorageRows?.[0]?.data?._managedAssets);
     const histTotalShares = safeBigInt(histStorageRows?.[0]?.data?._totalSupply);
     const histBalance = safeBigInt(histBalanceRows?.[0]?.value);
-    if (histTotalShares <= 0n) return "-";
+    if (histTotalShares <= 0n) { cacheApyResult(vaultAddress, APY_UNAVAILABLE); return APY_UNAVAILABLE; }
 
     const histPricingAssets = histBalance < histManagedAssets ? histBalance : histManagedAssets;
-    const rateNow = totalShares > 0n ? (pricingAssets * DECIMALS) / totalShares : DECIMALS;
+    const rateNow = (pricingAssets * DECIMALS) / totalShares;
     const rateStart = histTotalShares > 0n && histPricingAssets > 0n ? (histPricingAssets * DECIMALS) / histTotalShares : 0n;
-    if (rateStart <= 0n) return "0.00";
+    if (rateStart <= 0n) { cacheApyResult(vaultAddress, ZERO_APY); return ZERO_APY; }
 
     const periodReturn = Number(((rateNow - rateStart) * DECIMALS) / rateStart) / 1e18;
-    if (!isFinite(periodReturn) || periodReturn <= -1) return "-";
+    if (!isFinite(periodReturn) || periodReturn <= -1) { cacheApyResult(vaultAddress, APY_UNAVAILABLE); return APY_UNAVAILABLE; }
 
     const annualizationDays = Math.max(30, lookbackDays);
     const apy = (Math.pow(1 + periodReturn, 365 / annualizationDays) - 1) * 100;
-    return isFinite(apy) ? apy.toFixed(2) : "-";
+    const result = isFinite(apy) ? apy.toFixed(2) : APY_UNAVAILABLE;
+    cacheApyResult(vaultAddress, result);
+    return result;
   } catch {
-    return "-";
+    return APY_UNAVAILABLE;
   }
+}
+
+function cacheApyResult(vaultAddress: string, value: string) {
+  saveUsdstApyCache.set(vaultAddress, { value, expiry: Date.now() + SAVE_USDST_APY_TTL_MS });
 }

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -1,22 +1,36 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { hiddenSwapPools, yieldBenchmarks, compositeYieldMap } from "../../config/config";
+import * as appConfig from "../../config/config";
 import { toUTCTime } from "../helpers/cirrusHelpers";
 import { buildYieldAnchorOverlapFilter, computeExchangeRateAPY, getYieldWindowBounds, indexYieldHistoryRows, mergeBackfillRows } from "../helpers/earnYield.helper";
 import { totalDebtFromScaled, calculateAPYs } from "../helpers/lending.helper";
-import { fetchMultiTokenStablePools } from "../helpers/swapping.helper";
+import { calculateLPTokenPrice, fetchMultiTokenStablePools } from "../helpers/swapping.helper";
+import stakeSemanticsConfig from "./rewardsStakeSemantics.json";
 import {
   computeEquityFromMaps,
   computeVaultPerformanceMetrics,
   safeBigInt,
 } from "../helpers/vaultPerformance.helper";
-import { fetchAllActivities } from "./rewards.service";
 import { getSaveUsdstInfo } from "./saveUsdst.service";
 import { ApySource, TokenApyEntry } from "@mercata/shared-types";
 
 const { Pool, DECIMALS, Vault, Token } = constants;
 const ZERO_APY = "0.00";
 const CATA_PRICE_USD = 0.25;
+const STAKE_SEMANTICS = stakeSemanticsConfig as any;
+const USD_NOTIONAL_SWAP_SOURCES = new Set<string>(
+  STAKE_SEMANTICS.usd_notional.swapSources.map((source: string) => normalizeAddress(source))
+);
+const USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES = new Set<string>(
+  STAKE_SEMANTICS.usd_notional.depositCompletedSources.map((source: string) => normalizeAddress(source))
+);
+const USD_NOTIONAL_AMOUNT_USD_SOURCES = new Set<string>(
+  STAKE_SEMANTICS.usd_notional.amountUsdSources.map((source: string) => normalizeAddress(source))
+);
+const TOKEN_UNITS_SOURCES = new Set<string>(
+  STAKE_SEMANTICS.token_units.lpMintBurnSources.map((source: string) => normalizeAddress(source))
+);
 
 export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]> => {
   const now = Date.now();
@@ -24,8 +38,9 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const thirtyDaysAgo = toUTCTime(new Date(now - 30 * 24 * 60 * 60 * 1000));
   const { windowStart, windowEndExclusive, anchorsMs } = getYieldWindowBounds(now);
   const vaultAddr = constants.vault;
+  const rewardsAddr = appConfig.rewards;
 
-  const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""})`;
+  const mappingOr = `(and(address.eq.${constants.lendingPool},collection_name.eq.assetConfigs,key->>key.eq.${constants.USDST}),and(address.eq.${constants.USDST},collection_name.eq._balances,key->>key.eq.${constants.liquidityPool}),and(address.eq.${constants.priceOracle},collection_name.eq.prices)${vaultAddr ? `,and(address.eq.${vaultAddr},collection_name.eq.supportedAssets)` : ""}${rewardsAddr ? `,and(address.eq.${rewardsAddr},collection_name.in.(activities,activityStates))` : ""})`;
   const eventOr = `(and(event_name.eq.Swap,block_timestamp.gte.${twentyFourHoursAgo}),and(address.eq.${constants.safetyModule},event_name.in.(Staked,Redeemed,RewardNotified,ShortfallCovered),block_timestamp.gte.${thirtyDaysAgo}))`;
 
   // Phase 1: parallel calls
@@ -51,7 +66,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     cirrus.get(accessToken, `/${constants.Event}`, { params: { select: "address,event_name,attributes,block_timestamp", or: eventOr } }),
     cirrus.get(accessToken, `/${Pool}`, { params: {
       poolFactory: `eq.${constants.poolFactory}`,
-      select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
+      select: "address,tokenA:tokenA_fkey(address,_symbol),tokenB:tokenB_fkey(address,_symbol),lpToken:lpToken_fkey(address,_symbol,_totalSupply::text),tokenABalance::text,tokenBBalance::text,swapFeeRate,lpSharePercent,isPaused,isDisabled",
     }}),
     vaultAddr
       ? cirrus.get(accessToken, `/${Vault}`, { params: {
@@ -86,6 +101,8 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   let lendingCfg: any = null;
   let liqBalance: string | null = null;
   const vaultAssets: string[] = [];
+  const rewardActivityCfgById = new Map<string, any>();
+  const rewardActivityStateById = new Map<string, any>();
   for (const r of mappingRows || []) {
     if (r.collection_name === "prices") prices.set(r.key, r.value);
     else if (r.collection_name === "assetConfigs") lendingCfg = JSON.parse(r.value);
@@ -93,6 +110,13 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     else if (r.collection_name === "supportedAssets" && r.value) {
       const addr = r.value.replace(/"/g, "");
       if (addr) vaultAssets.push(addr);
+    } else if (rewardsAddr && normalizeAddress(r.address) === normalizeAddress(rewardsAddr) && r.value) {
+      const parsed = parseMappingValue(r.value);
+      if (!parsed) continue;
+      const activityId = String(r.key || "");
+      if (!activityId) continue;
+      if (r.collection_name === "activities") rewardActivityCfgById.set(activityId, parsed);
+      else if (r.collection_name === "activityStates") rewardActivityStateById.set(activityId, parsed);
     }
   }
 
@@ -105,7 +129,28 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     }
   }
 
-  const rewardActivities = await fetchAllActivities(accessToken).catch(() => []);
+  // Enrich prices with LP token prices from Phase 1 pool data (needed for reward stake USD)
+  for (const p of pools || []) {
+    if (p.lpToken?.address && p.lpToken._totalSupply) {
+      const lpPrice = calculateLPTokenPrice(
+        p.tokenABalance || "0", p.tokenBBalance || "0",
+        prices.get(p.tokenA?.address) || "0", prices.get(p.tokenB?.address) || "0",
+        p.lpToken._totalSupply
+      );
+      if (lpPrice !== "0") prices.set(p.lpToken.address, lpPrice);
+    }
+  }
+
+  const rewardActivities = buildRewardActivitiesFromMappings(
+    rewardActivityCfgById,
+    rewardActivityStateById,
+    {
+    priceMap: prices,
+    mTokenAddress: lpData?.mToken || null,
+    sTokenAddress: constants.sToken || null,
+    vaultShareTokenAddress: shareTokenAddress || null,
+    saveUsdstVaultAddress: appConfig.saveUsdstVault || null,
+  });
   const [{ data: poolFactoryRows }, stablePools] = await Promise.all([
     cirrus.get(accessToken, `/${constants.PoolFactory}`, {
       params: {
@@ -126,11 +171,14 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     const balances = await getCurrentVaultBalances(accessToken, filteredVaultAssets, botExecutor);
     balances.forEach((value, key) => currentVaultBalances.set(key, value));
 
+    const vaultEquity = computeEquityFromMaps(filteredVaultAssets, currentVaultBalances, prices);
+    const vaultTotalShares = safeBigInt(await getTokenTotalSupply(accessToken, shareTokenAddress));
+
     const vaultMetrics = await computeVaultPerformanceMetrics(
       accessToken,
       vaultAddr,
-      computeEquityFromMaps(filteredVaultAssets, currentVaultBalances, prices),
-      safeBigInt(await getTokenTotalSupply(accessToken, shareTokenAddress)),
+      vaultEquity,
+      vaultTotalShares,
       shareTokenAddress,
       botExecutor,
       vaultOracle,
@@ -144,6 +192,10 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
       stakeAssetAddress: shareTokenAddress,
       nameIncludes: ["vault"],
     });
+    if (vaultRewardsActivity && !vaultRewardsActivity.totalStakeUsd && vaultTotalShares > 0n && vaultEquity > 0n) {
+      const sharePrice = ((vaultEquity * DECIMALS) / vaultTotalShares).toString();
+      vaultRewardsActivity.totalStakeUsd = toUsdValue(vaultRewardsActivity.totalStake || "0", sharePrice);
+    }
     vaultRewardApy = computeRewardsApy(vaultRewardsActivity?.emissionRate, vaultRewardsActivity?.totalStakeUsd);
   }
 
@@ -472,6 +524,129 @@ async function getTokenTotalSupply(accessToken: string, tokenAddress: string): P
     return data?.[0]?._totalSupply || "0";
   } catch {
     return "0";
+  }
+}
+
+function buildRewardActivitiesFromMappings(
+  activityCfgById: Map<string, any>,
+  activityStateById: Map<string, any>,
+  pricingCtx: {
+    priceMap: Map<string, string>;
+    mTokenAddress: string | null;
+    sTokenAddress: string | null;
+    vaultShareTokenAddress: string | null;
+    saveUsdstVaultAddress: string | null;
+  }
+): any[] {
+  const activities: any[] = [];
+  for (const [activityId, activity] of activityCfgById.entries()) {
+    const state = activityStateById.get(activityId);
+    const sourceContract = String(activity?.sourceContract || "");
+    const totalStake = String(state?.totalStake || "0");
+    const name = String(activity?.name || "");
+    const emissionRate = String(activity?.emissionRate || "0");
+
+    const { stakeAssetAddress, totalStakeUsd } = computeRewardStakeUsd(
+      sourceContract,
+      name,
+      totalStake,
+      pricingCtx
+    );
+
+    activities.push({
+      activityId: Number(activityId),
+      name,
+      emissionRate,
+      sourceContract,
+      stakeAssetAddress,
+      totalStake,
+      totalStakeUsd,
+    });
+  }
+  return activities;
+}
+
+function computeRewardStakeUsd(
+  sourceContractRaw: string,
+  name: string,
+  totalStake: string,
+  ctx: {
+    priceMap: Map<string, string>;
+    mTokenAddress: string | null;
+    sTokenAddress: string | null;
+    vaultShareTokenAddress: string | null;
+    saveUsdstVaultAddress: string | null;
+  }
+): { stakeAssetAddress: string | null; totalStakeUsd: string | null } {
+  const sourceContract = normalizeAddress(sourceContractRaw);
+  const saveUsdstSource = normalizeAddress(ctx.saveUsdstVaultAddress);
+
+  const isUsdNotional =
+    USD_NOTIONAL_SWAP_SOURCES.has(sourceContract) ||
+    USD_NOTIONAL_DEPOSIT_COMPLETED_SOURCES.has(sourceContract) ||
+    USD_NOTIONAL_AMOUNT_USD_SOURCES.has(sourceContract);
+  if (isUsdNotional) {
+    return { stakeAssetAddress: null, totalStakeUsd: totalStake || "0" };
+  }
+
+  const stakeAssetAddress =
+    TOKEN_UNITS_SOURCES.has(sourceContract) || (saveUsdstSource && sourceContract === saveUsdstSource)
+      ? sourceContract
+      : null;
+
+  const directStakePrice = stakeAssetAddress ? getPriceForAddress(ctx.priceMap, stakeAssetAddress) : null;
+  if (directStakePrice) {
+    return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, directStakePrice) };
+  }
+
+  const lower = (name || "").toLowerCase();
+  if (lower.includes("safety")) {
+    const sTokenPrice = getPriceForAddress(ctx.priceMap, ctx.sTokenAddress);
+    if (sTokenPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, sTokenPrice) };
+  }
+
+  if (lower.includes("lending pool liquidity")) {
+    const mTokenPrice = getPriceForAddress(ctx.priceMap, ctx.mTokenAddress);
+    if (mTokenPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, mTokenPrice) };
+  }
+
+  if (lower.includes("borrow")) {
+    return { stakeAssetAddress, totalStakeUsd: totalStake || "0" };
+  }
+
+  if (lower.includes("vault")) {
+    const vaultPrice = getPriceForAddress(ctx.priceMap, ctx.vaultShareTokenAddress);
+    if (vaultPrice) return { stakeAssetAddress, totalStakeUsd: toUsdValue(totalStake, vaultPrice) };
+  }
+
+  return { stakeAssetAddress, totalStakeUsd: null };
+}
+
+function getPriceForAddress(priceMap: Map<string, string>, address?: string | null): string | null {
+  if (!address) return null;
+  const normalized = normalizeAddress(address);
+  const raw = String(address);
+  return (
+    priceMap.get(raw) ||
+    priceMap.get(normalized) ||
+    priceMap.get(raw.toLowerCase()) ||
+    null
+  );
+}
+
+function toUsdValue(amountWei: string, priceWei: string): string {
+  const amount = BigInt(amountWei || "0");
+  const price = BigInt(priceWei || "0");
+  if (amount === 0n || price === 0n) return "0";
+  return ((amount * price) / DECIMALS).toString();
+}
+
+function parseMappingValue(raw: string): any | null {
+  try {
+    const parsed = JSON.parse(raw || "{}");
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
   }
 }
 

--- a/mercata/backend/src/api/services/saveUsdst.service.ts
+++ b/mercata/backend/src/api/services/saveUsdst.service.ts
@@ -109,10 +109,15 @@ const getExchangeRate = (pricingAssets: bigint, totalShares: bigint): bigint => 
   return (pricingAssets * WAD) / totalShares;
 };
 
+const firstSaveUsdstDepositCache = new Map<string, { timestamp: Date } | null>();
+
 const getFirstSaveUsdstDepositDate = async (
   accessToken: string,
   vaultAddress: string
 ): Promise<{ timestamp: Date } | null> => {
+  const cached = firstSaveUsdstDepositCache.get(vaultAddress);
+  if (cached !== undefined) return cached;
+
   try {
     const { data } = await cirrus.get(accessToken, "/event", {
       params: {
@@ -125,10 +130,13 @@ const getFirstSaveUsdstDepositDate = async (
     });
 
     if (!data?.length || !data[0]?.block_timestamp) {
+      firstSaveUsdstDepositCache.set(vaultAddress, null);
       return null;
     }
 
-    return { timestamp: new Date(data[0].block_timestamp) };
+    const result = { timestamp: new Date(data[0].block_timestamp) };
+    firstSaveUsdstDepositCache.set(vaultAddress, result);
+    return result;
   } catch (error) {
     console.warn("Failed to fetch first saveUSDST deposit timestamp:", error);
     return null;

--- a/mercata/backend/src/config/constants.ts
+++ b/mercata/backend/src/config/constants.ts
@@ -183,6 +183,9 @@ export const constants = (() => {
     GAS_FEE: 0.01,
     GAS_FEE_WEI: 10n ** 16n, // 0.01 USDST in wei
     USDST: "937efa7e3a77e20bbdbd7c0d32b6514f368c1010",
+    ZERO_ADDRESS: "0000000000000000000000000000000000000000",
+    DAY_MS: 24 * 60 * 60 * 1000,
+    BPS_DIVISOR: 10000,
     voucher,
   };
 })();


### PR DESCRIPTION
## Summary
- Payload remained the same.
- Mainnet benchmark (`NODE_URL=https://app.strato.nexus`), 12 interleaved cold calls with 6s gaps.

## Benchmark results

<table>
<tr>
<td>

### Commit 1 — `b915d8c4ba`

| Metric | Value |
|---|---|
| API calls reduced | ~23 |
| Mean (old -> new) | 4.07s -> 2.43s |

</td>
<td>

### Commit 2 — `4ba22810f9`

| Metric | Value |
|---|---|
| API calls reduced | 1 |
| Mean (old -> new) | 2.34s -> 2.38s |

</td>
</tr>
<tr>
<td>

### Commit 3 — `2c61fc5b84`

| Metric | Value |
|---|---|
| API calls reduced | ~4 |
| Mean (old -> new) | 3.21s -> 0.78s |

</td>
<td>

### Commit 4 — `0f645a5f46`

| Metric | Value |
|---|---|
| API calls reduced | 1 |
| Mean (old -> new) | 0.56s -> 0.56s |

</td>
</tr>
<tr>
<td>

### Commit 5 — `ad7f1fb05a`

| Metric (warm) | Value |
|---|---|
| API calls reduced | 2 |
| Mean (old -> new) | 0.575s -> 0.550s |

</td>
<td>

### Commit 6 — `0b08660e02`

| Metric | Value |
|---|---|
| API calls reduced | 4 |
| Mean (old -> new) | 0.551s -> 0.562s |

</td>
</tr>
</table>

### Commit 7 — `762952dc7c`

Code cleanup: split helpers into earnRewards.helper.ts and earnYield.helper.ts, consolidate shared constants into config/constants.ts, pre-normalize reward activity fields, add 60s TTL cache on saveUSDST APY.

### Commit 8 — `eea320532c`

| Metric | Value |
|---|---|
| API calls reduced | 1 (warm) |
| Mean (old -> new) | 0.546s -> 0.353s |

### Overall (develop vs final)

| Metric | Value |
|---|---|
| Total API calls (old -> new) | ~48 -> 12 (warm) |
| Mean (old -> new) | 4.64s -> 0.38s |
| Total time shaved (12 runs) | 51.10s |
