### PR TITLE
Add info tooltip to Best Available APY labels

### DIFF
--- a/mercata/ui/src/components/cdp/v2/components/Mint/Mint.tsx
+++ b/mercata/ui/src/components/cdp/v2/components/Mint/Mint.tsx
@@ -18,6 +18,7 @@ import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 import { RewardsWidget } from '@/components/rewards/RewardsWidget';
 import { redirectToLogin } from '@/lib/auth';
 import EarnApyTooltip from '@/components/earn/EarnApyTooltip';
+import { BestApyInfoTooltip } from '@/components/earn/BestApyInfoTooltip';
 import MintProgressModal, { type ProgressStep } from '../../../MintProgressModal';
 import LoanForm from './LoanForm';
 import VaultBreakdown from './VaultBreakdown';
@@ -895,7 +896,10 @@ const Mint: React.FC<MintProps> = ({ onSuccess, refreshTrigger, guestMode = fals
           <div className="space-y-1 text-sm text-muted-foreground">
             {resolvedVaultApyInfo && (
               <div className="flex items-center justify-between gap-3">
-                <span>Best Available APY</span>
+                <span className="inline-flex items-center gap-1">
+                  Best Available APY
+                  <BestApyInfoTooltip />
+                </span>
                 <EarnApyTooltip info={resolvedVaultApyInfo} side="top" align="end">
                   <span className="font-medium text-foreground cursor-default">
                     {resolvedVaultApyInfo.total.toFixed(2)}%

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -8,6 +8,7 @@ import { formatBalance } from "@/utils/numberUtils";
 import { useEarnContext } from "@/context/EarnContext";
 import { buildEarnApyMap } from "@/utils/earnUtils";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 
 const isSaveUsdstAsset = (asset: { _symbol?: string; _name?: string } | null | undefined): boolean => {
   const symbol = asset?._symbol?.toLowerCase?.() || "";
@@ -106,12 +107,18 @@ const AssetsList = ({
       <div>
         {!isDashboard && (
           <div className="p-4 text-right border-b border-border flex justify-between">
-            <span className="font-bold">Earning Assets / Best Available APY</span>
+            <span className="font-bold inline-flex items-center gap-1">
+              Earning Assets / Best Available APY
+              <BestApyInfoTooltip />
+            </span>
           </div>
         )}
         {isDashboard && (
           <div className="p-3 md:p-4 text-right flex justify-between">
-            <span className="font-bold text-sm md:text-base">Earning Assets / Best Available APY</span>
+            <span className="font-bold text-sm md:text-base inline-flex items-center gap-1">
+              Earning Assets / Best Available APY
+              <BestApyInfoTooltip />
+            </span>
           </div>
         )}
         <div className={`w-full ${isDashboard ? 'overflow-x-auto md:overflow-visible px-3 md:px-0' : 'overflow-x-auto'}`}>
@@ -122,7 +129,10 @@ const AssetsList = ({
                   Asset
                 </th>
                 <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
-                  Best Available APY
+                  <span className="inline-flex items-center gap-1 justify-end w-full">
+                    Best Available APY
+                    <BestApyInfoTooltip />
+                  </span>
                 </th>
                 <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
                   Price

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -125,7 +125,7 @@ const AssetsList = ({
           <table className="w-full">
             <thead>
               <tr className="bg-muted/50">
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
+                <th className="text-left text-xs font-medium text-muted-foreground tracking-wider py-3 px-1 md:px-4">
                   Asset
                 </th>
                 <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-4">
@@ -134,19 +134,19 @@ const AssetsList = ({
                     <BestApyInfoTooltip />
                   </span>
                 </th>
-                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
+                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-4">
                   Price
                 </th>
-                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
+                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-4">
                   Available
                 </th>
-                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
+                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-4">
                   Collateral
                 </th>
-                <th className="text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
+                <th className="text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-1 md:px-4">
                   Value
                 </th>
-                <th className="text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
+                <th className="text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-1 md:px-4">
                   Balance
                 </th>
               </tr>

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -329,10 +329,10 @@ const AssetsList = ({
               <table className="w-full">
                 <thead>
                   <tr className="bg-muted/50">
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
+                    <th className="text-left text-xs font-medium text-muted-foreground tracking-wider py-3 px-1 md:px-4">
                       Asset
                     </th>
-                    <th className="text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
+                    <th className="text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-1 md:px-4">
                       Balance
                     </th>
                   </tr>

--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -128,7 +128,7 @@ const AssetsList = ({
                 <th className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-1 md:px-4">
                   Asset
                 </th>
-                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground uppercase tracking-wider py-3 px-4">
+                <th className="hidden md:table-cell text-right text-xs font-medium text-muted-foreground tracking-wider py-3 px-4">
                   <span className="inline-flex items-center gap-1 justify-end w-full">
                     Best Available APY
                     <BestApyInfoTooltip />

--- a/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
+++ b/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
@@ -16,6 +16,7 @@ import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
 import { RewardsWidget } from "@/components/rewards/RewardsWidget";
 import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { findBestEarnApyInfo } from "@/utils/earnUtils";
 
 const LendingPoolSection = () => {
@@ -552,7 +553,10 @@ const LendingPoolSection = () => {
                   </span>
                 </div>
                 <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
-                  <span className="text-muted-foreground text-sm sm:text-base">Best Available APY</span>
+                  <span className="text-muted-foreground text-sm sm:text-base inline-flex items-center gap-1">
+                    Best Available APY
+                    <BestApyInfoTooltip />
+                  </span>
                   <EarnApyTooltip info={lendingEarnApyInfo}>
                     <span className="font-medium text-sm sm:text-base cursor-default">
                       {lendingDisplayApy ? `${lendingDisplayApy}%` : "N/A"}

--- a/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
@@ -21,6 +21,7 @@ import { RewardsWidget } from '@/components/rewards/RewardsWidget';
 import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 import { isMultiTokenPool } from '@/helpers/swapCalculations';
 import EarnApyTooltip from '@/components/earn/EarnApyTooltip';
+import { BestApyInfoTooltip } from '@/components/earn/BestApyInfoTooltip';
 import { findPoolEarnApyInfo } from '@/utils/earnUtils';
 
 const formatNumber = (value: string | number): string => {
@@ -538,7 +539,10 @@ const LiquidityDepositModal = ({
               {/* Pool info */}
               <div className="rounded-lg bg-muted/50 p-2 md:p-3">
                 <div className="flex justify-between items-center text-xs md:text-sm text-muted-foreground">
-                  <span>Best Available APY</span>
+                  <span className="inline-flex items-center gap-1">
+                    Best Available APY
+                    <BestApyInfoTooltip />
+                  </span>
                   <EarnApyTooltip info={selectedPoolApyInfo}>
                     <span className="font-medium cursor-default">{selectedPoolApyLabel}</span>
                   </EarnApyTooltip>
@@ -827,7 +831,10 @@ const LiquidityDepositModal = ({
 
           <div className="rounded-lg bg-muted/50 p-2 md:p-3">
             <div className="flex justify-between items-center text-xs md:text-sm text-muted-foreground">
-              <span>Best Available APY</span>
+              <span className="inline-flex items-center gap-1">
+                Best Available APY
+                <BestApyInfoTooltip />
+              </span>
               <EarnApyTooltip info={selectedPoolApyInfo}>
                 <span className="font-medium cursor-default">{selectedPoolApyLabel}</span>
               </EarnApyTooltip>

--- a/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
+++ b/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
@@ -7,6 +7,7 @@ import { useSwapContext } from "@/context/SwapContext";
 import { useVaultContext } from "@/context/VaultContext";
 import { useEarnContext } from "@/context/EarnContext";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { findBestEarnApyInfo, findBestNonVaultEarnApyInfo, findVaultEarnApyInfo } from "@/utils/earnUtils";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import LPTokenDropdown from "./LPTokenDropdown";
@@ -142,8 +143,9 @@ export default function MyPoolParticipationSection({
   return (
     <Card className="rounded-xl shadow-sm w-full mb-6">
       <CardHeader className="pb-2 md:pb-4">
-        <CardTitle className="text-base md:text-lg font-semibold text-foreground">
+        <CardTitle className="text-base md:text-lg font-semibold text-foreground inline-flex items-center gap-1">
           My Pool Participation / Best Available APY
+          <BestApyInfoTooltip />
         </CardTitle>
       </CardHeader>
 
@@ -152,7 +154,10 @@ export default function MyPoolParticipationSection({
         <div className="grid grid-cols-3 md:grid-cols-4 px-3 md:px-4 text-xs md:text-sm text-muted-foreground font-medium">
           <div>Token</div>
           <div className="text-right md:text-center">Balance</div>
-          <div className="hidden md:block text-center">Best Available APY</div>
+          <div className="hidden md:flex items-center justify-center gap-1">
+            Best Available APY
+            <BestApyInfoTooltip />
+          </div>
           <div className="text-right">Value</div>
         </div>
 

--- a/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
+++ b/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
@@ -15,6 +15,7 @@ import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
 import { RewardsWidget } from "@/components/rewards/RewardsWidget";
 import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { EarnApyInfo } from "@/utils/earnUtils";
 
 const SafetyModuleSection = () => {
@@ -587,7 +588,10 @@ const SafetyModuleSection = () => {
                   </span>
                 </div>
                 <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
-                  <span className="text-muted-foreground text-sm sm:text-base">Best Available APY</span>
+                  <span className="text-muted-foreground text-sm sm:text-base inline-flex items-center gap-1">
+                    Best Available APY
+                    <BestApyInfoTooltip />
+                  </span>
                   {loading || !tokenApysLoaded ? (
                     <span className="text-muted-foreground animate-pulse text-sm sm:text-base">Loading...</span>
                   ) : (

--- a/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
+++ b/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
@@ -15,6 +15,7 @@ import LiquidityWithdrawModal from './LiquidityWithdrawModal';
 import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 import { useEarnContext } from "@/context/EarnContext";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { findBestEarnApyInfo } from "@/utils/earnUtils";
 
 const SwapPoolsSection = () => {
@@ -238,7 +239,10 @@ const SwapPoolsSection = () => {
                   )}
                   <div className="flex items-center justify-between sm:justify-end space-x-4">
                     <div className="text-left sm:text-right">
-                      <div className="text-sm text-muted-foreground">Best Available APY</div>
+                      <div className="text-sm text-muted-foreground inline-flex items-center gap-1">
+                        Best Available APY
+                        <BestApyInfoTooltip />
+                      </div>
                       <EarnApyTooltip info={apyInfo}>
                         <div className="font-medium cursor-default">{displayedApy}</div>
                       </EarnApyTooltip>

--- a/mercata/ui/src/components/earn/BestApyInfoTooltip.tsx
+++ b/mercata/ui/src/components/earn/BestApyInfoTooltip.tsx
@@ -1,0 +1,72 @@
+import { createPortal } from "react-dom";
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useMobileTooltip } from "@/hooks/use-mobile-tooltip";
+
+export const BEST_APY_TOOLTIP_TEXT =
+  "Estimated total yield available for this asset, combining native yield, pool/base yield, and rewards. Reward points can be claimed now and convert into tangible value at TGE. Actual returns may vary over time.";
+
+interface BestApyInfoTooltipProps {
+  className?: string;
+  iconClassName?: string;
+}
+
+export const BestApyInfoTooltip = ({
+  className,
+  iconClassName = "h-3 w-3 text-muted-foreground",
+}: BestApyInfoTooltipProps) => {
+  const { isMobile, showTooltip, handleToggle } = useMobileTooltip(
+    "best-apy-info-tooltip-container"
+  );
+
+  if (isMobile) {
+    return (
+      <span
+        className={`best-apy-info-tooltip-container inline-flex ${className || ""}`}
+      >
+        <Info
+          className={`${iconClassName} cursor-pointer`}
+          onClick={handleToggle}
+        />
+        {showTooltip &&
+          createPortal(
+            <>
+              <div className="best-apy-info-tooltip-container fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[100] bg-popover border rounded-lg px-4 py-3 text-sm text-popover-foreground shadow-lg max-w-[85vw] w-[320px]">
+                <div className="text-center whitespace-pre-line">
+                  {BEST_APY_TOOLTIP_TEXT}
+                </div>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleToggle(e);
+                  }}
+                  className="absolute top-2 right-2 text-muted-foreground hover:text-foreground text-lg leading-none"
+                >
+                  <span className="sr-only">Close</span>
+                  ×
+                </button>
+              </div>
+              <div
+                className="fixed inset-0 z-[99] bg-black/20"
+                onClick={handleToggle}
+              />
+            </>,
+            document.body
+          )}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Info className={`${iconClassName} cursor-help ${className || ""}`} />
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="max-w-xs">{BEST_APY_TOOLTIP_TEXT}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default BestApyInfoTooltip;

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -12,6 +12,7 @@ import { Link } from "react-router-dom";
 import { getActivityLink } from "@/lib/rewards/activityLinks";
 import { useMobileTooltip } from "@/hooks/use-mobile-tooltip";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { useEarnContext } from "@/context/EarnContext";
 import { useSaveUsdstContext } from "@/context/SaveUsdstContext";
 import { buildNativeRewardsApyInfo, EarnApyInfo, findBestEarnApyInfo, findPoolEarnApyInfo } from "@/utils/earnUtils";
@@ -187,7 +188,7 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                 <TableHead>
                   <div className="flex items-center gap-1">
                  Best Available APY
-                    <InfoTooltip content="Best Available APY shows the highest stacked yield available for this activity, combining Native APY, Base APY, and Rewards APY when applicable. Hover over the APY value to see the full breakdown." />
+                    <BestApyInfoTooltip />
                   </div>
                 </TableHead>
                 <TableHead>Type</TableHead>

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -1117,7 +1117,7 @@ const Earn = () => {
                     <thead className="bg-muted/40">
                       <tr className="border-b border-border/50">
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Opportunity</th>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">
                           <span className="inline-flex items-center gap-1">
                             Best Available APY
                             <BestApyInfoTooltip />

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -1116,17 +1116,17 @@ const Earn = () => {
                   <table className="w-full min-w-[1140px]">
                     <thead className="bg-muted/40">
                       <tr className="border-b border-border/50">
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Opportunity</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">Opportunity</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">
                           <span className="inline-flex items-center gap-1">
                             Best Available APY
                             <BestApyInfoTooltip />
                           </span>
                         </th>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">TVL</th>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Your Position</th>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Type</th>
-                        <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">Action</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">TVL</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">Your Position</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground tracking-wide">Type</th>
+                        <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground tracking-wide">Action</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -38,6 +38,7 @@ import { CircleArrowDown, PiggyBank, TrendingUp } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import stratoVaultLogo from "@/assets/strato-vault-logo.png";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { EarnApyInfo, buildNativeRewardsApyInfo, findBestEarnApyInfo, findPoolEarnApyInfo, findVaultEarnApyInfo } from "@/utils/earnUtils";
 import {
   mUsdstAddress,
@@ -911,8 +912,9 @@ const Earn = () => {
                         </div>
                       </div>
                       <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 rounded-xl bg-white/45 px-3 py-2.5 dark:bg-white/5">
-                        <p className="text-[11px] font-medium text-muted-foreground md:text-xs">
+                        <p className="text-[11px] font-medium text-muted-foreground md:text-xs inline-flex items-center gap-1">
                           {featuredOpportunityMeta.rateLabel}
+                          {featuredOpportunityMeta.rateLabel === "Best Available APY" && <BestApyInfoTooltip />}
                         </p>
                         <EarnApyTooltip info={featuredOpportunityApyInfo}>
                           <span className={`text-[22px] leading-none font-semibold md:text-[28px] ${featuredOpportunityApy.className} cursor-default`}>
@@ -1012,8 +1014,9 @@ const Earn = () => {
                       </div>
                     </div>
                     <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 rounded-xl bg-white/45 px-3 py-2.5 dark:bg-white/5">
-                      <p className="text-[11px] font-medium text-muted-foreground md:text-xs">
+                      <p className="text-[11px] font-medium text-muted-foreground md:text-xs inline-flex items-center gap-1">
                         {topOpportunityMeta.rateLabel}
+                        {topOpportunityMeta.rateLabel === "Best Available APY" && <BestApyInfoTooltip />}
                       </p>
                       <EarnApyTooltip info={topOpportunityApyInfo}>
                         <span className={`text-[22px] leading-none font-semibold md:text-[28px] ${topOpportunityApy.className} cursor-default`}>
@@ -1114,7 +1117,12 @@ const Earn = () => {
                     <thead className="bg-muted/40">
                       <tr className="border-b border-border/50">
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Opportunity</th>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Best Available APY</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                          <span className="inline-flex items-center gap-1">
+                            Best Available APY
+                            <BestApyInfoTooltip />
+                          </span>
+                        </th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">TVL</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Your Position</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">Type</th>

--- a/mercata/ui/src/pages/EarnLending.tsx
+++ b/mercata/ui/src/pages/EarnLending.tsx
@@ -22,6 +22,7 @@ import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
 import { RewardsWidget } from "@/components/rewards/RewardsWidget";
 import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { findBestEarnApyInfo } from "@/utils/earnUtils";
 
 const EarnLending = () => {
@@ -185,7 +186,10 @@ const EarnLending = () => {
                   </div>
                   <div className="grid grid-cols-2 gap-2 md:flex md:items-center">
                     <div className="rounded-lg border border-border/60 bg-card px-3 py-2">
-                      <p className="text-[11px] text-muted-foreground">Best Available APY</p>
+                      <p className="text-[11px] text-muted-foreground inline-flex items-center gap-1">
+                        Best Available APY
+                        <BestApyInfoTooltip />
+                      </p>
                       <EarnApyTooltip info={lendingEarnApyInfo}>
                         <p className="text-sm font-semibold cursor-default">
                           {lendingDisplayApy ? `${lendingDisplayApy}%` : "N/A"}
@@ -381,7 +385,7 @@ const EarnLending = () => {
                       <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Total Collateral Value</p><p className="text-sm font-semibold">{loadingLiquidity ? "Loading..." : formatBalance(liquidityInfo?.totalCollateralValue || 0n, undefined, 18, 2, 2, true)}</p></div>
                       <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Borrow Index</p><p className="text-sm font-semibold">{loadingLiquidity ? "Loading..." : liquidityInfo?.borrowIndex ? (() => { const s = formatUnits(liquidityInfo.borrowIndex || 0, 27); const [w, f = ""] = s.split("."); return f ? `${w}.${f.slice(0, 5)}` : w; })() : "0"}</p></div>
                       <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Reserves Accrued</p><p className="text-sm font-semibold">{loadingLiquidity ? "Loading..." : formatBalance(liquidityInfo?.reservesAccrued || 0n, undefined, 18, 2, 2, true)}</p></div>
-                      <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Best Available APY</p><EarnApyTooltip info={lendingEarnApyInfo}><p className="text-sm font-semibold cursor-default">{lendingDisplayApy ? `${lendingDisplayApy}%` : "N/A"}</p></EarnApyTooltip></div>
+                      <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground inline-flex items-center gap-1">Best Available APY<BestApyInfoTooltip /></p><EarnApyTooltip info={lendingEarnApyInfo}><p className="text-sm font-semibold cursor-default">{lendingDisplayApy ? `${lendingDisplayApy}%` : "N/A"}</p></EarnApyTooltip></div>
                       <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Max Supply APY</p><p className="text-sm font-semibold">{liquidityInfo?.maxSupplyAPY ? `${liquidityInfo.maxSupplyAPY}%` : "N/A"}</p></div>
                       <div className="rounded-lg border border-border/60 p-3"><p className="text-xs text-muted-foreground">Borrow APY</p><p className="text-sm font-semibold">{liquidityInfo?.borrowAPY ? `${liquidityInfo.borrowAPY}%` : "N/A"}</p></div>
                       {isLoggedIn && (

--- a/mercata/ui/src/pages/EarnPools.tsx
+++ b/mercata/ui/src/pages/EarnPools.tsx
@@ -11,6 +11,7 @@ import GuestSignInBanner from "@/components/ui/GuestSignInBanner";
 import LiquidityDepositModal from "@/components/dashboard/LiquidityDepositModal";
 import LiquidityWithdrawModal from "@/components/dashboard/LiquidityWithdrawModal";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import { useSwapContext } from "@/context/SwapContext";
 import { useEarnContext } from "@/context/EarnContext";
 import { useTokenContext } from "@/context/TokenContext";
@@ -205,7 +206,10 @@ const EarnPools = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2 md:flex md:items-center">
                   <div className="rounded-lg border border-border/60 bg-card px-3 py-2">
-                    <p className="text-[11px] text-muted-foreground">Best Available APY</p>
+                    <p className="text-[11px] text-muted-foreground inline-flex items-center gap-1">
+                      Best Available APY
+                      <BestApyInfoTooltip />
+                    </p>
                     <EarnApyTooltip info={highlightedPoolApyInfo}>
                       <p className="text-sm font-semibold cursor-default">
                         {pageLoading ? "Loading..." : displayedHighlightedPoolApy ? formatPct(displayedHighlightedPoolApy) : "N/A"}
@@ -336,7 +340,10 @@ const EarnPools = () => {
                         </p>
                       </div>
                       <div className="rounded-lg border border-border/60 p-3">
-                        <p className="text-xs text-muted-foreground">Best Available APY</p>
+                        <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                          Best Available APY
+                          <BestApyInfoTooltip />
+                        </p>
                         <EarnApyTooltip info={highlightedPoolApyInfo}>
                           <p className="text-sm font-semibold cursor-default">
                             {pageLoading ? "Loading..." : formatPct(displayedHighlightedPoolApy)}

--- a/mercata/ui/src/pages/EarnSave.tsx
+++ b/mercata/ui/src/pages/EarnSave.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
+import { BestApyInfoTooltip } from "@/components/earn/BestApyInfoTooltip";
 import {
   Dialog,
   DialogContent,
@@ -452,7 +453,10 @@ const EarnSave = () => {
                           </p>
                         </div>
                         <div className="rounded-lg border border-border/60 bg-background/70 p-3">
-                          <p className="text-muted-foreground">Best Available APY</p>
+                          <p className="text-muted-foreground inline-flex items-center gap-1">
+                            Best Available APY
+                            <BestApyInfoTooltip />
+                          </p>
                           {loadingInfo || rewardsActivitiesLoading ? (
                             <p className="mt-1 text-lg font-semibold">...</p>
                           ) : (


### PR DESCRIPTION
## Summary
- Adds a shared `BestApyInfoTooltip` component next to every "Best Available APY" label across the app (~19 spots in 12 files).
- Tooltip text (per Maya's design + Kieren's sign-off): *"Estimated total yield available for this asset, combining native yield, pool/base yield, and rewards. Reward points can be claimed now and convert into tangible value at TGE. Actual returns may vary over time."*
- Replaces the older tooltip text in `ActivitiesTable.tsx` with the new unified text so wording is consistent everywhere.

## Notes
- Tooltip text lives in one constant (`BEST_APY_TOOLTIP_TEXT`) — single source of truth, won't drift.
- Mobile popup uses `createPortal` to avoid invalid `<div>` inside `<p>` HTML where the label is inside a `<p>` tag.
- Desktop uses the existing Radix `Tooltip` (already portaled by Radix).
- On Earn page's featured/top opportunity cards, the tooltip only renders when `rateLabel === "Best Available APY"` (skips yield-vault cards that use "APY" instead).