### PR TITLE
Fix stacked yield calculation for Diversified Vault

### DIFF
--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -55,7 +55,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
     },
   );
 
-  const { vaultAPY, vaultRewardApy, currentVaultBalances } = await computeVaultApys(
+  const { vaultAPY, vaultRewardApy } = await computeVaultApys(
     accessToken, vaultAddr, ctx, phase1b, rewardActivities,
   );
 
@@ -69,19 +69,10 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const exchangeRateHistory = indexYieldHistoryRows(mergeBackfillRows(phase1.exchangeRateRows ?? []));
   const baseYieldByAddr = addBaseYieldApys(add, exchangeRateHistory, anchorsMs);
 
-  const vaultWeightedApy = currentVaultBalances.size > 0 && baseYieldByAddr.size > 0
-    ? weightedBaseYield(
-        ctx.filteredVaultAssets,
-        ctx.filteredVaultAssets.map(a => currentVaultBalances.get(a) ?? "0"),
-        ctx.prices, baseYieldByAddr,
-      )
-    : null;
-
   await addPoolApys(accessToken, add, phase1.pools, phase1b.stablePools, ctx, rewardActivities, baseYieldByAddr);
 
   if (ctx.shareTokenAddress) {
     if (isPositiveApy(vaultAPY)) add(ctx.shareTokenAddress, { source: "vault", apy: vaultAPY });
-    if (isPositiveApy(vaultWeightedApy)) add(ctx.shareTokenAddress, { source: "vault_weighted", apy: vaultWeightedApy });
     if (isPositiveApy(vaultRewardApy)) add(ctx.shareTokenAddress, { source: "rewards", apy: vaultRewardApy, meta: "vault" });
   }
 
@@ -268,7 +259,7 @@ async function computeVaultApys(
       ctx.filteredVaultAssets, ctx.prices,
     );
 
-    vaultAPY = vaultMetrics.alpha !== APY_UNAVAILABLE ? vaultMetrics.alpha : null;
+    vaultAPY = vaultMetrics.apy !== APY_UNAVAILABLE ? vaultMetrics.apy : null;
     const vaultRewardsActivity = findRewardActivity(rewardActivities, {
       sourceContract: ctx.shareTokenAddress,
       stakeAssetAddress: ctx.shareTokenAddress,
@@ -281,7 +272,7 @@ async function computeVaultApys(
     vaultRewardApy = computeRewardsApy(vaultRewardsActivity?.emissionRate, vaultRewardsActivity?.totalStakeUsd);
   }
 
-  return { vaultAPY, vaultRewardApy, currentVaultBalances };
+  return { vaultAPY, vaultRewardApy };
 }
 
 // ── APY assembly helpers ──────────────────────────────────────────────────────

--- a/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
+++ b/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
@@ -74,8 +74,8 @@ export default function MyPoolParticipationSection({
         return {
           value: info
             ? info.total.toFixed(2)
-            : vaultState.alpha && vaultState.alpha !== "0" && vaultState.alpha !== "-"
-              ? vaultState.alpha
+            : vaultState.apy && vaultState.apy !== "0" && vaultState.apy !== "-"
+              ? vaultState.apy
               : null,
           info,
         };
@@ -87,7 +87,7 @@ export default function MyPoolParticipationSection({
         info,
       };
     },
-    [liquidityInfo, lpTokenPoolMap, pools, tokenApys, vaultState.alpha, vaultState.shareTokenAddress]
+    [liquidityInfo, lpTokenPoolMap, pools, tokenApys, vaultState.apy, vaultState.shareTokenAddress]
   );
 
   const rows = useMemo(

--- a/mercata/ui/src/pages/Earn.tsx
+++ b/mercata/ui/src/pages/Earn.tsx
@@ -557,7 +557,7 @@ const Earn = () => {
     () =>
       vaultEarnApyInfo ||
       buildNativeRewardsApyInfo(
-        vaultState.alpha,
+        vaultState.apy,
         vaultRewardActivity?.emissionRate ? vaultRewardActivity.emissionRate.toString() : null,
         vaultRewardActivity?.totalStakeUsd ?? vaultState.totalEquity ?? null,
         "vault"
@@ -566,13 +566,13 @@ const Earn = () => {
       vaultEarnApyInfo,
       vaultRewardActivity?.emissionRate,
       vaultRewardActivity?.totalStakeUsd,
-      vaultState.alpha,
+      vaultState.apy,
       vaultState.totalEquity,
     ]
   );
   const vaultDisplayApyRaw = resolvedVaultApyInfo
     ? resolvedVaultApyInfo.total.toFixed(2)
-    : vaultState.alpha;
+    : vaultState.apy;
   const allOpportunities = useMemo<OpportunityRow[]>(() => {
     const rows: OpportunityRow[] = [];
 


### PR DESCRIPTION
The Earn page and MyPoolParticipation section of the Dashboard were incorrectly using Diversified Vault's alpha vs HODL APY rather than the native APY for its stacked yield calculation. This PR replaces these calculations' alpha component with the native APY component.