### PR TITLE
Add Cursor Cloud specific dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,30 @@
 - Default priceOracle is system contract `0000…1002` (same for vaults and system default — no separate query)
 - Sidebar nav uses category groupings (TRADE, SPEND, EARN, PRO) defined in `DashboardSidebar.tsx`, `MobileSidebar.tsx`, and `MobileBottomNav.tsx`; all three must stay in sync; Card is under SPEND. SolidVM contract tests: `solid-vm-cli test <file>` from test dir; pattern is `Describe_*` contract with `beforeAll`/`beforeEach`/`it_*` functions; `fetchMinDepositAmount` depends on both `selectedToken` AND `currentNetwork`/`chainId`
 - CDP collateral on prod is listed via CDPRegistry (`…1012`) and CDPEngine (`…1011`) in Cirrus; many assets are configured with USDST often paused as collateral; the depositable set follows `getVaultCandidates` (excludes USDST and paused assets — typically on the order of a dozen depositable)
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+The primary dev loop involves three services — see `mercata/README.md` for canonical commands:
+
+| Service | Dir | Command | Port |
+|---|---|---|---|
+| Backend | `mercata/backend/` | `npm run dev` | 3001 |
+| UI | `mercata/ui/` | `npm run dev` | 8080 |
+| Nginx | `mercata/nginx/` | `docker compose -f docker-compose.nginx-standalone.yml up -d --build` | 80 |
+
+**Shared types** (`mercata/packages/shared-types/`) are built automatically via `postinstall` hooks in both backend and UI.
+
+### Required environment variables
+
+Backend requires four OAuth and node env vars (see `mercata/README.md` DEV MODE section for names). These are injected as secrets in the Cloud Agent environment.
+
+### Key caveats
+
+- **Access the app on port 80** (through nginx) — not port 8080. The OAuth/login flow only works through the nginx proxy; the Vite dev server on 8080 does not handle authentication.
+- **Docker is required** for nginx. In the Cloud Agent VM (nested container), Docker needs `fuse-overlayfs` storage driver and `iptables-legacy`. The daemon must be started manually: `sudo dockerd &>/tmp/dockerd.log &` then `sudo chmod 666 /var/run/docker.sock`.
+- **Nginx uses `host.docker.internal`** to reach backend (3001) and UI (8080) on the host. The `extra_hosts: host.docker.internal:host-gateway` directive in the compose file handles this.
+- Backend emits non-fatal YAML warnings from Swagger JSDoc annotations at startup — these can be ignored.
+- **Lint**: `cd mercata/ui && npx eslint .` — the existing codebase has pre-existing lint errors; this is normal.
+- **Type-check backend**: `cd mercata/backend && npx tsc --noEmit`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Add `## Cursor Cloud specific instructions` section to `AGENTS.md`
- Document service table (backend on 3001, UI on 8080, nginx on 80) with dev commands
- Document key caveats: port-80 access for OAuth, Docker nested-VM setup, lint/type-check commands

[mercata_login_demo.mp4](https://cursor.com/agents/bc-c4071e84-3fc8-4424-9e43-c4e6a75a7cb0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmercata_login_demo.mp4)
Full login flow through nginx → Keycloak → dashboard

[Dashboard after login](https://cursor.com/agents/bc-c4071e84-3fc8-4424-9e43-c4e6a75a7cb0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_login.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4071e84-3fc8-4424-9e43-c4e6a75a7cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4071e84-3fc8-4424-9e43-c4e6a75a7cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

