### PR TITLE
Add support for BSC

### DIFF
--- a/docker-compose.bridge.tpl.yml
+++ b/docker-compose.bridge.tpl.yml
@@ -25,6 +25,7 @@ services:
     - CHAIN_59144_RPC_URL=${CHAIN_59144_RPC_URL}  
     - CHAIN_8453_RPC_URL=${CHAIN_8453_RPC_URL}
     - CHAIN_84532_RPC_URL=${CHAIN_84532_RPC_URL}
+    - CHAIN_56_RPC_URL=${CHAIN_56_RPC_URL}
     build: .
     image: ${BRIDGE_IMAGE:-<REPO_URL>bridge:<VERSION>-<HASH_BRIDGE>}
     restart: unless-stopped

--- a/mercata/backend/src/config/rpc.config.ts
+++ b/mercata/backend/src/config/rpc.config.ts
@@ -6,6 +6,7 @@ const baseChainId = "8453";
 const baseSepoliaChainId = "84532";
 const lineaChainId = "59144";
 const lineaSepoliaChainId = "59141";
+const bscChainId = "56";
 
 const fallbackRpcUpstreams: RpcMapping = {
   [mainnetChainId]: process.env.RPC_URL_MAINNET_FALLBACK || "https://eth.merkle.io",
@@ -14,6 +15,7 @@ const fallbackRpcUpstreams: RpcMapping = {
   [baseSepoliaChainId]: process.env.RPC_URL_BASE_SEPOLIA_FALLBACK || "https://sepolia.base.org",
   [lineaChainId]: process.env.RPC_URL_LINEA_FALLBACK || "https://rpc.linea.build",
   [lineaSepoliaChainId]: process.env.RPC_URL_LINEA_SEPOLIA_FALLBACK || "https://rpc.sepolia.linea.build",
+  [bscChainId]: process.env.RPC_URL_BSC_FALLBACK || "https://bsc-rpc.publicnode.com",
 };
 
 const rpcUpstreams: RpcMapping = {
@@ -23,6 +25,7 @@ const rpcUpstreams: RpcMapping = {
   [baseSepoliaChainId]: process.env.RPC_URL_BASE_SEPOLIA || fallbackRpcUpstreams[baseSepoliaChainId],
   [lineaChainId]: process.env.RPC_URL_LINEA || fallbackRpcUpstreams[lineaChainId],
   [lineaSepoliaChainId]: process.env.RPC_URL_LINEA_SEPOLIA || fallbackRpcUpstreams[lineaChainId],
+  [bscChainId]: process.env.RPC_URL_BSC || fallbackRpcUpstreams[bscChainId],
 };
 
 export function getRpcUpstream(chainId: string): { upstream: string | undefined; fallback: string | undefined } {

--- a/mercata/ethereum/.openzeppelin/bsc.json
+++ b/mercata/ethereum/.openzeppelin/bsc.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xaf58c4fC2377365Bb0418b84Fc3B44Bd285867E5",
+      "txHash": "0xc90d1e99a796b00a85796efa8c45e396814d6d4bc88c9822a90eeae73c600d80",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "05a3ff049112dc83b017602c34560ac372280c94d3ee67ff0a2ddce777824945": {
+      "address": "0x203B3a810F01773dEB09fC8853276277D1d00D15",
+      "txHash": "0xead33be61ce78ec05adc6a6463858242eddcf12480aab8217522af95a75859eb",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "PERMIT2",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IPermit2)3370",
+            "contract": "DepositRouter",
+            "src": "contracts/bridge/DepositRouter.sol:36"
+          },
+          {
+            "label": "gnosisSafe",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "DepositRouter",
+            "src": "contracts/bridge/DepositRouter.sol:38"
+          },
+          {
+            "label": "depositId",
+            "offset": 20,
+            "slot": "1",
+            "type": "t_uint96",
+            "contract": "DepositRouter",
+            "src": "contracts/bridge/DepositRouter.sol:39"
+          },
+          {
+            "label": "tokenConfig",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_struct(TokenConfig)2432_storage)",
+            "contract": "DepositRouter",
+            "src": "contracts/bridge/DepositRouter.sol:41"
+          },
+          {
+            "label": "routePermitted",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "DepositRouter",
+            "src": "contracts/bridge/DepositRouter.sol:43"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)224_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)288_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IPermit2)3370": {
+            "label": "contract IPermit2",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(TokenConfig)2432_storage)": {
+            "label": "mapping(address => struct DepositRouter.TokenConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TokenConfig)2432_storage": {
+            "label": "struct DepositRouter.TokenConfig",
+            "members": [
+              {
+                "label": "min",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "isPermitted",
+                "type": "t_bool",
+                "offset": 12,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/mercata/ethereum/README.md
+++ b/mercata/ethereum/README.md
@@ -35,10 +35,13 @@ Modular Hardhat setup for deploying Mercata contracts to Ethereum networks with 
 | `npm run compile`                 | Compile all contracts                          |
 | `npm run deployWithProxy:sepolia` | Deploy contract with proxy to Sepolia testnet  |
 | `npm run deployWithProxy:mainnet` | Deploy contract with proxy to Ethereum mainnet |
+| `npm run deployWithProxy:bsc`     | Deploy contract with proxy to BSC mainnet      |
+| `npm run deployImpl:bsc`          | Deploy implementation only to BSC mainnet      |
 | `npm run verify:sepolia`          | Verify contract on Sepolia Etherscan           |
 | `npm run verify:mainnet`          | Verify contract on Mainnet Etherscan           |
 | `npm run scan:sepolia`            | Scan token configurations on Sepolia testnet   |
 | `npm run scan:mainnet`            | Scan token configurations on Ethereum mainnet  |
+| `npm run scan:bsc`                | Scan token configurations on BSC mainnet       |
 
 ## Utility Scripts
 

--- a/mercata/ethereum/README.md
+++ b/mercata/ethereum/README.md
@@ -39,6 +39,7 @@ Modular Hardhat setup for deploying Mercata contracts to Ethereum networks with 
 | `npm run deployImpl:bsc`          | Deploy implementation only to BSC mainnet      |
 | `npm run verify:sepolia`          | Verify contract on Sepolia Etherscan           |
 | `npm run verify:mainnet`          | Verify contract on Mainnet Etherscan           |
+| `npm run verify:bsc`              | Verify contract on BSC (Etherscan v2 / BSCScan)|
 | `npm run scan:sepolia`            | Scan token configurations on Sepolia testnet   |
 | `npm run scan:mainnet`            | Scan token configurations on Ethereum mainnet  |
 | `npm run scan:bsc`                | Scan token configurations on BSC mainnet       |

--- a/mercata/ethereum/env.example
+++ b/mercata/ethereum/env.example
@@ -14,6 +14,7 @@ ALCHEMY_API_KEY=
 ROUTER_IMPL_ETH=
 ROUTER_IMPL_BASE=
 ROUTER_IMPL_LINEA=
+ROUTER_IMPL_BSC=
 
 # Safe proposer config
 SAFE_PROPOSER_ADDRESS=0x0000000000000000000000000000000000000000
@@ -26,10 +27,12 @@ BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
 MAINNET_RPC_URL=https://ethereum-rpc.publicnode.com
 BASE_RPC_URL=https://mainnet.base.org
 LINEA_RPC_URL=https://rpc.linea.build
+BSC_RPC_URL=https://bsc-rpc.publicnode.com
 
 # Etherscan/BaseScan (optional verification tooling)
 ETHERSCAN_API_KEY=
 BASESCAN_API_KEY=
+BSCSCAN_API_KEY=
 
 # Legacy compatibility (existing flows/tools still use these)
 # Network RPC URLs above are still used by legacy scripts.

--- a/mercata/ethereum/hardhat.config.js
+++ b/mercata/ethereum/hardhat.config.js
@@ -44,6 +44,11 @@ module.exports = {
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
       gasPrice: "auto",
     },
+    bsc: {
+      url: process.env.BSC_RPC_URL || "https://bsc-rpc.publicnode.com",
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      gasPrice: "auto",
+    },
     localhost: {
       url: "http://127.0.0.1:8545",
     },

--- a/mercata/ethereum/package.json
+++ b/mercata/ethereum/package.json
@@ -19,6 +19,7 @@
 
     "verify:sepolia": "hardhat verify --network sepolia",
     "verify:mainnet": "hardhat verify --network mainnet",
+    "verify:bsc": "hardhat verify --network bsc",
 
     "scan:sepolia": "npx hardhat run scripts/scanTokenConfig.js --network sepolia",
     "scan:mainnet": "npx hardhat run scripts/scanTokenConfig.js --network mainnet",

--- a/mercata/ethereum/package.json
+++ b/mercata/ethereum/package.json
@@ -7,10 +7,12 @@
 
     "deployWithProxy:sepolia": "npx hardhat run scripts/deployWithProxy.js --network sepolia",
     "deployWithProxy:mainnet": "npx hardhat run scripts/deployWithProxy.js --network mainnet",
+    "deployWithProxy:bsc": "npx hardhat run scripts/deployWithProxy.js --network bsc",
     "deployImpl:sepolia": "npx hardhat run scripts/deployImplementationOnly.js --network sepolia",
     "deployImpl:mainnet": "npx hardhat run scripts/deployImplementationOnly.js --network mainnet",
     "deployImpl:baseSepolia": "npx hardhat run scripts/deployImplementationOnly.js --network baseSepolia",
     "deployImpl:base": "npx hardhat run scripts/deployImplementationOnly.js --network base",
+    "deployImpl:bsc": "npx hardhat run scripts/deployImplementationOnly.js --network bsc",
     "router:ops": "node scripts/depositRouterOps.js",
     "router:ops:testnet": "node scripts/depositRouterOps.js --env testnet",
     "router:ops:prod": "node scripts/depositRouterOps.js --env prod",
@@ -19,7 +21,8 @@
     "verify:mainnet": "hardhat verify --network mainnet",
 
     "scan:sepolia": "npx hardhat run scripts/scanTokenConfig.js --network sepolia",
-    "scan:mainnet": "npx hardhat run scripts/scanTokenConfig.js --network mainnet"
+    "scan:mainnet": "npx hardhat run scripts/scanTokenConfig.js --network mainnet",
+    "scan:bsc": "npx hardhat run scripts/scanTokenConfig.js --network bsc"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",

--- a/mercata/ethereum/scripts/depositRouterQueueSetters.js
+++ b/mercata/ethereum/scripts/depositRouterQueueSetters.js
@@ -77,6 +77,10 @@ const CHAIN_NAME_TO_ID = {
   "linea-mainnet": 59144,
   linea_sepolia: 59141,
   "linea-sepolia": 59141,
+  bsc: 56,
+  bnb: 56,
+  bnb_chain: 56,
+  "bnb-chain": 56,
 };
 
 function parseChains(args) {

--- a/mercata/ethereum/scripts/depositRouterUpgradePropose.js
+++ b/mercata/ethereum/scripts/depositRouterUpgradePropose.js
@@ -80,6 +80,10 @@ const CHAIN_NAME_TO_ID = {
   linea_sepolia: 59141,
   "linea-sepolia": 59141,
   lineasepolia: 59141,
+  bsc: 56,
+  bnb: 56,
+  bnb_chain: 56,
+  "bnb-chain": 56,
 };
 
 function parseChains(args) {
@@ -104,9 +108,11 @@ function getImplementationForChain(chainId) {
   const implEth = normalizeAddress(process.env.ROUTER_IMPL_ETH);
   const implBase = normalizeAddress(process.env.ROUTER_IMPL_BASE);
   const implLinea = normalizeAddress(process.env.ROUTER_IMPL_LINEA);
+  const implBsc = normalizeAddress(process.env.ROUTER_IMPL_BSC);
   if (chainId === 1 || chainId === 11155111) return implEth;
   if (chainId === 8453 || chainId === 84532) return implBase;
   if (chainId === 59144 || chainId === 59141) return implLinea;
+  if (chainId === 56) return implBsc;
   return "";
 }
 
@@ -127,6 +133,7 @@ function getHardhatNetwork(chainId) {
   if (chainId === 84532) return "baseSepolia";
   if (chainId === 59144) return "linea";
   if (chainId === 59141) return "lineaSepolia";
+  if (chainId === 56) return "bsc";
   return "";
 }
 

--- a/mercata/ethereum/scripts/lib/depositRouterSafeOps.js
+++ b/mercata/ethereum/scripts/lib/depositRouterSafeOps.js
@@ -68,6 +68,12 @@ const CHAIN_CONFIG = {
     rpcEnv: "LINEA_SEPOLIA_RPC_URL",
     defaultRpcUrl: "https://rpc.sepolia.linea.build",
   },
+  56: {
+    chainId: 56,
+    name: "bsc",
+    rpcEnv: "BSC_RPC_URL",
+    defaultRpcUrl: "https://bsc-rpc.publicnode.com",
+  },
 };
 
 function normalizeAddress(value) {

--- a/mercata/ethereum/scripts/lib/envProfile.js
+++ b/mercata/ethereum/scripts/lib/envProfile.js
@@ -26,6 +26,7 @@ const CHAIN_RPC_ENV_MAP = {
   CHAIN_1_RPC_URL: "MAINNET_RPC_URL",
   CHAIN_8453_RPC_URL: "BASE_RPC_URL",
   CHAIN_59144_RPC_URL: "LINEA_RPC_URL",
+  CHAIN_56_RPC_URL: "BSC_RPC_URL",
 };
 
 function normalizeProfile(value) {
@@ -62,6 +63,7 @@ function applyEnvProfile(profile) {
     MAINNET_RPC_URL: `https://eth-mainnet.g.alchemy.com/v2/${alchemyKey}`,
     BASE_RPC_URL: `https://base-mainnet.g.alchemy.com/v2/${alchemyKey}`,
     LINEA_RPC_URL: `https://linea-mainnet.g.alchemy.com/v2/${alchemyKey}`,
+    BSC_RPC_URL: `https://bnb-mainnet.g.alchemy.com/v2/${alchemyKey}`,
   };
 
   for (const [key, fallback] of Object.entries(rpcDefaults)) {

--- a/mercata/services/bridge/.env.example
+++ b/mercata/services/bridge/.env.example
@@ -21,10 +21,11 @@ SENDGRID_API_KEY=xxxxxxxxxxxxx                        # SendGrid API key for sen
 # RPC config
 # Chain RPC URLs (Dynamically Validated)
 # The service automatically validates that RPC URLs are configured for all enabled chains from the bridge contract:
-CHAIN_11155111_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}   # Sepolia
-CHAIN_1_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}          # Ethereum mainnet
+CHAIN_11155111_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY} # Sepolia
+CHAIN_1_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}        # Ethereum mainnet
 CHAIN_8453_RPC_URL=https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}    # Base mainnet
-CHAIN_84532_RPC_URL=https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}    # Base Sepolia
+CHAIN_84532_RPC_URL=https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}   # Base Sepolia
 CHAIN_59144_RPC_URL=https://linea-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}  # Linea mainnet
 CHAIN_59141_RPC_URL=https://linea-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}  # Linea Sepolia
-# CHAIN_${chainId}_RPC_URL=<rpc-url-for-other-enabled-chain>                     # Any additional enabled chains
+CHAIN_56_RPC_URL=https://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}       # BSC mainnet
+# CHAIN_${chainId}_RPC_URL=<rpc-url-for-other-enabled-chain>                   # Any additional enabled chains

--- a/mercata/services/bridge/src/services/emailService.ts
+++ b/mercata/services/bridge/src/services/emailService.ts
@@ -13,6 +13,7 @@ const getSafeChainIdentifier = (chainId: number | string): string => {
     11155111: "sep",
     59144: "linea",
     84532: "basesep",
+    56: "bnb",
   };
   return chainMap[chainIdNum] || `chain-${chainIdNum}`;
 };

--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -3,6 +3,9 @@
     "ETH": {
       "targetAssetAddress": "93fb7295859b2d70199e0a4883b7c320cf874e6c"
     },
+    "BNB": {
+      "targetAssetAddress": "78af9c667e8c5bc23f202176ba70b8cbd94ef9f0"
+    },
     "KAG": {
       "targetAssetAddress": "2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94",
       "submit": false

--- a/mercata/services/oracle/src/config/sources.json
+++ b/mercata/services/oracle/src/config/sources.json
@@ -5,7 +5,7 @@
     "parse": "data[].prices[0].value",
     "timestamp": "data[0].prices[0].lastUpdatedAt",
     "apiKeyEnvVar": "ALCHEMY_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX","WEETH"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX","WEETH", "BNB"]
   },
   "CoinMarketCap": {
     "url": "https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest",
@@ -14,7 +14,7 @@
     "parse": "data.{symbol}[0].quote.USD.price",
     "timestamp": "data.{firstSymbol}[0].quote.USD.last_updated",
     "apiKeyEnvVar": "COINMARKETCAP_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "WEETH"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "WEETH", "BNB"]
   },
   "Metals.dev": {
     "url": "https://api.metals.dev/v1/latest",
@@ -42,7 +42,7 @@
     "parse": "{id}.usd",
     "timestamp": "{id}.last_updated_at",
     "apiKeyEnvVar": "COINGECKO_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX", "SPYX", "WEETH"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX", "SPYX", "WEETH", "BNB"],
     "symbolMapping": {
       "ETH": "ethereum",
       "WBTC": "wrapped-bitcoin",
@@ -56,7 +56,8 @@
       "USDT": "tether",
       "TSLAX": "tesla-xstock",
       "SPYX": "sp500-xstock",
-      "WEETH": "wrapped-eeth"
+      "WEETH": "wrapped-eeth",
+      "BNB": "binancecoin"
     }
   },
   "CoinAPI": {
@@ -66,13 +67,13 @@
     "parse": "assets",
     "timestamp": "data_quote_start",
     "apiKeyEnvVar": "COINAPI_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "USDC", "USDT", "TSLAX", "SPYX", "WEETH"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "USDC", "USDT", "TSLAX", "SPYX", "WEETH", "BNB"]
   },
   "DefiLlama": {
     "url": "https://pro-api.llama.fi/${API_KEY}/coins/prices/current/${SYMBOLS}",
     "parse": "defiLlama",
     "apiKeyEnvVar": "DEFILLAMA_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX", "SPYX", "WEETH"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH", "USDC", "USDT", "TSLAX", "SPYX", "WEETH", "BNB"],
     "symbolMapping": {
       "ETH": "coingecko:ethereum",
       "WBTC": "coingecko:wrapped-bitcoin",
@@ -86,7 +87,8 @@
       "USDT": "coingecko:tether",
       "TSLAX": "coingecko:tesla-xstock",
       "SPYX": "coingecko:sp500-xstock",
-      "WEETH": "coingecko:wrapped-eeth"
+      "WEETH": "coingecko:wrapped-eeth",
+      "BNB": "coingecko:binancecoin"
     }
   },
   "CommodityPriceAPI": {

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -4,7 +4,7 @@ import UsdstBalanceBox from "@/components/layouts/UsdstBalanceBox";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Transport, WagmiProvider } from "wagmi";
-import { mainnet, polygon, sepolia, base, baseSepolia } from "wagmi/chains";
+import { mainnet, polygon, sepolia, base, baseSepolia, bsc } from "wagmi/chains";
 import {
   connectorsForWallets,
   RainbowKitProvider,
@@ -137,7 +137,7 @@ const App = () => {
               rpcUrls: { default: { http: [typeof window !== "undefined" ? `${window.location.origin}/api/rpc/${networkId}` : ""] } },
             })
           : null;
-      const baseChains = [mainnet, polygon, sepolia, base, baseSepolia] as const;
+      const baseChains = [mainnet, polygon, sepolia, base, baseSepolia, bsc] as const;
       const chains = stratoChain ? [...baseChains, stratoChain] : baseChains;
       const transports: Record<number, Transport> = Object.fromEntries(
         chains.map((chain) => [chain.id, http(`/api/rpc/${chain.id}`, { onFetchRequest: csrfOnRequest })])


### PR DESCRIPTION
Code changes for #6785: Support for the BSC chain in the bridge, creation of BNB token on STRATO with price feeds.

Admin Deployment Steps Doc: [BNB Deployment Doc](https://docs.google.com/document/d/1BGB4gMeznIsxEQR2iBKfMPKKn-uCVyzZQF8vX7ptLsQ/edit?usp=sharing)

The related Admin Deployment Steps Doc is at [BNB Deployment Doc](https://docs.google.com/document/d/1BGB4gMeznIsxEQR2iBKfMPKKn-uCVyzZQF8vX7ptLsQ/edit?usp=sharing)

`mercata/ethereum` changes used to deploy and verify `DepositRouter.sol` on BSC.

Price oracle changes tested on `testnet-oracle1`; should be deployed on the mainnet oracles only when the token deploy order has been decided; the address in `assets.json` assumes that BNB will be the next token created (no pools or tokens created before it) following the already deployed `STRATO aUSDT`.

Bridge must be built locally and pushed to the docker registry, then the docker-compose.yml updated with the new tags. I already updated `run-bridge.sh` and `docker-compose.bridge.yml` with the new env var on `mainnet-bridge`, so just the image tags need updated and then do `./run-bridge.sh` to deploy; this can be done before any of the admin steps.