### PR TITLE
rewards-poller: rewrite service docs (README, FLOW, OPERATIONS)

### DIFF
--- a/mercata/services/rewards-poller/README.md
+++ b/mercata/services/rewards-poller/README.md
@@ -1,193 +1,203 @@
 # Mercata Rewards Poller Service
 
-The Mercata Rewards Poller Service monitors protocol events from Cirrus DB and posts batch transactions to the Rewards contract to track user activity for reward distribution.
+The rewards poller is a long-running Node service. It reads protocol events from Cirrus DB, converts them to USD amounts via the on-chain Price Oracle, and writes them to the `Rewards` contract through a single method: `batchHandleAction`. It also computes periodic bonus (boost) credits for holders of configured bonus tokens and posts those through the same method.
 
-## Features
+- **How it works end-to-end** → [docs/FLOW.md](docs/FLOW.md)
+- **Runbooks — add/remove a reward, add/remove a bonus token** → [docs/OPERATIONS.md](docs/OPERATIONS.md)
 
-* **Event Monitoring**: Polls Cirrus DB for events from protocol contracts (Pool, LiquidityPool, LendingPool)
-* **Automatic Mapping**: Maps protocol events to Rewards contract actions (deposit, withdraw, occurred)
-* **Batch Processing**: Groups events by action type and posts transactions in batches
-* **OAuth Integration**: Secure authentication with STRATO using OpenID Connect
-* **Comprehensive Logging**: Secure and contextual logging using Winston
-* **Health Monitoring**: Health check endpoint with error tracking
+---
 
-## Prerequisites
+## Source map
 
-- Node.js 22.12 or higher
-- Access to STRATO node
-- STRATO OAuth credentials
-- Rewards contract address
-
-## Installation
-
-1. Navigate to the rewards poller service:
-```bash
-cd services/rewards-poller
+```text
+src/
+├── index.ts                                  Express bootstrap, /health, cycle init
+├── features/
+│   ├── polling/
+│   │   ├── polling.bootstrap.ts              Starts both cycles
+│   │   └── polling.scheduler.ts              Recursive setTimeout loop
+│   ├── rewards-cycle/
+│   │   ├── rewardsCycle.processor.ts         Rewards cycle: read events → batch → write
+│   │   ├── rewardsBatch.writer.ts            batchHandleAction / batchAddBonus wrappers
+│   │   └── rewardsBalance.guard.ts           Pre-flight USDST/Voucher balance check
+│   ├── bonus-cycle/
+│   │   ├── bonusCycle.processor.ts           Bonus cycle: retry pending, compute, write
+│   │   ├── bonusCredit.calculator.ts         Boost math
+│   │   └── bonusConfig.validator.ts          Schema-checks bonusTokenConfig.json + validates BonusCredit objects
+│   └── events-read/
+│       ├── cirrusEvents.client.ts            Discovers activities + fetches events
+│       ├── activity.mapper.ts                attributeMapping.json + PriceOracle USD conversion
+│       ├── actionableEvents.parser.ts        Parses Rewards.activities.actionableEvents
+│       ├── bonusEligibility.reader.ts        Current bonus-token balances per user
+│       ├── emissionRates.reader.ts           Per-user per-activity emission rates
+│       ├── stakeUsd.provider.ts              Per-activity USD notional: LP tokens (reserve-weighted, via Oracle), vault shares (on-chain NAV), CDP (passthrough)
+│       ├── directPayout.resolver.ts          Maps bonus token → direct-payout event name
+│       └── eventRecord.mapper.ts, mappingRow.parser.ts, addressNormalization.ts
+├── infra/
+│   ├── config/
+│   │   ├── runtimeConfig.ts                  Single `config` object
+│   │   ├── constants.ts, env.ts              Defaults and env validation
+│   │   ├── attributeMapping.json             (see Configuration)
+│   │   └── bonusTokenConfig.json             (see Configuration)
+│   ├── auth/
+│   │   └── oauth.client.ts, tokenProvider.ts OpenID / STRATO auth + BA user address
+│   ├── http/
+│   │   ├── api.ts                            strato / bloc / cirrus axios clients
+│   │   ├── strato.client.ts                  buildFunctionTx + postAndWaitForTx + execute
+│   │   └── retry.policy.ts                   Exponential backoff wrapper
+│   ├── observability/
+│   │   ├── logger.ts                         Structured console logging with secret redaction
+│   │   └── errorFileSink.ts, healthMonitor.ts Error flag file for /health
+│   └── state/
+│       ├── atomicJson.store.ts               Atomic JSON write (write-to-tmp then rename)
+│       ├── blockTracking.repo.ts             Block cursor (lastProcessedBlock.json)
+│       └── bonusTracking.repo.ts             Bonus state (lastBonusRun.json)
+└── shared/
+    ├── core/                                 address.ts, errors.ts, retry.ts
+    └── types/index.ts
 ```
 
-2. Install dependencies:
-```bash
-npm install
-```
-
-3. Copy the example environment file and update the values:
-```bash
-cp .env.example .env
-```
+---
 
 ## Configuration
 
-### Required Environment Variables
+### Required environment variables
 
-#### Authentication
-- `BA_USERNAME` - BlockApps username
-- `BA_PASSWORD` - BlockApps password
-- `CLIENT_SECRET` - OAuth client secret
-- `CLIENT_ID` - OAuth client ID
-- `OPENID_DISCOVERY_URL` - OpenID discovery endpoint
 
-#### Blockchain
-- `NODE_URL` - STRATO node URL
-- `REWARDS_CONTRACT_ADDRESS` - Rewards contract address
-- `PRICE_ORACLE_ADDRESS` - Price Oracle contract address (required for Swap event USD conversion)
+| Variable                     | Purpose                                             |
+| ---------------------------- | --------------------------------------------------- |
+| `BA_USERNAME`, `BA_PASSWORD` | BlockApps credentials                               |
+| `CLIENT_ID`, `CLIENT_SECRET` | OAuth client credentials                            |
+| `OPENID_DISCOVERY_URL`       | OpenID discovery endpoint                           |
+| `NODE_URL`                   | STRATO node URL                                     |
+| `REWARDS_CONTRACT_ADDRESS`   | Rewards contract (proxy)                            |
+| `PRICE_ORACLE_ADDRESS`       | Price Oracle contract (required for USD conversion) |
 
-### Optional Environment Variables
 
-#### Service
-- `PORT` - Service port (default: `3004`)
+### Optional environment variables
 
-#### Contract Addresses
-- `USDST_ADDRESS` - USDST token contract address (default: `937efa7e3a77e20bbdbd7c0d32b6514f368c1010`)
-- `VOUCHER_ADDRESS` - Voucher contract address (default: `000000000000000000000000000000000000100e`)
 
-#### Polling Configuration
-- `POLLING_INTERVAL` - Polling interval in milliseconds (default: `600000`)
-- `MAX_BATCH_SIZE` - Maximum number of actions per batch (default: `50`)
+| Variable                         | Default                                    | Purpose                                       |
+| -------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| `PORT`                           | `3004`                                     | Express port                                  |
+| `USDST_ADDRESS`                  | `937efa7e3a77e20bbdbd7c0d32b6514f368c1010` | USDST token                                   |
+| `VOUCHER_ADDRESS`                | `000000000000000000000000000000000000100e` | Voucher token                                 |
+| `POLLING_INTERVAL`               | `600000` (10 min)                          | Rewards cycle interval, ms                    |
+| `MAX_BATCH_SIZE`                 | `50`                                       | Actions per `batchHandleAction` call          |
+| `BONUS_CRON_SCHEDULE`            | `0 3,9,15,21 * * *`                        | Bonus cycle cron                              |
+| `GAS_FEE_USDST`                  | `1` (= 0.01 USDST)                         | Gas estimate per tx, multiplied by 1e16       |
+| `GAS_FEE_VOUCHER`                | `100` (= 1 Voucher)                        | Gas estimate per tx, multiplied by 1e16       |
+| `MIN_TRANSACTIONS_THRESHOLD`     | `1`                                        | Abort cycle if estimated txs remaining ≤ this |
+| `WARNING_TRANSACTIONS_THRESHOLD` | `100`                                      | Log error (flag unhealthy) below this         |
+| `RETRY_MAX_ATTEMPTS`             | `2`                                        | Exponential backoff for Strato calls          |
+| `RETRY_INITIAL_DELAY`            | `1000`                                     | ms                                            |
+| `RETRY_MAX_DELAY`                | `10000`                                    | ms                                            |
 
-#### Bonus Configuration
-- `BONUS_CRON_SCHEDULE` - Cron schedule for bonus processing (default: `0 3,9,15,21 * * *`)
 
-#### Balance Configuration
-- `GAS_FEE_USDST` - Gas fee in USDST, multiplied by 1e16 (default: `1` = 0.01 USDST)
-- `GAS_FEE_VOUCHER` - Gas fee in Voucher, multiplied by 1e16 (default: `100` = 1 Voucher)
-- `MIN_TRANSACTIONS_THRESHOLD` - Minimum transactions that can be processed with current balance (default: `1`)
-- `WARNING_TRANSACTIONS_THRESHOLD` - Threshold for low balance warning (default: `100`)
+See [`src/infra/config/constants.ts`](src/infra/config/constants.ts) for the full list of defaults.
 
-#### Retry Configuration
-- `RETRY_MAX_ATTEMPTS` - Maximum retry attempts (default: `2`)
-- `RETRY_INITIAL_DELAY` - Initial retry delay in milliseconds (default: `1000`)
-- `RETRY_MAX_DELAY` - Maximum retry delay in milliseconds (default: `10000`)
+### Event attribute mapping
 
-### Example .env File
+[`src/infra/config/attributeMapping.json`](src/infra/config/attributeMapping.json) is keyed by contract address, then by event name. Each entry tells the poller which attribute on the event payload holds the amount (and optionally which holds the user address; otherwise `transaction_sender` is used).
 
-```env
-# Authentication
-BA_USERNAME=your_username
-BA_PASSWORD=your_password
-CLIENT_SECRET=your_client_secret
-CLIENT_ID=your_client_id
-OPENID_DISCOVERY_URL=https://your-openid-provider/.well-known/openid-configuration
-
-# Contract Addresses
-REWARDS_CONTRACT_ADDRESS=0000000000000000000000000000000000000000
-PRICE_ORACLE_ADDRESS=0000000000000000000000000000000000000000
-USDST_ADDRESS=937efa7e3a77e20bbdbd7c0d32b6514f368c1010
-VOUCHER_ADDRESS=000000000000000000000000000000000000100e
-
-# API Configuration
-NODE_URL=https://your-strato-node-url
-
-# Polling Configuration
-POLLING_INTERVAL=600000
-MAX_BATCH_SIZE=50
-
-# Bonus Configuration
-BONUS_CRON_SCHEDULE="0 3,9,15,21 * * *"
-
-# Balance Configuration
-GAS_FEE_USDST=1
-GAS_FEE_VOUCHER=100
-MIN_TRANSACTIONS_THRESHOLD=1
-WARNING_TRANSACTIONS_THRESHOLD=100
-
-# Retry Configuration
-RETRY_MAX_ATTEMPTS=2
-RETRY_INITIAL_DELAY=1000
-RETRY_MAX_DELAY=10000
+```json
+{
+  "0000000000000000000000000000000000001004": {
+    "Deposited":  { "amount": "mTokenMinted", "user": "user" },
+    "Withdrawn":  { "amount": "mTokenBurned" }
+  }
+}
 ```
 
-## Event Mappings
 
-The service uses hardcoded event mappings to convert protocol events to Rewards contract calls:
+| Field    | Required | Meaning                                                                         |
+| -------- | -------- | ------------------------------------------------------------------------------- |
+| `amount` | yes      | Event attribute that holds the amount                                           |
+| `user`   | no       | Event attribute that holds the user address; falls back to `transaction_sender` |
 
-- `Pool.Deposited` → `rewards.deposit(activityId: 1, user, amount)`
-- `Pool.Withdrawn` → `rewards.withdraw(activityId: 1, user, amount)`
-- `LiquidityPool.Deposited` → `rewards.deposit(activityId: 2, user, amount)`
-- `LiquidityPool.Withdrawn` → `rewards.withdraw(activityId: 2, user, amount)`
-- `LendingPool.Borrowed` → `rewards.occurred(activityId: 3, user, amount)`
-- `LendingPool.Repaid` → `rewards.occurred(activityId: 4, user, amount)`
 
-## Usage
+Keys are the 40-hex-char address (no `0x`, lowercase). Categories currently represented: protocol pool events, bridge events, stablecoin mint/burn, staking, AMM swaps, LP token mint/burn, external vaults. See [FLOW.md](docs/FLOW.md) for how this file is used at runtime, and [OPERATIONS.md](docs/OPERATIONS.md) for how to add entries.
 
-### Development
+### Bonus token config
+
+[`src/infra/config/bonusTokenConfig.json`](src/infra/config/bonusTokenConfig.json) is an array of objects:
+
+```json
+[
+  {
+    "address": "<stratoTokenAddress>",
+    "maxMultiplier": 2,
+    "conversionRate": 0.3
+  }
+]
+```
+
+
+| Field            | Constraint                 | Meaning                                                            |
+| ---------------- | -------------------------- | ------------------------------------------------------------------ |
+| `address`        | 40-hex, no `0x`, lowercase | Bonus token contract on STRATO                                     |
+| `maxMultiplier`  | strictly `> 1`             | Total boost cap; `2` means up to 2× total rewards at full coverage |
+| `conversionRate` | in `(0, 1]`                | Bonus token → USD; `0.3` means 1 token covers $0.30 of position    |
+
+
+> **Important:** Constraints are enforced at startup by `bonusConfig.validator.ts`. An invalid config crashes the service on boot.
+
+> **Caveat:** `maxMultiplier` is currently taken from the **first** token config entry only (`tokenConfigs[0].maxMultiplier` at `bonusCycle.processor.ts:40`) and applied to all users. If multiple bonus tokens are configured with different `maxMultiplier` values, only the first entry's value is used.
+
+---
+
+## Running
+
 ```bash
-npm run dev
+cd services/rewards-poller
+npm install
+cp .env.example .env   # fill in the required variables
+npm start              # runs ts-node on src/index.ts
+npm run build          # compile to dist/ via tsc
 ```
 
-### Production
-```bash
-npm start
-```
+> **Note:** `npm run dev` (nodemon) is not usable as-is because the service writes state files (`lastProcessedBlock.json`, `lastBonusRun.json`) in the working directory on every cycle, which nodemon detects and triggers a restart loop. Use `npm start` for local work, or run nodemon manually with `--ignore '*.json' --ignore '*.flag'`.
 
-### Build
-```bash
-npm run build
-```
+---
 
-## API Endpoints
+## Health, state, and logging
 
-### Health Check
+### Health check
+
 ```
 GET /health
 ```
 
-Returns service health status. Returns 500 if error file exists, 200 otherwise.
+Returns `200` when the error flag file is empty or missing; `500` when it has content. The `/health` handler calls `healthMonitor.errorFileExists()` ([`healthMonitor.ts`](src/infra/observability/healthMonitor.ts)), which wraps [`errorFileSink.ts:errorFileHasContent`](src/infra/observability/errorFileSink.ts) with ENOENT handling.
 
-## Architecture
+The flag is append-only: every `logError` call writes to it — low-balance warnings, transient Cirrus failures, anything at error level. Once set, the service stays unhealthy until you delete or truncate `rewards-poller-error.flag` after resolving the root cause.
 
-### Service Structure
+For recovery scenarios, see [FLOW.md § State, idempotency, and recovery](docs/FLOW.md#state-idempotency-and-recovery).
 
-- `src/index.ts` - Express server entry point
-- `src/infra/` - Infrastructure concerns (config, auth, observability, state helpers)
-- `src/features/` - Feature modules (polling, events-read, rewards-cycle, bonus-cycle)
-- `src/shared/` - Shared core helpers and shared types
+### State files (working directory)
 
-### Polling Flow
 
-1. Service polls Cirrus DB for events from configured protocol contracts
-2. Events are mapped to Rewards actions based on hardcoded mappings
-3. Actions are grouped by type (deposit/withdraw/occurred)
-4. Batched transactions are posted to the Rewards contract
-5. Last processed block numbers are tracked to avoid reprocessing
+| File                        | Shape                                                             | Writer                                                           | Atomic?              |
+| --------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------- |
+| `lastProcessedBlock.json`   | `{ blockNumber, eventIndex, block_timestamp }`                    | [`blockTracking.repo.ts`](src/infra/state/blockTracking.repo.ts) | yes (write)          |
+| `lastBonusRun.json`         | `{ lastSuccessfulTimestamp, pendingCredits[], balanceSnapshots }` | [`bonusTracking.repo.ts`](src/infra/state/bonusTracking.repo.ts) | yes (write)          |
+| `rewards-poller-error.flag` | Append-only log of error-level events                             | [`errorFileSink.ts`](src/infra/observability/errorFileSink.ts)   | no (`fs.appendFile`) |
 
-### Error Handling
 
-- Duplicate transaction errors are handled gracefully
-- Errors are logged but polling continues
-- Failed events can be retried on next polling cycle
-- Error file tracking for health monitoring
+Atomic writes go through [`atomicJson.store.ts`](src/infra/state/atomicJson.store.ts) (write-to-tmp then rename). Reads use `fs.readFile` directly. Non-empty `.flag` means `/health` reports unhealthy.
 
-## Logging
+### Logging
 
-The service uses structured logging with:
-- Info logs for successful operations
-- Error logs for failures with context
-- Sensitive data redaction (API keys, tokens)
-- Error file tracking for health monitoring
+Structured JSON-ish logs to stdout/stderr via [`src/infra/observability/logger.ts`](src/infra/observability/logger.ts) (plain `console`, not Winston):
 
-## Future Shared Extraction Candidates
+- `logInfo(context, message, data?)` — successful operations.
+- `logError(context, error, data?)` — failures; also appends to the error flag file.
 
-- `src/infra/observability` (logger + error file sink)
-- `src/infra/auth` (OAuth bootstrap/token flow)
-- `src/infra/http` (API clients + retry + STRATO helper)
-- `src/infra/state/atomicJson.store.ts`
+Known sensitive patterns redacted before output:
+
+- `api_key=` / `api-key=` / `apikey=`
+- `Bearer <token>`
+- `Authorization:` headers
+
+> **Warning:** Raw credential strings outside the patterns above are not auto-redacted. Be careful about log context.
+

--- a/mercata/services/rewards-poller/docs/FLOW.md
+++ b/mercata/services/rewards-poller/docs/FLOW.md
@@ -1,0 +1,272 @@
+# Rewards Poller — End-to-End Flow
+
+How the service works, from start to finish.
+
+- For **how to change things** → [OPERATIONS.md](OPERATIONS.md)
+- For **module map, config, health** → [README](../README.md)
+
+---
+
+## Contents
+
+1. [Startup](#startup)
+2. [The rewards cycle](#the-rewards-cycle)
+3. [The bonus cycle](#the-bonus-cycle)
+4. [Anatomy of a contract write](#anatomy-of-a-contract-write)
+5. [State, idempotency, and recovery](#state-idempotency-and-recovery)
+
+---
+
+## Startup
+
+`src/index.ts` is the entry point. On boot the service:
+
+1. Loads `.env` via `dotenv`.
+2. Builds the single `config` object ([`runtimeConfig.ts`](../src/infra/config/runtimeConfig.ts)). At module load time the order is:
+   1. Parse and validate [`bonusTokenConfig.json`](../src/infra/config/bonusTokenConfig.json) via `bonusConfig.validator.ts`.
+   2. Construct the `config` object.
+   3. Run `validateRequiredEnvVars` on `REQUIRED_ENV_VARS` (see [`constants.ts`](../src/infra/config/constants.ts)).
+
+   An invalid bonus config throws an uncaught `Error` first; a missing env var calls `process.exit(2)` last. Either crashes the process on boot, through different mechanisms.
+3. Starts an Express app on `PORT` (default `3004`) exposing `GET /health`.
+4. `initOpenIdConfig()` fetches the OpenID discovery document and primes the OAuth flow ([`tokenProvider.ts`](../src/infra/auth/tokenProvider.ts)).
+5. `initializeRewardsPolling()` (in [`polling.bootstrap.ts`](../src/features/polling/polling.bootstrap.ts)):
+   - Reads the block cursor from `lastProcessedBlock.json`. If the file is absent or corrupt, `getLatestCursorFromEvents()` queries Cirrus for the **most recent** `ActionProcessed` event on the Rewards contract (`order: id.desc`, `limit: 1`) and uses that as the starting cursor.
+   - Starts the rewards cycle via `polling.scheduler.ts` (recursive `setTimeout`, so each cycle waits for the previous to finish before scheduling the next).
+   - Schedules the bonus cycle via `node-cron` using `BONUS_CRON_SCHEDULE`.
+
+> **Note:** On a fresh deploy with no cursor file, the service starts from the **tip** of the Cirrus event stream — it does not backfill history.
+
+From this point the service is two concurrent loops plus the HTTP server.
+
+---
+
+## The rewards cycle
+
+Entry: [`rewardsCycle.processor.ts`](../src/features/rewards-cycle/rewardsCycle.processor.ts) → `processRewardsCycle()`. Runs every `POLLING_INTERVAL` ms (default 10 minutes).
+
+### 1. Balance guard
+
+`checkBalances()` ([`rewardsBalance.guard.ts`](../src/features/rewards-cycle/rewardsBalance.guard.ts)):
+
+- Reads the service account's USDST and Voucher balances from Cirrus (`/BlockApps-Token-_balances`, `/BlockApps-Voucher-_balances`).
+- Divides each by `GAS_FEE_*` to estimate transactions remaining; sums the two counts.
+- Throws if the sum is at or below `MIN_TRANSACTIONS_THRESHOLD` (default `1`), aborting this cycle.
+- If the sum is below `WARNING_TRANSACTIONS_THRESHOLD` (default `100`), calls `logError`.
+
+> **Warning:** A low-balance warning goes through `logError`, which appends to the error flag file and marks the service **unhealthy**. Operators clear this by topping up the account and deleting or truncating the flag.
+
+### 2. Activity discovery
+
+`getEventQueryParams()` ([`cirrusEvents.client.ts`](../src/features/events-read/cirrusEvents.client.ts)) queries Cirrus for the Rewards contract's `activities` mapping, filtered to entries with non-zero `emissionRate`. For each activity it reads `sourceContract` and `actionableEvents` and builds three lookup structures:
+
+| Structure | Built as | Returned as | Use |
+|:--|:--|:--|:--|
+| `contractAddresses` | `Set<string>` | `string[]` | SQL filter |
+| `eventNames` | `Set<string>` | `string[]` | SQL filter |
+| `validPairs` | `Set<string>` (pair keys) | `Set<string>` | Post-filter against the SQL cross-product |
+
+> **Note:** What gets tracked is fully on-chain. The service has no local list; admin governance on `Rewards.sol` is the source of truth.
+
+### 3. Event fetch
+
+`getEventsBatch()` pulls new events since the stored cursor (`{blockNumber, eventIndex, block_timestamp}`). Two parallel paths:
+
+**Regular events** (`/event` Cirrus table):
+
+- Filtered by contract address + event name + `block_timestamp >= cursor.block_timestamp`.
+- Results post-filtered to drop events at or before `(cursor.blockNumber, cursor.eventIndex)`.
+- For each event that passes the cursor filter, [`activity.mapper.ts`](../src/features/events-read/activity.mapper.ts) → `extractAmountFromAttributes` looks up the right attribute per [`attributeMapping.json`](../src/infra/config/attributeMapping.json).
+- For `Swap`, `DepositCompleted`, `WithdrawalCompleted` the amount is converted to USD using the most recent `BlockApps-PriceOracle-PriceUpdated` / `BlockApps-PriceOracle-BatchPricesUpdated` event at or before the event's timestamp.
+- `DepositCompleted` / `WithdrawalCompleted` additionally drop any token that isn't USDST — only USDST bridge flows accrue rewards.
+
+**LP-token transfers** (`/BlockApps-Token-Transfer`):
+
+- For addresses whose `attributeMapping.json` entry has `Minted` and/or `Burned`.
+- Filtered by `from = 0000…0` (mint) or `to = 0000…0` (burn) — the 40-hex zero address.
+- Synthesized into a `Minted` or `Burned` protocol event with `amount = value`.
+
+`getEventsBatch()` merges the two sets and sorts by `(blockNumber, eventIndex)`.
+
+### 4. Batch and write
+
+Events are mapped to `RewardsAction` records and chunked into batches of `MAX_BATCH_SIZE` (default `50`). For each batch:
+
+1. [`rewardsBatch.writer.ts`](../src/features/rewards-cycle/rewardsBatch.writer.ts) → `batchHandleAction()` builds a `FunctionInput` targeting `Rewards.batchHandleAction(...)`.
+2. `retryWithBackoff` ([`retry.policy.ts`](../src/infra/http/retry.policy.ts)) wraps the call — default 2 attempts with exponential backoff.
+3. `execute()` ([`strato.client.ts`](../src/infra/http/strato.client.ts)) posts to STRATO's `/transaction/parallel?resolve=true`, waits for tx hashes, then polls `/transactions/results` until each is no longer `Pending`.
+4. On success, the block cursor is advanced to the last event in the batch via `blockTrackingService.updateCursor()`.
+
+### 5. Error handling
+
+| Error kind | Behavior |
+|:--|:--|
+| Contract execution failure (per `isContractExecutionFailure()`) | Batch skipped, **cursor still advances**. One poisoned event can't block the queue. |
+| Anything else (network, Strato, auth) | Re-thrown from the per-batch `catch`, then swallowed by the outer `catch` in `processRewardsCycle` which calls `logError` and returns. The cycle ends early, the cursor does not advance past the failed batch, the polling loop continues, and the next cycle retries the same range. |
+
+---
+
+## The bonus cycle
+
+Entry: [`bonusCycle.processor.ts`](../src/features/bonus-cycle/bonusCycle.processor.ts) → `processBonusCycle()`. Scheduled by `node-cron` using `BONUS_CRON_SCHEDULE` (default `0 3,9,15,21 * * *` — four times a day).
+
+### 1. What the bonus actually is
+
+A user who holds an eligible bonus token gets a multiplier on their base rewards, up to `maxMultiplier` total, scaled by how much of their active position value is "covered" by their bonus-token holdings. Holding more bonus tokens than your position does **not** push coverage past 1.0 — the multiplier caps there.
+
+Base rewards still accrue via the regular rewards cycle (via `batchHandleAction` on Position / OneTime activities). The bonus cycle **only posts the delta** — the extra amount on top of base rewards — as a direct-payout credit.
+
+### 2. Eligibility
+
+- Every **Position** activity the user is staked in counts toward `eligibleActivityUsd`.
+- **OneTime** activities (`activityType === "1"`) are excluded (see `isPositionActivity()`, [`bonusCredit.calculator.ts`](../src/features/bonus-cycle/bonusCredit.calculator.ts)).
+- Each activity's USD notional comes from [`stakeUsd.provider.ts`](../src/features/events-read/stakeUsd.provider.ts). Different activity shapes use different pricing paths:
+  - **LP tokens** — priced reserve-weighted via the Price Oracle (`getOraclePrices()`).
+  - **Vault shares** — priced from on-chain vault state (`BlockApps-SaveUSDSTVault` + `BlockApps-Token-_balances`) as a conservative `min(liveBalance, managedAssets) / totalShares`. The Price Oracle is not consulted for vault pricing.
+  - **CDP notional** — passthrough (activity names containing "cdp", "mint", or "borrow" return `userStake` as-is on the assumption that the stake is already USD-denominated).
+
+### 3. Anti-gaming: trailing-average balances
+
+Per `(bonusToken, user)` pair, the service keeps a rolling window of `BONUS_SNAPSHOT_WINDOW = 28` balance snapshots (one per successful cycle). The effective balance for the cycle is:
+
+```text
+effectiveBalance = min(currentBalance, averageOfSnapshots)
+```
+
+A user who spikes their bonus-token balance right before a cycle sees only the rolling average, not their current holdings. The window grows cycle-by-cycle to its cap.
+
+Snapshots are stored in `lastBonusRun.json` under `balanceSnapshots[<tokenKey>][<user>]` and trimmed to the most recent 28 entries each cycle.
+
+### 4. The math
+
+```text
+effectiveBalance = min(currentBalance, trailingAvg)
+boostCapUsd      = effectiveBalance * conversionRate
+coverage         = min(1, boostCapUsd / eligibleActivityUsd)
+boostedRewards   = baseRewards * coverage * (maxMultiplier - 1)
+totalRewards     = baseRewards + boostedRewards
+```
+
+What the service actually posts (the delta) is computed at `bonusCredit.calculator.ts:189`:
+
+```text
+bonusAmount = eligibleEmissionRate * intervalSeconds * coverage * (maxMultiplier - 1)
+```
+
+| Term | Meaning |
+|:--|:--|
+| `eligibleEmissionRate` | Sum of the user's per-activity personal emission rates across eligible (Position) activities. Pulled via [`emissionRates.reader.ts`](../src/features/events-read/emissionRates.reader.ts) from Cirrus. |
+| `intervalSeconds` | Seconds since the last successful bonus run, clamped to `[1, MAX_BONUS_INTERVAL_SECONDS]` where `MAX_BONUS_INTERVAL_SECONDS = 86400` (24h). On first run, `getCronIntervalSeconds()` derives a sensible interval from the cron expression. |
+
+### 5. Retry: pending credits first
+
+Each cycle:
+
+1. Load state from `lastBonusRun.json`: `{lastSuccessfulTimestamp, pendingCredits[], balanceSnapshots}`.
+2. Fetch current bonus-token balances ([`bonusEligibility.reader.ts`](../src/features/events-read/bonusEligibility.reader.ts)).
+3. Build `bonusUsers` and advance `balanceSnapshots`.
+4. **Compute** new credits.
+5. **Validate** — `[...pendingCredits, ...newCredits]` are each run through `isValidBonusCredit()`. If any credit has missing fields, the cycle throws before any write happens (`bonusCycle.processor.ts:45-49`).
+6. **Write** any `pendingCredits` from the previous cycle first (in batches of `MAX_BATCH_SIZE`). Failed batches stay pending.
+7. **Write** the new credits. Failed batches are added to `pendingCredits`.
+8. Persist updated state.
+
+> **Note:** Computation of new credits happens before any write this cycle, but on the wire, previous-cycle leftovers go first. A single invalid credit anywhere in the combined set aborts the entire cycle before either write.
+
+### 6. Per-user error isolation
+
+If `computeStakeUsdForActivities()` throws for a specific user (e.g. an LP pricing error), `bonusCredit.calculator.ts:161-170` catches and skips that user — the rest of the cycle continues.
+
+### 7. Writing the credit
+
+`batchAddBonus()` ([`rewardsBatch.writer.ts`](../src/features/rewards-cycle/rewardsBatch.writer.ts)) builds a `FunctionInput` for `Rewards.batchHandleAction` — the **same method** as the regular cycle — but:
+
+- The event name used is the one registered via `addOneTimeDirectPayoutActivity` for that bonus token (looked up at runtime by [`directPayout.resolver.ts`](../src/features/events-read/directPayout.resolver.ts)).
+- Each credit uses sentinel `blockNumber = 1`, `eventIndex = 1`. Direct-payout activities on the contract bypass the idempotency check, so the same sentinels can be reused across cycles without collisions.
+- No `retryWithBackoff` wrapper here — unlike the regular cycle, a failed `batchAddBonus` falls through immediately to the pending-credit path.
+
+---
+
+## Anatomy of a contract write
+
+The service makes exactly **one kind of on-chain write**: `Rewards.batchHandleAction(...)`. A single batch (from either the rewards cycle or the bonus cycle) moves through five stages:
+
+### Stage 1 — Input
+
+Either `RewardsAction[]` (regular cycle) or `BonusCredit[]` (bonus cycle), both chunked to `MAX_BATCH_SIZE`.
+
+### Stage 2 — Build `FunctionInput` (`rewardsBatch.writer`)
+
+```ts
+{
+  contractName:    "Rewards",
+  contractAddress: REWARDS_CONTRACT_ADDRESS,
+  method:          "batchHandleAction",
+  args: {
+    sourceContracts: [...],
+    eventNames:      [...],
+    users:           [...],
+    amounts:         [...],
+    blockNumbers:    [...],
+    eventIndexes:    [...],
+  },
+}
+```
+
+### Stage 3 — Wrap as `BuiltTx` (`strato.client.buildFunctionTx`)
+
+```ts
+{
+  txs: [{ type: "FUNCTION", payload: { /* the FunctionInput */ } }],
+  txParams: { gasLimit, gasPrice },  // fixed in constants.ts
+}
+```
+
+### Stage 4 — Submit and poll (`strato.client.execute`)
+
+| Call | Endpoint | Purpose |
+|:--|:--|:--|
+| `strato.post(...)` | `/transaction/parallel?resolve=true` | Submit; returns `[{ hash, ... }]` |
+| `bloc.post(...)` | `/transactions/results` | Polled with each hash until no result is `Pending`. Returns `{ status: Success \| Failure, hash }` |
+
+### Stage 5 — On-chain execution (`Rewards.batchHandleAction`)
+
+For each `(sourceContract, eventName, user, amount, blockNumber, eventIndex)` in the batch:
+
+1. Look up the activity via `sourceEventInfo[sourceContract][eventName]`. Reverts the action if no activity is registered for that pair.
+2. If the activity is marked `directPayout`, credit the user directly and return — this path bypasses the idempotency check (see [Idempotency](#idempotency)).
+3. Otherwise, check `processedEvents[keccak256(blockNumber, eventIndex)]` — if already processed, silently skip.
+4. Update the activity's global reward index, then settle the user's pending rewards using their **old** stake (Aave-style: rewards = oldStake × (currentIndex − userIndex)). This credits `unclaimedRewards` before the stake changes.
+5. Apply the `Deposit` / `Withdraw` / `Occurred` action to the user's stake; update `userInfo.stake` and `totalStake`.
+
+---
+
+## State, idempotency, and recovery
+
+### Where state lives
+
+Three files in the service's working directory — see [README § State files](../README.md#state-files-working-directory) for the canonical listing. In brief:
+
+| File | Purpose |
+|:--|:--|
+| `lastProcessedBlock.json` | Rewards-cycle cursor |
+| `lastBonusRun.json` | Bonus-cycle state |
+| `rewards-poller-error.flag` | Health-check sink |
+
+> **Important:** The block cursor is cached in memory by `blockTracking.repo.ts` and a regression guard refuses to write a cursor that goes backwards during a run. To rewind the cursor for replay, **stop the service first** — otherwise the file edit will be overwritten on the next successful cycle.
+
+### Idempotency
+
+On-chain `batchHandleAction` uses `keccak256(blockNumber, eventIndex)` as a global dedup key in a single `processedEvents` mapping: processed events are silently skipped (mechanism described in [Anatomy of a contract write](#anatomy-of-a-contract-write) above). In practice the `(blockNumber, eventIndex)` pair is unique across all on-chain events, so this behaves as per-event dedup. Operational implications:
+
+- **Replaying the rewards cycle is safe.** Rewind `lastProcessedBlock.json` (service stopped), restart. Duplicate events are dropped on-chain.
+- **Bonus credits deliberately bypass** this check. Direct-payout activities use sentinel `blockNumber=1, eventIndex=1`, so the same user can receive multiple credits across cycles — which is exactly what you want for a periodic payout.
+
+### Common recovery scenarios
+
+| Symptom | What to do |
+|:--|:--|
+| Poisoned event blocking the cycle | Usually not an issue — contract execution failures auto-skip at `rewardsCycle.processor.ts:54-68` and the cursor advances. If not, manually advance the cursor past the offending `(blockNumber, eventIndex)`. |
+| `/health` returns 500 | Inspect `rewards-poller-error.flag` for context, fix the root cause (top up gas, fix auth, fix Cirrus), then delete or truncate the flag. |
+| Missed bonus cycles | `MAX_BONUS_INTERVAL_SECONDS = 86400` caps the interval at 24h regardless of downtime. You lose boost accrual beyond 24h of downtime. |
+| Pending credits backlog | Inspect `lastBonusRun.json.pendingCredits[]`. They retry each cycle. If they fail persistently, the root cause is almost always the on-chain direct-payout activity being missing or misconfigured. |

--- a/mercata/services/rewards-poller/docs/OPERATIONS.md
+++ b/mercata/services/rewards-poller/docs/OPERATIONS.md
@@ -1,0 +1,254 @@
+# Rewards Poller — Operations Runbook
+
+Step-by-step procedures for adding and removing rewards and bonuses. Use this when onboarding a new protocol, pool, or bonus token.
+
+- For **how the service works** → [FLOW.md](FLOW.md)
+- For **config and deployment** → [README](../README.md)
+
+---
+
+## Contents
+
+- [Add a reward](#add-a-reward)
+- [Remove a reward](#remove-a-reward)
+- [Add a bonus](#add-a-bonus)
+- [Remove a bonus](#remove-a-bonus)
+- [Upgrade the Rewards contract](#upgrade-the-rewards-contract)
+
+---
+
+> **Note:** The authoritative registry of what is tracked lives on-chain in the Rewards contract's `activities` mapping. The poller discovers it at every cycle via Cirrus, so there is no "register in the service" step for activities. The two local JSON files ([`attributeMapping.json`](../src/infra/config/attributeMapping.json) and [`bonusTokenConfig.json`](../src/infra/config/bonusTokenConfig.json)) only tell the service how to interpret what the contract has already registered.
+
+---
+
+## Add a reward
+
+Use when you want to reward users for a new kind of event (new pool, new LP, new protocol). "Reward" here means an **activity** on the Rewards contract — either **Position** (stake accrues rewards over time) or **OneTime** (one-shot credit per event).
+
+### 1. Decide the activity shape
+
+| Shape | When to use | Events |
+|:--|:--|:--|
+| **Position** | Stake accrues rewards proportional to `stake / totalStake`. Deposits, LPs, lending positions, vaults. | Paired `Deposit` + `Withdraw` |
+| **OneTime** | One-shot credit when the event fires. Referrals, boosts, completed actions. | Single `Occurred` |
+
+### 2. Register the activity on-chain (admin vote)
+
+All activity registration happens via an Admin-UI governance vote on the Rewards contract. Pick the one function that matches your activity shape:
+
+#### Option A — Position activity with deposit + withdraw events
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy (`REWARDS_CONTRACT_ADDRESS`)
+> - **Function:** `addPositionActivitySimple(string name, uint256 emissionRate, address sourceContract, string depositEventName, string withdrawEventName)`
+
+Example args:
+
+- `name`: `"NewPool Staking"`
+- `emissionRate`: CATA per second in the smallest unit (18 decimals — so `1e18` ≈ 1 CATA/sec). Use `0` to register disabled and enable later.
+- `sourceContract`: pool contract address (no `0x` prefix, lowercase).
+- `depositEventName`: `"Deposited"`
+- `withdrawEventName`: `"Withdrawn"`
+
+#### Option B — Position activity with custom events
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy
+> - **Function:** `addPositionActivity(string name, uint256 emissionRate, address sourceContract, ActionableEvent[] actionableEvents)`
+
+`ActionableEvent = (string eventName, ActionType actionType)` where `ActionType ∈ {Deposit, Withdraw, Occurred}`. At least one entry required.
+
+#### Option C — OneTime activity
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy
+> - **Function:** `addOneTimeActivity(string name, uint256 emissionRate, address sourceContract, string eventName)`
+
+---
+
+In all three cases:
+
+**Admin UI → Vote On Issues → Create New Issue → select the function above, fill args, approve.**
+
+### 3. Add attribute mapping
+
+Edit [`src/infra/config/attributeMapping.json`](../src/infra/config/attributeMapping.json) — see [README § Event attribute mapping](../README.md#event-attribute-mapping) for the schema. Add a new entry keyed by `sourceContract` → `eventName`.
+
+Extra considerations:
+
+- **USD conversion** — if the event emits a non-USDST token amount that needs USD-denomination, extend `PRICE_CONVERSION_MAP` in [`activity.mapper.ts`](../src/features/events-read/activity.mapper.ts) with `"<EventName>": "<tokenAttributeName>"`. Make sure `PRICE_ORACLE_ADDRESS` is set.
+
+  > **Warning:** `DepositCompleted` / `WithdrawalCompleted` have a hardcoded filter that drops any token other than USDST. A new entry in `PRICE_CONVERSION_MAP` does **not** inherit that filter.
+
+- **LP mint/burn** — events named `Minted` / `Burned` use a special code path (fetched from `BlockApps-Token-Transfer` with zero-address `from`/`to`, not from `/event`). Use those event names for LP mint/burn tracking.
+
+Commit and redeploy the service.
+
+### 4. (Optional) Tune the activity
+
+Additional admin on-chain calls, all `onlyOwner` on the Rewards proxy, same Admin-UI vote mechanism as step 2:
+
+| Function | Purpose |
+|:--|:--|
+| `setEmissionRate(uint256 activityId, uint256 newEmissionRate)` | Change emission rate (set to `0` to disable) |
+| `setActivityName(uint256 activityId, string newName)` | Rename |
+| `setActivityMinAmount(uint256 activityId, uint256 newMinAmount)` | Require a minimum per-action amount to qualify |
+| `setActivityWeight(uint256 activityId, uint256 newWeight)` | Weight multiplier, default `1e18` (1×). OneTime activities only. Must be `> 0` |
+| `setPositionActivityEvents(uint256 activityId, ActionableEvent[] newActionableEvents)` | Replace events on a Position activity. Requires `totalStake == 0` |
+| `setPositionActivityEventsSimple(uint256 activityId, string depositEventName, string withdrawEventName)` | Convenience form of the above. Requires `totalStake == 0` |
+| `setOneTimeActivityEvent(uint256 activityId, string newEventName)` | Change the event on a OneTime activity. Requires `totalStake == 0` |
+
+### 5. Verify
+
+- Logs should include `CirrusService Loaded activities: N contracts, M event names, cursor: …` with N/M increased.
+- On the next cycle, `CirrusService Fetched K events (…)` should include events from the new contract.
+- `RewardsPolling Processed K actions` should follow.
+- Confirm `batchHandleAction` transactions succeed on STRATO (no Failure status).
+
+> **Note:** If you see `AttributeMapping No attribute mapping found for contract …` or `Amount attribute '…' not found`, fix the JSON and redeploy.
+
+---
+
+## Remove a reward
+
+The clean way to remove a reward is to set the activity's emission rate to zero. The poller filters out activities where `emissionRate == 0` in `getEventQueryParams`, so the events stop being fetched.
+
+### 1. Disable on-chain
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy (`REWARDS_CONTRACT_ADDRESS`)
+> - **Function:** `setEmissionRate(uint256 activityId, uint256 newEmissionRate)`
+> - **Args:** `activityId` = id from the original registration; `newEmissionRate` = `0`.
+
+Admin UI → Vote On Issues → Create New Issue → select `setEmissionRate`, fill args, approve.
+
+> **Note:** Existing user stakes and unclaimed rewards are preserved on-chain — only accrual stops. Re-enabling with `setEmissionRate(activityId, rate > 0)` resumes earning for all existing stakers at the new rate.
+
+### 2. (Optional) Clean up attribute mapping
+
+If no other activity uses the same `(contractAddress, eventName)` pair, you can remove the entry from `attributeMapping.json` to keep it tidy. Not required — unused entries are harmless.
+
+### 3. Verify
+
+On the next cycle, `CirrusService Loaded activities: …` should show a lower contract/event count. No new `batchHandleAction` calls will include that contract.
+
+---
+
+## Add a bonus
+
+> **Note:** This runbook assumes the bonus token already exists on STRATO. If it's a bridged token, bridge onboarding happens separately and is not part of rewards operations. If the deployed Rewards contract doesn't yet support the boost model, run [Upgrade the Rewards contract](#upgrade-the-rewards-contract) first.
+
+### 1. Edit `bonusTokenConfig.json`
+
+Add an entry to [`src/infra/config/bonusTokenConfig.json`](../src/infra/config/bonusTokenConfig.json) — see [README § Bonus token config](../README.md#bonus-token-config) for the schema and validation rules.
+
+```json
+{
+  "address": "<stratoTokenAddress>",
+  "maxMultiplier": 2,
+  "conversionRate": 0.3
+}
+```
+
+Address is 40-hex, no `0x`, lowercase.
+
+### 2. Register the direct-payout activity on-chain
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy (`REWARDS_CONTRACT_ADDRESS`)
+> - **Function:** `addOneTimeDirectPayoutActivity(string name, address sourceContract, string eventName)`
+> - **Args:**
+>   - `name`: human-readable label, e.g. `"<Token> Bonus"`
+>   - `sourceContract`: the bonus token's STRATO address (matches `address` in step 1)
+>   - `eventName`: the synthetic bonus event label, e.g. `"Bonus"`
+
+Admin UI → Vote On Issues → Create New Issue → select `addOneTimeDirectPayoutActivity`, fill args, approve.
+
+Direct-payout activities have emission = 0 and skip the idempotency check, so the poller can post credits with sentinel `blockNumber = 1, eventIndex = 1`. The `eventName` is looked up per-token by `directPayout.resolver.ts` from the on-chain activity definition — as long as the registration lands, the poller picks it up.
+
+> **Warning:** Only **one** direct-payout activity is allowed per `sourceContract`. `directPayout.resolver.ts` throws if it finds more than one.
+
+### 3. Activate the token
+
+Admin UI → Token Status:
+
+- **Status:** `ACTIVE`
+- **Status Code:** `2`
+
+### 4. Redeploy the poller
+
+`runtimeConfig.ts` reads `bonusTokenConfig.json` once at startup — the service must be restarted to pick up the new entry.
+
+### 5. Verify
+
+- Next bonus cycle (per `BONUS_CRON_SCHEDULE`) should log:
+  - `CirrusService Loaded N current bonus balances from M bonus tokens` (M should include the new token)
+  - `BonusUtils Calculated bonus credits for X/Y users`
+  - `RewardsBonusPolling Applied X/Y bonus credits`
+- `lastBonusRun.json` should grow a `balanceSnapshots[<newTokenKey>]` section.
+- Confirm `batchHandleAction` transactions succeed on STRATO (no Failure status).
+
+> **Note:** If you see `BonusUtils Skipped N users because bonus token direct payout is not initialized`, step 2 didn't land — re-check the vote.
+
+---
+
+## Remove a bonus
+
+### 1. Drain pending credits first
+
+Inspect `lastBonusRun.json` for a `pendingCredits[]` entry referencing the token (match on `sourceContract`). If any exist, they were computed in a prior cycle but failed to post and are still being retried. Either:
+
+- Wait for the next successful bonus cycle to drain them, or
+- Manually edit `lastBonusRun.json` to remove those entries if you explicitly want to forfeit them.
+
+> **Warning:** Skipping this step will cause the service to keep re-submitting credits for the removed token until the direct-payout activity is also disabled on-chain (step 3).
+
+### 2. Remove the config entry
+
+Delete the object from [`src/infra/config/bonusTokenConfig.json`](../src/infra/config/bonusTokenConfig.json) and redeploy. On the next successful bonus cycle, the service writes a new state that no longer contains `balanceSnapshots[<tokenKey>]` — the rolling snapshot history for that token is discarded.
+
+### 3. (Optional) Disable the on-chain activity
+
+> **Admin on-chain call**
+>
+> - **Contract:** Rewards proxy (`REWARDS_CONTRACT_ADDRESS`)
+> - **Function:** `setEmissionRate(uint256 activityId, uint256 newEmissionRate)`
+> - **Args:** `activityId` = the direct-payout activity id for this bonus token; `newEmissionRate` = `0`.
+
+No-op for emission (direct-payout activities are already at 0), but it signals intent and makes admin history clear.
+
+### 4. Verify
+
+Bonus cycle logs should no longer reference the removed token, and `balanceSnapshots[<tokenKey>]` should disappear from `lastBonusRun.json` after the next successful cycle.
+
+---
+
+## Upgrade the Rewards contract
+
+Run this when the deployed Rewards proxy doesn't yet support the boost model and you need to onboard a bonus token (or pick up any other newer contract features).
+
+### 1. Check whether the upgrade is needed
+
+Any successful `addOneTimeDirectPayoutActivity` call on the current deployment is the machine-checkable signal that the boost model is already in place. If such a call has succeeded, skip this operation.
+
+### 2. Run the upgrade script
+
+```bash
+cd mercata/contracts
+npm install
+npm run upgrade -- \
+  --proxy-address <rewards-proxy-address> \
+  --contract-file BaseCodeCollection.sol \
+  --contract-name Rewards \
+  --constructor-args '{"initialOwner":"<ownerAddress>"}' \
+  +OVERRIDE-CHECKS
+```
+
+### 3. Verify
+
+After the upgrade, a test call to `addOneTimeDirectPayoutActivity` (Admin UI → Vote On Issues) should succeed. You can now proceed with [Add a bonus](#add-a-bonus).


### PR DESCRIPTION
`rewards-poller` service docs so both AI agents and humans can navigate the service without reading every source file. No code change