### PR TITLE
Update Rewards Overview

### DIFF
--- a/mercata/backend/package-lock.json
+++ b/mercata/backend/package-lock.json
@@ -383,6 +383,7 @@
       "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1041,6 +1042,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2427,6 +2429,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/mercata/backend/package-lock.json
+++ b/mercata/backend/package-lock.json
@@ -383,7 +383,6 @@
       "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1042,7 +1041,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2429,7 +2427,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -9,7 +9,6 @@ import {
   calculatePersonalEmissionRate,
   parseActivityType,
   fetchRewardsContractData,
-  fetchActivityIds,
   fetchActivities,
   fetchActivityStates,
   fetchUserInfo,
@@ -290,12 +289,16 @@ export const fetchRewardsOverview = async (
   try {
     // All these functions now use the same cached contract state, so they're fast
     // fetchAllUsersLeaderboard also uses cached contract state + cached claimed rewards
-    const [contractData, activityIds, activityStatesMap, allUsersLeaderboard] = await Promise.all([
+    const [contractData, activitiesMap, activityStatesMap, allUsersLeaderboard] = await Promise.all([
       fetchRewardsContractData(accessToken, rewardsAddress, forceRefresh),
-      fetchActivityIds(accessToken, rewardsAddress, forceRefresh),
+      fetchActivities(accessToken, rewardsAddress, forceRefresh),
       fetchActivityStates(accessToken, rewardsAddress, forceRefresh),
       fetchAllUsersLeaderboard(accessToken, rewardsAddress, forceRefresh)
     ]);
+
+    // Count only actively-emitting activities (matches UI visibility filter)
+    const activeActivityCount = Array.from(activitiesMap.values())
+      .filter((a) => BigInt(a.emissionRate || "0") > 0n).length;
 
     // Hardcoded season info for now
     const currentSeason = 2;
@@ -337,7 +340,7 @@ export const fetchRewardsOverview = async (
       rewardTokenSymbol,
       totalRewardsEmission: contractData.totalRewardsEmission,
       lastBlockHandled: contractData.highestBlockSeen,
-      activityCount: activityIds.length,
+      activityCount: activeActivityCount,
       totalStake: totalStake.toString(),
       totalDistributed: totalDistributed.toString(),
       currentSeason

--- a/mercata/ui/src/components/rewards/RewardsOverview.tsx
+++ b/mercata/ui/src/components/rewards/RewardsOverview.tsx
@@ -7,19 +7,13 @@ import CopyButton from "@/components/ui/copy";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useState } from "react";
+import { truncateAddress } from "@/utils/numberUtils";
 
 interface RewardsOverviewProps {
   state: RewardsState | null;
   loading: boolean;
   onRefresh?: () => void;
 }
-
-
-const truncateTokenAddress = (address: string, front: number = 6, back: number = 4) => {
-  if (!address) return "";
-  if (address.length <= front + back) return address;
-  return `${address.substring(0, front)}...${address.substring(address.length - back)}`;
-};
 
 export const RewardsOverview = ({ state, loading, onRefresh }: RewardsOverviewProps) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -164,7 +158,7 @@ export const RewardsOverview = ({ state, loading, onRefresh }: RewardsOverviewPr
               {state.rewardToken && (
                 <div className="flex items-center gap-1 mt-1">
                   <p className="text-sm font-semibold font-mono">
-                    {truncateTokenAddress(state.rewardToken)}
+                    {truncateAddress(state.rewardToken)}
                   </p>
                   <CopyButton address={state.rewardToken} />
                 </div>

--- a/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
+++ b/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
@@ -289,7 +289,7 @@ export const UserRewardsSummary = ({
 
       <Card>
         <CardHeader className="px-4 md:px-6 pb-2 md:pb-3">
-          <CardTitle className="text-sm md:text-base">Rewards Overview</CardTitle>
+          <CardTitle className="text-sm md:text-base">Global Rewards Overview</CardTitle>
           <CardDescription className="text-xs">Global rewards statistics</CardDescription>
         </CardHeader>
         <CardContent className="px-4 md:px-6">

--- a/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
+++ b/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
@@ -9,10 +9,9 @@ import {
   calculateRealTimePendingRewards,
   roundByMagnitude,
   formatRoundedWithCommas,
-  formatEmissionRatePerDay,
 } from "@/services/rewardsService";
 import { formatBalance } from "@/utils/numberUtils";
-import { Loader2, Coins, Star, Gift, Info, Zap, Clock } from "lucide-react";
+import { Loader2, Coins, Star, Gift, Info, Activity } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { useUser } from "@/context/UserContext";
@@ -203,20 +202,11 @@ export const UserRewardsSummary = ({
   )) + " points";
 
   // Overview stats (global)
-  const totalRewardsEmissionStr = rewardsState?.totalRewardsEmission ? String(rewardsState.totalRewardsEmission) : null;
-  const totalRewardsEmissionBig = totalRewardsEmissionStr ? safeBigInt(totalRewardsEmissionStr) : null;
-  const hasValidEmission = totalRewardsEmissionBig !== null && totalRewardsEmissionBig > 0n;
-  const emissionPerDay = hasValidEmission && totalRewardsEmissionStr
-    ? formatEmissionRatePerDay(totalRewardsEmissionStr)
-    : "?";
   const totalDistributedFormatted = rewardsState?.totalDistributed
     ? formatRoundedWithCommas(roundByMagnitude(String(parseFloat(rewardsState.totalDistributed) / 1e18)))
     : "0";
-  const lastBlock = rewardsState?.lastBlockHandled && rewardsState.lastBlockHandled !== "0"
-    ? `Block ${rewardsState.lastBlockHandled}`
-    : "?";
   const activityCountLabel = rewardsState?.activityCount !== undefined && rewardsState?.activityCount !== null && rewardsState.activityCount >= 0
-    ? `${rewardsState.activityCount} ${rewardsState.activityCount === 1 ? "activity" : "activities"}`
+    ? String(rewardsState.activityCount)
     : "?";
 
   return (
@@ -290,7 +280,7 @@ export const UserRewardsSummary = ({
       <Card>
         <CardHeader className="px-4 md:px-6 pb-2 md:pb-3">
           <CardTitle className="text-sm md:text-base">Global Rewards Overview</CardTitle>
-          <CardDescription className="text-xs">Global rewards statistics</CardDescription>
+          <CardDescription className="text-xs">Rewards statistics over all users</CardDescription>
         </CardHeader>
         <CardContent className="px-4 md:px-6">
           {rewardsStateLoading ? (
@@ -302,24 +292,14 @@ export const UserRewardsSummary = ({
           ) : (
             <div className="space-y-2 text-xs md:text-sm">
               <div className="flex items-center gap-2">
-                <Zap className="h-3.5 w-3.5 text-blue-500 shrink-0" />
-                <span className="text-muted-foreground">Emission:</span>
-                <span className="font-semibold truncate">
-                  {emissionPerDay}{emissionPerDay !== "?" ? " pts/day" : ""}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
                 <Star className="h-3.5 w-3.5 text-amber-500 shrink-0" />
                 <span className="text-muted-foreground">Total Earned:</span>
                 <span className="font-semibold truncate">{totalDistributedFormatted}</span>
               </div>
               <div className="flex items-center gap-2">
-                <Clock className="h-3.5 w-3.5 text-purple-500 shrink-0" />
-                <span className="text-muted-foreground">Last Update:</span>
-                <span className="font-semibold truncate">{lastBlock}</span>
-              </div>
-              <div className="text-xs text-muted-foreground pl-5.5">
-                {activityCountLabel}
+                <Activity className="h-3.5 w-3.5 text-blue-500 shrink-0" />
+                <span className="text-muted-foreground">Activities:</span>
+                <span className="font-semibold truncate">{activityCountLabel}</span>
               </div>
             </div>
           )}

--- a/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
+++ b/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
@@ -10,13 +10,14 @@ import {
   roundByMagnitude,
   formatRoundedWithCommas,
 } from "@/services/rewardsService";
-import { formatBalance } from "@/utils/numberUtils";
+import { formatBalance, truncateAddress } from "@/utils/numberUtils";
 import { Loader2, Coins, Star, Gift, Info, Activity } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { useUser } from "@/context/UserContext";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useMobileTooltip } from "@/hooks/use-mobile-tooltip";
+import CopyButton from "@/components/ui/copy";
 
 interface UserRewardsSummaryProps {
   userRewards: UserRewardsData | null;
@@ -300,6 +301,20 @@ export const UserRewardsSummary = ({
                 <Activity className="h-3.5 w-3.5 text-blue-500 shrink-0" />
                 <span className="text-muted-foreground">Activities:</span>
                 <span className="font-semibold truncate">{activityCountLabel}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Coins className="h-3.5 w-3.5 text-green-500 shrink-0" />
+                <span className="text-muted-foreground">Reward Token:</span>
+                {rewardsState?.rewardToken ? (
+                  <span className="flex items-center gap-1 min-w-0">
+                    <span className="font-semibold font-mono truncate">
+                      {truncateAddress(rewardsState.rewardToken)}
+                    </span>
+                    <CopyButton address={rewardsState.rewardToken} />
+                  </span>
+                ) : (
+                  <span className="font-semibold">?</span>
+                )}
               </div>
             </div>
           )}

--- a/mercata/ui/src/utils/numberUtils.ts
+++ b/mercata/ui/src/utils/numberUtils.ts
@@ -23,6 +23,19 @@ export const ensureHexPrefix = (address: string | undefined | null): `0x${string
 };
 
 /**
+ * Shortens an address to "front…back" form (e.g. 0x1234…abcd).
+ */
+export const truncateAddress = (
+  address: string | undefined | null,
+  front: number = 6,
+  back: number = 4
+): string => {
+  if (!address) return "";
+  if (address.length <= front + back) return address;
+  return `${address.slice(0, front)}...${address.slice(-back)}`;
+};
+
+/**
  * Safely parses a string to BigInt using parseUnits, handling edge cases
  * that would normally cause parseUnits to throw an error.
  * 

--- a/mercata/ui/src/utils/numberUtils.ts
+++ b/mercata/ui/src/utils/numberUtils.ts
@@ -23,7 +23,7 @@ export const ensureHexPrefix = (address: string | undefined | null): `0x${string
 };
 
 /**
- * Shortens an address to "front…back" form (e.g. 0x1234…abcd).
+ * Shortens an address to "front…back" form (e.g. 0x123456…abcd).
  */
 export const truncateAddress = (
   address: string | undefined | null,


### PR DESCRIPTION
# Update Rewards Overview

Fixes #6891

- Include only active rewards activities (nonzero `emissionRate`) in count
- Remove Total Emission Rate and Block Number from logged in user's Global Rewards Overview (renamed from Rewards Overview for clarity)
- Show copyable Rewards Token address in logged in Global Rewards Overview, similar to logged out
- Implement shared util `truncateAddress` to show addresses in `0x123456...abcd` form; this should be applied in many places throughout the app, but for this PR's scope, it is applied only to the rewards UI.

Before:
<img width="3695" height="792" alt="image" src="https://github.com/user-attachments/assets/aad2f8f3-a78a-410a-81b1-9d6d6d6f13b8" />

After:
<img width="3695" height="792" alt="image" src="https://github.com/user-attachments/assets/905746a9-3e7a-4f87-8bfd-00106c98641d" />
