### PR TITLE
oracle: rewrite service docs (README, FLOW, OPERATIONS)

### DIFF
--- a/mercata/services/oracle/README.md
+++ b/mercata/services/oracle/README.md
@@ -1,81 +1,106 @@
 # Price Oracle Service
 
-Fetches asset prices from multiple sources and pushes them to the STRATO blockchain.
+The oracle is a long-running Node service. It fetches asset prices from multiple external providers (Alchemy, CoinGecko, CoinMarketCap, DefiLlama, CoinAPI, TwelveData, OANDA, Metals.dev, MetalsAPI, CommodityPriceAPI), aggregates each asset's price by median (minimum 3 valid sources), and pushes the result to the `PriceOracle` contract on STRATO. Three write methods are used: `setAssetPrices`, `setRebaseFactors`, and `setExchangeRates`.
 
-## Features
+- **How it works end-to-end** -> [docs/FLOW.md](docs/FLOW.md)
+- **Runbooks -- add/remove an asset, add/remove a source** -> [docs/OPERATIONS.md](docs/OPERATIONS.md)
 
-- **Median Aggregation**: Robust price calculation using median of all valid sources
-- **Minimum Source Requirement**: Requires at least 3 valid sources to submit a price
-- **Batch Updates**: Multiple assets updated in single transaction
-- **Configurable Interval**: Update schedule via `CRON_SCHEDULE` cron pattern (e.g., '0 */15 * * * *' for :00, :15, :30, :45 or '30 7,22,37,52 * * * *' for :07:30, :22:30, :37:30, :52:30)
-- **Parallel Processing**: All feeds run simultaneously
-- **Automatic Retry**: All API calls retry twice on failure
-- **Health Monitoring**: Service marks itself unhealthy on persistent failures
-- **Balance Checks**: Validates USDST balance before transactions
-- **Transaction Metrics**: Records transaction timing data to AWS CloudWatch (optional)
-- **Weekend Fallback**: Metals weekend feed falls back to metals-batch prices when insufficient sources
+---
 
-## Environment Variables
+## Source map
 
-```env
-# STRATO Configuration
-STRATO_NODE_URL=https://node1.mercata-testnet.blockapps.net/
-PRICE_ORACLE_ADDRESS=0000000000000000000000000000000000001002
-
-# OAuth Configuration
-OAUTH_CLIENT_ID=your-client-id
-OAUTH_CLIENT_SECRET=your-client-secret
-OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid_configuration
-
-# API Keys
-ALCHEMY_API_KEY=your-alchemy-key
-COINMARKETCAP_API_KEY=your-coinmarketcap-key
-COINGECKO_API_KEY=your-coingecko-api-key
-METALS_DEV_API_KEY=your-metals-dev-key
-METALS_API_API_KEY=your-metals-api-key
-COMMODITIES_API_KEY=your-commodities-api-key
-COMMODITY_PRICE_API_KEY=your-commodity-price-api-key
-COINAPI_API_KEY=your-coinapi-api-key
-DEFILLAMA_API_KEY=your-defillama-api-key  # Pro/API plan: https://defillama.com/subscription
-TWELVEDATA_API_KEY=your-twelvedata-key
-OANDA_API_KEY=your-oanda-api-key
-OANDA_ACCOUNT_ID=your-oanda-account-id  # Fetch via: curl -H "Authorization: Bearer API_KEY" https://api-fxpractice.oanda.com/v3/accounts
-
-# Oracle Configuration
-CRON_SCHEDULE="0 */15 * * * *"
-
-# Token Configuration (Optional)
-USDST_ADDRESS=86a5ae535ded415203c3e27d654f9a1d454c553b  # USDST contract address
-GAS_FEE_USDST=1  # Gas fee in USDST (0.01 = 1, default: 1)
-
-# AWS Configuration (for CloudWatch Metrics - Optional)
-# Leave CLOUDWATCH_NAMESPACE empty to disable metrics
-AWS_REGION=us-east-1
-CLOUDWATCH_NAMESPACE=Testnet/Oracle/Transactions
+```text
+src/
+├── index.ts                          Express /health, startup, calls startCronScheduler()
+├── cronScheduler.ts                  Main orchestrator: processAllAssets(), cron, median, aggregation
+├── adapters/
+│   └── genericRestAdapter.ts         Universal REST adapter driven by sources.json; also fetchRebaseFactor, fetchExchangeRate, generateConstantPrices
+├── config/
+│   ├── assets.json                   What to price: targetAssetAddress, constantPrice, weekendProxy, equivalentAssets, rebase, exchangeRate, submit
+│   └── sources.json                  Where to fetch: url, params, parse, headers, apiKeyEnvVar, symbolMapping, assets
+├── types/
+│   └── index.ts                      Asset, SourceConfig, RebaseConfig, ExchangeRateConfig, AggregatedPrice, CallListArg, etc.
+└── utils/
+    ├── oraclePusher.ts               pushAssetPrices, pushRebaseFactors, pushExchangeRates + callListAndWait + waitForTransaction
+    ├── priceReader.ts                Fetches previous on-chain prices from Cirrus for change detection
+    ├── balanceChecker.ts             Pre-flight USDST + Voucher balance check; exits on critically low balance
+    ├── configLoader.ts               Loads assets.json + sources.json, resolves API keys from env
+    ├── validateConfig.ts             Startup validation: env vars, OAuth, asset/source cross-refs, MIN_VALID_SOURCES
+    ├── oauth.ts                      STRATO OpenID auth (token + user address)
+    ├── apiClient.ts                  Axios wrapper with retry (withRetry) and withTimeout
+    ├── healthMonitor.ts              Error/warning flag files for /health
+    ├── logger.ts                     Structured console logging with secret redaction + Slack forwarding
+    ├── slackNotifier.ts              Sends warnings/errors to Slack (optional, needs SLACK_BOT_TOKEN)
+    ├── txMetricsService.ts           CloudWatch transaction metrics (optional, needs CLOUDWATCH_NAMESPACE)
+    └── constants.ts                  ORACLE_CONFIG, TIMEOUTS, GAS_PARAMS, RETRY_DELAYS, CONSTANTS (balance thresholds)
 ```
 
-## Development
+---
+
+## Configuration
+
+### Required environment variables
+
+| Variable | Purpose |
+| - | - |
+| `STRATO_NODE_URL` | STRATO node base URL |
+| `PRICE_ORACLE_ADDRESS` | PriceOracle contract address (no `0x` prefix) |
+| `USERNAME`, `PASSWORD` | BlockApps credentials |
+| `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` | OAuth client credentials |
+| `OAUTH_DISCOVERY_URL` | OpenID discovery endpoint |
+| `ALCHEMY_API_KEY` | Alchemy (prices + exchange-rate/rebase `eth_call`) |
+| `COINMARKETCAP_API_KEY` | CoinMarketCap |
+| `COINGECKO_API_KEY` | CoinGecko Pro |
+| `METALS_DEV_API_KEY` | Metals.dev |
+| `METALS_API_API_KEY` | MetalsAPI |
+| `COMMODITY_PRICE_API_KEY` | CommodityPriceAPI |
+| `COINAPI_API_KEY` | CoinAPI |
+| `DEFILLAMA_API_KEY` | DefiLlama Pro |
+| `TWELVEDATA_API_KEY` | TwelveData |
+| `OANDA_API_KEY`, `OANDA_ACCOUNT_ID` | OANDA |
+
+### Optional environment variables
+
+| Variable | Default | Purpose |
+| - | - | - |
+| `HEALTH_PORT` | `3000` | Express port for `/health` |
+| `CRON_SCHEDULE` | `0 */15 * * * *` (every 15 min) | 6-field cron (includes seconds) |
+| `USDST_ADDRESS` | `937efa7e3a77e20bbdbd7c0d32b6514f368c1010` | USDST token for balance check |
+| `VOUCHER_ADDRESS` | `000000000000000000000000000000000000100e` | Voucher token for balance check |
+| `GAS_FEE_USDST` | `1` (= 0.01 USDST) | Gas estimate per tx, multiplied by 1e16 |
+| `GAS_FEE_VOUCHER` | `100` (= 1 Voucher) | Gas estimate per tx, multiplied by 1e16 |
+| `MIN_TRANSACTIONS_THRESHOLD` | `100` | Mark unhealthy if estimated txs remaining <= this |
+| `SLACK_BOT_TOKEN` | _(disabled)_ | Slack bot token for warning/error notifications |
+| `SLACK_WARNING_CHANNEL` | `#ops-monitoring` | Slack channel |
+| `ORACLE_NAME` | `Dev Oracle` | Identifier in Slack messages |
+| `AWS_REGION` | `us-east-1` | CloudWatch region |
+| `CLOUDWATCH_NAMESPACE` | _(disabled)_ | Set to enable tx metrics (e.g. `Testnet/Oracle/Transactions`) |
+
+### Config JSON files
+
+- [`src/config/assets.json`](src/config/assets.json) -- one entry per asset. See [FLOW.md](docs/FLOW.md) for the full schema. Current categories: crypto (ETH, WBTC), stablecoins (USDC, USDT, USDST), precious metals (XAU, XAG), gold-backed tokens (PAXG, XAUT), yield-bearing (RETH, WSTETH, SUSDS, SYRUPUSDC, WEETH), Aave aTokens (AWETH, AWBTC, AWEETH, AWSTETH, AUSDC, AUSDT), xStock wrappers (WSPYX, WTSLAX), and proxy-only feeds (KAG, SPYX, TSLAX, WEETH).
+- [`src/config/sources.json`](src/config/sources.json) -- one entry per external price provider. Each entry declares the URL, parse path, API-key env var, and which assets it covers. See [OPERATIONS.md -- Add a source](docs/OPERATIONS.md#add-a-source).
+
+---
+
+## Running
 
 ```bash
 npm install
 npm run build
-npm run dev
+npm run dev     # development
+npm start       # production
 ```
 
-## Health Check
+The service runs one cycle immediately on startup, then schedules `CRON_SCHEDULE`.
 
-```bash
-curl http://localhost:3000/health
+## Health check
+
+```
+GET /health
 ```
 
-**Response:**
-- **200 OK**: Service is healthy
-- **503 Service Unavailable**: Service is unhealthy (after retry failure)
+- **200** -- healthy (no `oracle-error.flag` file).
+- **500** -- unhealthy (`oracle-error.flag` exists and is non-empty).
 
-## Health Monitoring
-
-The service automatically marks itself as unhealthy when:
-- Any API source fails twice in a row
-- Transaction submission fails twice in a row  
-- USDST balance check fails twice in a row
-- USDST balance is below minimum threshold (10 USDST) 
+The flag file is appended to by `logError()` (every error call writes to it). To recover, fix the underlying issue, delete the flag, and restart.

--- a/mercata/services/oracle/docs/FLOW.md
+++ b/mercata/services/oracle/docs/FLOW.md
@@ -1,0 +1,301 @@
+# Price Oracle -- How it works
+
+This document walks through one full price cycle from cron trigger to on-chain write.
+
+---
+
+## Entry point
+
+[`index.ts`](../src/index.ts) is the entry point. On boot the service:
+
+1. `dotenv.config()` at module level.
+2. Express `/health` starts listening on `HEALTH_PORT` (default `3000`) — also at module level, **before** `main()` is called. The health endpoint is reachable before validation completes.
+3. `main()` runs:
+   1. `validateConfig()` — validates required env vars, OAuth credentials, `assets.json` / `sources.json` structure and cross-references (minimum sources per asset, constant-price wiring, rebase underlying references, weekend-proxy source counts). Exits on failure.
+   2. `startCronScheduler()` in [`cronScheduler.ts`](../src/cronScheduler.ts) — creates a `ConfigLoader`, schedules a `node-cron` job on `CRON_SCHEDULE`, and fires one immediate run via `setTimeout(job, 1000)`.
+
+---
+
+## The cycle (`processAllAssets`)
+
+Each cron tick runs `processAllAssets(configLoader)`. Steps:
+
+### 1. OAuth pre-warm
+
+```
+oauthClient().validateToken()
+```
+
+Warms the token cache before the parallel fan-out so all downstream calls share the same token.
+
+### 2. Parallel pre-flight
+
+Two calls in parallel:
+
+| Call | What it does |
+|:--|:--|
+| `checkBalances()` | Fetches the service account's Voucher + USDST balances from Cirrus (`BlockApps-Voucher-_balances`, `BlockApps-Token-_balances`). Estimates how many transactions the balance supports. Calls `logError` (which marks unhealthy) if below `MIN_TRANSACTIONS_THRESHOLD`. Calls `process.exit(1)` if fewer than 1 transaction is possible. |
+| `fetchPreviousPrices()` | Reads the current on-chain price map from Cirrus (`BlockApps-PriceOracle-prices` table, `key` = asset address, `value` = price). Returns `Map<address, price>` for later change-detection alerts. Returns empty map on failure (non-blocking). |
+
+### 3. Market status
+
+```
+const marketClosed = isMetalsMarketClosed();
+```
+
+Checks whether precious-metals markets are closed based on New York (ET) time:
+
+- **Closed**: Friday noon ET through Monday 5:30 AM ET (inclusive of Saturday and Sunday).
+- **Open**: all other times.
+
+Used by aggregation (step 4) to decide whether to use weekend proxy feeds for metals.
+
+### 4. Fetch from all sources
+
+```
+fetchFromAllSources(configLoader) -> Map<sourceName, SourceResult>
+```
+
+Iterates every entry in `sources.json`. For each source:
+
+- Calls `fetchPrices(sourceConfig)` from [`genericRestAdapter.ts`](../src/adapters/genericRestAdapter.ts) with a `withTimeout(TIMEOUTS.FETCH)` wrapper (default 30 s).
+- Special case: the `constant` source calls `generateConstantPrices()` which returns the `constantPrice` value from `assets.json` for each asset it covers (e.g. USDST = 1e18).
+- If a source fails (timeout, HTTP error, parse error), it is logged as a warning and dropped -- it does **not** abort the cycle.
+- All sources run in parallel via `Promise.all`.
+
+Returns a map of `sourceName -> { prices: { [assetKey]: { price, feedTimestamp } }, success, duration }`.
+
+### 5. Aggregate prices
+
+```
+aggregatePrices(configLoader, sourceResults, marketClosed, previousPrices) -> AggregatedPrice[]
+```
+
+Per asset (excluding `rebase` assets, which are handled in step 7):
+
+1. **Required source count**: `constantPrice` assets need only 1; everything else needs `ORACLE_CONFIG.MIN_VALID_SOURCES` (currently **3**).
+
+2. **Weekend proxy logic**: if the asset has `weekendProxy` and `marketClosed === true`:
+   - First, try collecting sources for the proxy symbol (e.g. `PAXG` for `XAU`).
+   - If enough proxy sources exist, use them. Otherwise, fall back to the asset's own weekday sources.
+
+3. **Collect prices**: for each source that covers this asset, pull the price from the source result map.
+
+4. **Validate**: if collected sources < required, the asset is marked `failed` with an error message and an `logError` call. It will not be submitted.
+
+5. **Median**: `calculateMedian()` sorts the source prices and picks the middle value. For even-length arrays, it takes `floor((a + b) / 2)` -- integer arithmetic, no rounding up. All prices are in 1e18 (wei) scale.
+
+6. **Divergence alert**: if the max-min spread among sources exceeds `MAX_SOURCE_DIVERGENCE_PERCENT` (5%), a warning is logged. The price is still submitted.
+
+7. **Price-change alert**: if the new median differs from the previous on-chain price by more than `MAX_PRICE_CHANGE_PERCENT` (20%), a warning is logged. The price is still submitted.
+
+> Both alerts are advisory-only -- they fire `logWarning` (which also forwards to Slack if configured) but do **not** block submission.
+
+### 6. Equivalent asset prices
+
+```
+addEquivalentAssetPrices(prices, configLoader) -> AggregatedPrice[]
+```
+
+If an asset has `equivalentAssets` in its config (e.g. `XAU` lists `["XAUT"]`), this function:
+
+1. Finds the equivalent asset's already-aggregated median.
+2. Adds it as one additional synthetic source (named `"XAUT(equiv)"`).
+3. Recalculates the median with the extra source.
+4. If the asset was previously `failed` (insufficient sources) and now has >= `MIN_VALID_SOURCES`, it is un-failed.
+
+This rescues assets that have too few direct feeds by borrowing prices from equivalent assets.
+
+### 7. Rebase factors
+
+```
+applyRebaseFactors(prices, configLoader, previousPrices) -> RebaseFactorEntry[]
+```
+
+Only for assets with a `rebase` config block (e.g. AWETH, AWBTC, AWEETH, AWSTETH, AUSDC, AUSDT, WSPYX, WTSLAX). For each:
+
+1. Look up the underlying asset's aggregated median from step 5 (e.g. ETH for AWETH, WBTC for AWBTC).
+2. Fetch the raw rebase factor via `fetchRebaseFactor()` -- typically an `eth_call` to Aave's `getReserveNormalizedIncome()` or xStock's `getCurrentMultiplier()`, routed through Alchemy.
+3. Normalize to WAD: `wadFactor = rawFactor * 1e18 / factorPrecision` (precision is `1e27` for Aave RAY, `1e18` for xStock WAD).
+4. Compute rebased price: `rebasedPrice = underlyingMedian * rawFactor / factorPrecision`.
+5. Push the rebased price back into the `prices` array as a normal `AggregatedPrice` (1 source, the synthetic `"ETH×rebaseFactor(...)"` source).
+6. Collect `{ targetAddress, wadFactor }` for on-chain submission.
+7. Run price-change alert against previous on-chain price.
+
+### 8. Exchange rates
+
+```
+collectExchangeRates(configLoader) -> ExchangeRateEntry[]
+```
+
+For assets with an `exchangeRate` config block (RETH, SUSDS, SYRUPUSDC, WSTETH, WEETH, and all Aave aTokens). For each:
+
+1. `fetchExchangeRate()` issues an `eth_call` via Alchemy (e.g. `rETH.getExchangeRate()`, `wstETH.stEthPerToken()`, `sUSDS.convertToAssets(1e18)`).
+2. Normalize: `wadRate = rawRate * 1e18 / ratePrecision`. `ratePrecision` is `1e18` for most, `1e6` for syrupUSDC, `1e27` for Aave RAY.
+3. Collect `{ targetAddress, wadRate }` for on-chain submission.
+
+> Exchange rates and rebase factors are fetched in parallel via `Promise.all([applyRebaseFactors(...), collectExchangeRates(...)])`.
+
+### 9. Partition and submit
+
+1. Partition `prices` into `validPrices` (no `failed` flag) and `failedPrices`. Assets with `submit: false` (proxy-only feeds like KAG, SPYX, TSLAX, WEETH) are excluded from both.
+2. If `validPrices` is empty, throw `'No valid prices to submit'` -- the cycle aborts.
+3. Push in parallel:
+
+| Push | Contract method | Data |
+|:--|:--|:--|
+| `pushAssetPrices(validPrices)` | `PriceOracle.setAssetPrices(address[], uint256[])` | `[targetAddress, ...]`, `[medianPrice, ...]` |
+| `pushRebaseFactors(factors)` | `PriceOracle.setRebaseFactors(address[], uint256[])` | `[targetAddress, ...]`, `[wadFactor, ...]` |
+| `pushExchangeRates(rates)` | `PriceOracle.setExchangeRates(address[], uint256[])` | `[targetAddress, ...]`, `[wadRate, ...]` |
+
+4. Log each asset's feed details via `logFeedUpdate()` (including failed ones, for visibility).
+
+---
+
+## Anatomy of a write
+
+All three push functions go through the same path: `callListAndWait()` in [`oraclePusher.ts`](../src/utils/oraclePusher.ts).
+
+### Stage 1 -- Build `CallListArg[]`
+
+```ts
+{
+  contract: { address: PRICE_ORACLE_ADDRESS, name: "PriceOracle" },
+  method: "setAssetPrices",  // or setRebaseFactors, setExchangeRates
+  args: {
+    assets:      [...targetAddresses],
+    priceValues: [...medianPrices],   // or factors / rates
+  },
+}
+```
+
+### Stage 2 -- Build transaction payload
+
+```ts
+{
+  txs: [{ type: "FUNCTION", payload: { contractName, contractAddress, method, args } }],
+  txParams: { gasLimit: 32_100_000_000, gasPrice: 10 },
+}
+```
+
+### Stage 3 -- Submit
+
+POST to `${STRATO_NODE_URL}/bloc/v2.2/transaction/parallel?resolve=true` with Bearer token.
+
+Timeout: `TIMEOUTS.SUBMIT` (20 s).
+
+### Stage 4 -- Evaluate immediate result
+
+The `resolve=true` flag asks STRATO to try returning the result inline. Three outcomes:
+
+| Inline status | Action |
+|:--|:--|
+| `Success` | Return immediately with hash. |
+| `Failed` / `Failure` | Throw with the contract error message. |
+| `Pending` or absent | Fall through to polling. |
+
+### Stage 5 -- Poll for result (if pending)
+
+POST `[txHash]` to `${STRATO_NODE_URL}/bloc/v2.2/transactions/results`. Retries every `RETRY_DELAYS.STATUS` (2 s) up to `TIMEOUTS.WAIT` (180 s). On `Success`, return. On `Failed`/`Failure`, throw. On timeout, throw.
+
+### Stage 6 -- Record metrics
+
+If `CLOUDWATCH_NAMESPACE` is set, `txMetricsService.recordTxMetric()` pushes `{ txHash, duration, status }` to CloudWatch.
+
+---
+
+## Error handling
+
+| Error kind | Behavior |
+|:--|:--|
+| **Single source fetch failure** | Logged as warning (`logWarning`); source dropped for this cycle. Other sources proceed. If an asset falls below `MIN_VALID_SOURCES`, that asset is marked `failed` and excluded from submission -- all other assets still submit. |
+| **Rebase factor fetch failure** | Logged as error; that rebased asset is skipped. Others proceed. |
+| **Exchange rate fetch failure** | Logged as error; that rate is skipped. Others proceed. |
+| **No valid prices** | `throw new Error('No valid prices to submit')` -- cycle aborts, caught at the top of `job` in `startCronScheduler`, logged as error. Next cron tick retries. |
+| **Transaction failure** | Thrown from `callListAndWait` → `waitForTransaction`. Caught at `job` level, logged as error. Next cron tick retries. |
+| **Transaction timeout** (> 180 s) | Same as transaction failure. |
+| **Balance below threshold** | `logError` marks unhealthy via error flag file. If < 1 tx possible, `process.exit(1)`. |
+| **OAuth failure** | Thrown from `validateToken()`, caught at `main()`, `process.exit(1)`. |
+
+### Health file mechanics
+
+- `logError()` appends to `oracle-error.flag` (via [`healthMonitor.ts`](../src/utils/healthMonitor.ts)). The `/health` endpoint returns 500 if this file exists and is non-empty.
+- `logWarning()` appends to `oracle-warning.log` (informational; does not affect `/health`).
+- Both `logWarning` and `logError` forward to Slack (if `SLACK_BOT_TOKEN` is set) with contextual emoji.
+
+---
+
+## What lives on-chain vs in this service
+
+| Concern | Location |
+|:--|:--|
+| Per-asset price + timestamp | `PriceOracle` contract (`setAssetPrices`) |
+| Rebase factors | `PriceOracle` contract (`setRebaseFactors`) |
+| Exchange rates | `PriceOracle` contract (`setExchangeRates`) |
+| What assets to price | `src/config/assets.json` |
+| Where to fetch prices | `src/config/sources.json` |
+| API keys, credentials, schedule | Environment variables |
+| How to parse each source's response | `genericRestAdapter.ts` + `sources.json` parse patterns |
+
+---
+
+## `assets.json` schema reference
+
+Each key in the `"assets"` object is the asset symbol (e.g. `"ETH"`). The value is:
+
+| Field | Type | Required | Purpose |
+|:--|:--|:--|:--|
+| `targetAssetAddress` | `string` (40 hex) | yes | On-chain address the PriceOracle stores the price under |
+| `constantPrice` | `number` | no | Hardcoded price in 1e18 scale (e.g. USDST = `1000000000000000000`). Source count required drops to 1. |
+| `weekendProxy` | `string` | no | Proxy asset symbol to fetch during metals market closure (e.g. `"PAXG"` for XAU) |
+| `equivalentAssets` | `string[]` | no | Asset keys whose aggregated median can be borrowed as an extra source (e.g. `["XAUT"]` for XAU) |
+| `submit` | `boolean` | no | `false` to exclude from on-chain submission. Used for proxy-only feeds (KAG, SPYX, TSLAX, WEETH). Default `true`. |
+| `rebase` | `RebaseConfig` | no | See below |
+| `exchangeRate` | `ExchangeRateConfig` | no | See below |
+
+### `RebaseConfig`
+
+Used for rebasing tokens (aTokens, xStock wrappers). Price = `underlying.median * factor / precision`.
+
+| Field | Purpose |
+|:--|:--|
+| `underlyingAsset` | Asset key in `assets.json` whose price is the base (e.g. `"ETH"` for AWETH) |
+| `factorUrl` | REST/RPC endpoint (supports `${STRATO_NODE_URL}`, `${API_KEY}` substitution) |
+| `factorMethod` | HTTP method (default `GET`; use `POST` for JSON-RPC `eth_call`) |
+| `factorBody` | JSON body template for POST requests |
+| `factorParse` | JSON path to extract the raw factor (e.g. `"result"` for `eth_call` hex response) |
+| `factorPrecision` | Divisor for the raw factor (`1e27` for Aave RAY, `1e18` for WAD) |
+| `factorApiKeyEnvVar` | Env var holding the API key |
+| `factorHeaders` | Optional. Comma-separated header names that receive the API key |
+
+### `ExchangeRateConfig`
+
+Used for yield-bearing tokens (rETH, wstETH, sUSDS, syrupUSDC, weETH, aTokens).
+
+| Field | Purpose |
+|:--|:--|
+| `rateUrl` | REST/RPC endpoint |
+| `rateMethod` | HTTP method |
+| `rateBody` | JSON body template |
+| `rateParse` | JSON path to extract the raw rate |
+| `ratePrecision` | Native precision (`1e18` for WAD, `1e6` for 6-decimal, `1e27` for RAY) |
+| `rateApiKeyEnvVar` | Env var holding the API key |
+| `rateHeaders` | Optional. Comma-separated header names that receive the API key |
+
+---
+
+## `sources.json` schema reference
+
+Each key is the source name (e.g. `"CoinGecko"`). The value is:
+
+| Field | Type | Required | Purpose |
+|:--|:--|:--|:--|
+| `url` | `string` | yes (except `constant`) | Fetch URL. Supports `${API_KEY}`, `${ACCOUNT_ID}`, `${SYMBOLS}` substitution. |
+| `params` | `string` | no | Comma-separated URL query parameters |
+| `headers` | `string` | no | Comma-separated header names that receive the API key |
+| `parse` | `string` | yes | JSON path pattern for extracting prices from the response |
+| `timestamp` | `string` | no | JSON path for extracting the feed timestamp |
+| `apiKeyEnvVar` | `string` | no | Env var name for the API key |
+| `accountIdEnvVar` | `string` | no | Env var name for account ID (OANDA) |
+| `symbolMapping` | `Record<string, string>` | no | Maps asset keys to API-specific identifiers |
+| `assets` | `string[]` | yes | Which asset keys this source covers |

--- a/mercata/services/oracle/docs/OPERATIONS.md
+++ b/mercata/services/oracle/docs/OPERATIONS.md
@@ -1,0 +1,290 @@
+# Price Oracle -- Operations Runbook
+
+Step-by-step procedures for adding and removing assets and price sources. Use this when onboarding a new token or a new price provider.
+
+- For **how the service works** -> [FLOW.md](FLOW.md)
+- For **config and deployment** -> [README](../README.md)
+
+---
+
+## Contents
+
+- [Add an asset](#add-an-asset)
+  - [Plain asset](#plain-asset)
+  - [Constant-price asset](#constant-price-asset)
+  - [Yield-bearing token (exchangeRate)](#yield-bearing-token-exchangerate)
+  - [Rebasing token](#rebasing-token)
+- [Remove an asset](#remove-an-asset)
+- [Add a source](#add-a-source)
+- [Remove a source](#remove-a-source)
+
+---
+
+> **Note:** The source of truth for what is priced lives in two JSON config files: [`assets.json`](../src/config/assets.json) (what to price) and [`sources.json`](../src/config/sources.json) (where to fetch). Both are read once at startup by `ConfigLoader`. Changes require a redeploy.
+
+---
+
+## Add an asset
+
+### Plain asset
+
+Use for a standard token with market-price feeds from external providers (e.g. ETH, WBTC, PAXG).
+
+> **Important:** A plain asset needs at least **3** sources (`MIN_VALID_SOURCES`) wired up in `sources.json`. If fewer are configured, `validateConfig()` will **block startup** with an error. Add the sources in the same change as the asset.
+
+#### 1. Add to `assets.json`
+
+```json
+"NEWSYMBOL": {
+  "targetAssetAddress": "40-hex-address-no-0x-prefix"
+}
+```
+
+Optional fields:
+
+| Field | When to use |
+|:--|:--|
+| `weekendProxy` | Asset whose sources to use when metals market is closed (e.g. `"PAXG"` for a gold asset). Assets with `weekendProxy` skip the 3-source startup check. |
+| `equivalentAssets` | Other asset keys whose median to borrow as an extra source (e.g. `["XAUT"]` for XAU) |
+
+#### 2. Wire up sources
+
+For each external provider that should cover this asset, add the symbol to the source's `assets` array in [`sources.json`](../src/config/sources.json). If the provider uses a different identifier, add a `symbolMapping` entry:
+
+```json
+"CoinGecko": {
+  "assets": ["ETH", "WBTC", "NEWSYMBOL"],
+  "symbolMapping": {
+    "NEWSYMBOL": "coingecko-id-for-newsymbol"
+  }
+}
+```
+
+You need the symbol in at least **3** different sources. At runtime, if fewer than 3 sources return a valid price for this asset during a cycle, the asset is skipped for that cycle (not submitted) but the service stays up.
+
+#### 3. Redeploy
+
+Restart the service so `ConfigLoader` picks up the new config.
+
+#### 4. Verify
+
+- Startup log: `ConfigValidator Configuration valid. N/M assets to submit, K sources.` (N should include the new asset).
+- Cycle log: `CronScheduler Submitting N prices: [..., NEWSYMBOL, ...]`.
+- `[FeedLogger]` block for `NEWSYMBOL` shows the price and `Sources: K/K`.
+- Check the `PriceOracle` contract state on Cirrus to confirm the price landed.
+
+---
+
+### Constant-price asset
+
+Use for a token with a hardcoded price (e.g. USDST pegged at $1).
+
+#### 1. Add to `assets.json` with `constantPrice`
+
+```json
+"USDST": {
+  "targetAssetAddress": "937efa7e3a77e20bbdbd7c0d32b6514f368c1010",
+  "constantPrice": 1000000000000000000
+}
+```
+
+The value is in 1e18 scale (`1000000000000000000` = $1.00).
+
+#### 2. Add to the `constant` source
+
+In `sources.json`, add the symbol to the `constant` source's `assets` array:
+
+```json
+"constant": {
+  "parse": "constant",
+  "assets": ["USDST", "NEWSYMBOL"]
+}
+```
+
+Constant-price assets require only **1** source (the `constant` source). No external provider needed.
+
+#### 3. Redeploy + verify
+
+Same as [plain asset](#plain-asset) steps 3-4.
+
+---
+
+### Yield-bearing token (exchangeRate)
+
+Use for tokens that have a market price **and** an on-chain exchange rate (rETH, wstETH, sUSDS, syrupUSDC, weETH, Aave aTokens). Both the price and the exchange rate are pushed to the `PriceOracle` contract.
+
+#### 1. Add with market-price sources
+
+Follow [plain asset](#plain-asset) steps 1-2 to add the asset to `assets.json` and wire up market-price sources.
+
+#### 2. Add the `exchangeRate` block
+
+In `assets.json`, add an `exchangeRate` object alongside the `targetAssetAddress`:
+
+```json
+"RETH": {
+  "targetAssetAddress": "2e4789eb7db143576da25990a3c0298917a8a87d",
+  "exchangeRate": {
+    "rateUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+    "rateMethod": "POST",
+    "rateBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0xae78736Cd615f374D3085123A210448E74Fc6393\",\"data\":\"0xe6aa216c\"},\"latest\"]}",
+    "rateParse": "result",
+    "ratePrecision": "1000000000000000000",
+    "rateApiKeyEnvVar": "ALCHEMY_API_KEY"
+  }
+}
+```
+
+| Field | How to fill |
+|:--|:--|
+| `rateUrl` | Typically Alchemy mainnet RPC. `${API_KEY}` is substituted from the env var. |
+| `rateMethod` | `POST` for JSON-RPC `eth_call`. Defaults to `GET` if omitted. |
+| `rateBody` | ABI-encoded call. `"to"` = Ethereum contract, `"data"` = function selector + args. |
+| `rateParse` | JSON path to extract the rate value from the response (e.g. `"result"` for `eth_call` hex). |
+| `ratePrecision` | Raw response precision: `"1000000000000000000"` (1e18/WAD) for most; `"1000000"` (1e6) for 6-decimal tokens like syrupUSDC; `"1000000000000000000000000000"` (1e27/RAY) for Aave. |
+| `rateApiKeyEnvVar` | Usually `ALCHEMY_API_KEY`. |
+| `rateHeaders` | Optional. Comma-separated header names that receive the API key. |
+
+#### 3. Redeploy + verify
+
+- Cycle log: `CronScheduler RETH: exchangeRate=<wadRate> (raw=<rawRate>)`.
+- `OraclePusher Exchange rates pushed for N asset(s)`.
+- On-chain: `PriceOracle.setExchangeRates` tx succeeds.
+
+---
+
+### Rebasing token
+
+Use for tokens that derive their price from an underlying asset times a rebase factor (Aave aTokens, xStock wrappers). Market-price sources for the rebasing token itself are **not** needed -- only the underlying's sources matter.
+
+#### 1. Ensure the underlying asset exists
+
+The `rebase.underlyingAsset` must be a key in `assets.json`. It can have `submit: false` if only used as an underlying (e.g. SPYX for WSPYX, TSLAX for WTSLAX, WEETH for AWEETH).
+
+> **Important:** Even with `submit: false`, the underlying still needs at least **3** sources wired up in `sources.json` to produce a valid median at runtime. The startup validator does not enforce this for `submit: false` assets, but at runtime `aggregatePrices` will mark the underlying as `failed` if fewer than 3 sources return a price — and the rebased asset silently gets no price that cycle.
+
+#### 2. Add the rebasing asset
+
+```json
+"AWETH": {
+  "targetAssetAddress": "6d40952f0895d21d2bf20cd088f0eb9a1574583f",
+  "rebase": {
+    "underlyingAsset": "ETH",
+    "factorUrl": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY}",
+    "factorMethod": "POST",
+    "factorBody": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2\",\"data\":\"0xd15e0053000000000000000000000000C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\"},\"latest\"]}",
+    "factorParse": "result",
+    "factorPrecision": "1000000000000000000000000000",
+    "factorApiKeyEnvVar": "ALCHEMY_API_KEY"
+  }
+}
+```
+
+Rebasing assets do **not** need entries in `sources.json` -- they derive their price entirely from the underlying. The startup validator skips the `MIN_VALID_SOURCES` check for them.
+
+Optional fields not shown above: `factorHeaders` (comma-separated header names that receive the API key, analogous to `rateHeaders`). See [FLOW.md](FLOW.md#rebaseconfig) for the full schema.
+
+> **Note:** If the asset also needs an on-chain exchange rate (common for Aave aTokens), add an `exchangeRate` block too -- both `rebase` and `exchangeRate` can coexist on the same asset. See [yield-bearing token](#yield-bearing-token-exchangerate) for the `exchangeRate` fields.
+
+#### 3. Redeploy + verify
+
+- Cycle log: `CronScheduler AWETH: rebased price $X.XXXX (underlying=$Y.YYYY, wadFactor=Z)`.
+- `OraclePusher Rebase factors pushed for N asset(s)`.
+- The rebased asset appears in `Submitting N prices: [...]` (it is submitted as a regular price).
+
+---
+
+## Remove an asset
+
+### Full removal
+
+Delete the asset's entry from `assets.json`. Redeploy. The service no longer prices it. The on-chain price remains at its last submitted value until governance updates or zeroes it.
+
+### Keep as proxy/underlying only
+
+If the asset is still needed as a weekend proxy or equivalent or rebase underlying for another asset, keep it with `submit: false` instead of deleting:
+
+```json
+"KAG": {
+  "targetAssetAddress": "...",
+  "submit": false
+}
+```
+
+The service still aggregates the price internally but does not submit it on-chain. Current examples: KAG, SPYX, TSLAX, WEETH.
+
+### Verify
+
+- `ConfigValidator` log should show a reduced submission count.
+- The asset should not appear in `Submitting N prices: [...]`.
+
+---
+
+## Add a source
+
+### 1. Add to `sources.json`
+
+```json
+"NewSource": {
+  "url": "https://api.newsource.com/v1/prices",
+  "params": "apikey,symbols",
+  "headers": "X-Api-Key",
+  "parse": "data.{symbol}.price",
+  "timestamp": "data.{symbol}.timestamp",
+  "apiKeyEnvVar": "NEWSOURCE_API_KEY",
+  "assets": ["ETH", "WBTC"],
+  "symbolMapping": {
+    "ETH": "ethereum",
+    "WBTC": "bitcoin-wrapped"
+  }
+}
+```
+
+| Field | Notes |
+|:--|:--|
+| `url` | Supports `${API_KEY}`, `${ACCOUNT_ID}`, `${SYMBOLS}` substitution. Optional for the `constant` source. |
+| `method` | HTTP method. Defaults to `GET`. Use `POST` for JSON-RPC style APIs. |
+| `params` | Comma-separated query params. `apikey` is replaced with the resolved API key. |
+| `headers` | Comma-separated header names that receive the API key (e.g. `"X-Api-Key"`, `"Authorization"`) |
+| `body` | Request body key (for POST requests). |
+| `parse` | JSON path pattern. `{symbol}` is replaced per-asset. Special parsers: `"defiLlama"`, `"oanda.prices"`, `"assets"` (CoinAPI), `"constant"`. |
+| `timestamp` | JSON path for extracting the feed timestamp from the response. |
+| `apiKeyEnvVar` | Environment variable name for the API key (e.g. `"COINGECKO_API_KEY"`). |
+| `accountIdEnvVar` | Environment variable for account ID, used by OANDA (`"OANDA_ACCOUNT_ID"`). |
+| `symbolMapping` | Maps asset keys to API-specific identifiers. If absent, the asset key itself is used. |
+| `assets` | Which assets this source covers. Must reference keys that exist in `assets.json`. |
+
+### 2. Add the API key
+
+Add the env var (e.g. `NEWSOURCE_API_KEY`) to `.env` and the deployment secret store. If the key is missing, `validateConfig()` errors and blocks startup.
+
+### 3. Redeploy + verify
+
+- Startup: `ConfigValidator Configuration valid. ...` (no new errors).
+- First cycle: `CronScheduler N/M sources: [... NewSource (Xms) ...]` in the succeeded list.
+- Assets covered by the new source show an increased source count in `[FeedLogger]` output.
+
+---
+
+## Remove a source
+
+### Full removal
+
+Delete the source's entry from `sources.json`. Redeploy.
+
+### Narrow scope
+
+Remove specific assets from the source's `assets` array instead of deleting the entire source. The source will still run for its remaining assets.
+
+### Check remaining coverage
+
+Before removing, ensure every affected plain asset still has >= **3** other sources in `sources.json`. If not:
+
+- The startup validator will **block startup** with an error for any plain asset below 3 sources.
+- Add another source first ([Add a source](#add-a-source)), or set `submit: false` on the undercovered asset.
+- At runtime, even with 3+ sources configured, if some sources fail during a cycle and fewer than 3 return a valid price, the asset is skipped for that cycle (not submitted) and `logError` fires.
+
+### Verify
+
+- Startup: `ConfigValidator Configuration valid. ...` with the source no longer listed.
+- Assets that lost a source show a decreased source count in `[FeedLogger]` output.


### PR DESCRIPTION
`oracle` service docs so both AI agents and humans can navigate the service without reading every source file. No code change. Mirrors the structure of #6889.