### PR TITLE
bridge: rewrite service docs (README, FLOW, OPERATIONS)

### DIFF
--- a/mercata/services/bridge/README.md
+++ b/mercata/services/bridge/README.md
@@ -1,200 +1,136 @@
 # Mercata Bridge Service
 
-The Mercata Bridge Service is responsible for seamlessly bridging assets between multiple blockchain networks and the STRATO testnet. It manages deposits and withdrawals using a Safe multisig wallet and monitors blockchain activity in real-time using dynamic RPC connections.
+The bridge service is a long-running Node service that moves tokens between Ethereum (and other EVM chains) and STRATO. It handles two directions:
 
-## Features
+- **Bridge-in** (Ethereum → STRATO): polls `DepositRouter` events via `eth_getLogs`, mirrors them to the `MercataBridge` contract on STRATO, verifies on-chain receipts, confirms deposits (which mints the STRATO-side tokens), and awards Voucher rewards.
+- **Bridge-out** (STRATO → Ethereum): picks up withdrawal requests from STRATO, builds and proposes Safe multisig transactions on the destination chain, monitors Safe execution, and finalizes or aborts on-chain.
 
-* **Dynamic Chain Support**: Automatically detects and configures RPC endpoints for all enabled chains from the bridge contract
-* **Safe Multisig Integration**: Proposes and executes transactions through Gnosis Safe for secure asset management
-* **Real-time Monitoring**: Polls blockchain events and transaction statuses across all supported chains
-* **Bridge Out Flow**: Complete STRATO → Ethereum asset transfer with Safe approval workflow
-* **Bridge In Flow**: Ethereum → STRATO deposit processing and confirmation
-* **Dynamic Asset Management**: Fetches enabled assets and chain information from on-chain bridge contract
-* **Email Notifications**: Sends transaction alerts to configured email addresses
-* **Comprehensive Logging**: Secure and contextual logging using Winston
-* **OAuth Integration**: Secure authentication with STRATO using OpenID Connect
+It also exposes `POST /request-deposit-action` for operators to manually unblock stuck deposits.
 
-## Prerequisites
+- **How it works end-to-end** → [docs/FLOW.md](docs/FLOW.md)
+- **Runbooks — add/remove a chain, add/remove an asset** → [docs/OPERATIONS.md](docs/OPERATIONS.md)
 
-- Node.js 18 or higher
-- Access to Alchemy API for Ethereum networks
-- Gnosis Safe multisig wallet
-- Safe owner private key
-- STRATO OAuth credentials
+---
 
-## Installation
+## Source map
 
-1. Clone the repository
-2. Navigate to the bridge service:
-```bash
-cd services/bridge
+```text
+src/
+├── index.ts                                   Express bootstrap, /health, /request-deposit-action, polling init
+├── polling/
+│   ├── alchemyPolling.ts                      Bridge-in: Ethereum event polling → depositBatch
+│   └── mercataPolling.ts                      STRATO-side: deposit verification, withdrawal request, withdrawal tx monitoring
+├── services/
+│   ├── bridgeService.ts                       MercataBridge contract call wrappers (deposit, confirm, review, withdrawal, finalize, abort)
+│   ├── verificationService.ts                 Deposit receipt verification (ETH-direct, ETH-via-router, ERC20)
+│   ├── depositActionService.ts                HTTP unblock: requestDepositAction wrapper
+│   ├── voucherService.ts                      Voucher.mint after deposit confirmation
+│   ├── blockTrackingService.ts                Per-chain bridge-in cursor (local + on-chain dual cursor)
+│   ├── cirrusService.ts                       Cirrus query helpers (chains, assets, deposits, withdrawals, prices)
+│   ├── emailService.ts                        SendGrid notification to withdrawal approvers
+│   ├── rpcService.ts                          Ethereum JSON-RPC helpers (eth_getLogs, eth_blockNumber, receipts, traces)
+│   └── safeService.ts                         Safe orchestration: create proposals, monitor tx status (executed / rejected / pending)
+├── controllers/
+│   └── depositAction.controller.ts            Express handler for POST /request-deposit-action
+├── auth/
+│   ├── index.ts                               OpenID / OAuth init + token helpers
+│   ├── oauth.ts                               simple-oauth2 wrapper
+│   └── tokenMiddleware.ts                     OIDC bearer-token verification middleware
+├── config/
+│   └── index.ts                               Single config object, constants, env validation
+├── types/
+│   └── index.ts                               Shared TypeScript types
+└── utils/
+    ├── api.ts                                 strato / bloc / cirrus axios clients
+    ├── stratoHelper.ts                        buildFunctionTx + execute (same pattern as rewards-poller)
+    ├── safeHelper.ts                          Safe low-level: nonce allocation, meta-tx building, signing, API proposal submission, hot-wallet execution
+    ├── balanceCheck.ts                        Pre-flight USDST/Voucher balance check
+    ├── configValidator.ts                     Startup validation: OIDC, auth probe, address formats, chain RPC URLs
+    ├── healthMonitor.ts                       Error flag file for /health
+    ├── logger.ts                              Structured console logging with secret redaction
+    └── utils.ts                               Address normalization, hex helpers
 ```
 
-3. Install dependencies:
-```bash
-npm install
-```
-
-4. Copy the example environment file and update the values:
-```bash
-cp .env.example .env
-```
+---
 
 ## Configuration
 
-### Required Environment Variables
+### Required environment variables
 
-#### Authentication
-- `BA_USERNAME` - BlockApps username
-- `BA_PASSWORD` - BlockApps password
-- `CLIENT_SECRET` - OAuth client secret
-- `CLIENT_ID` - OAuth client ID
-- `OPENID_DISCOVERY_URL` - OpenID discovery endpoint
+| Variable | Purpose |
+|:--|:--|
+| `BA_USERNAME`, `BA_PASSWORD` | BlockApps credentials |
+| `CLIENT_ID`, `CLIENT_SECRET` | OAuth client credentials |
+| `OPENID_DISCOVERY_URL` | OpenID discovery endpoint |
+| `BRIDGE_ADDRESS` | MercataBridge contract on STRATO |
+| `PRICE_ORACLE_ADDRESS` | Price Oracle contract (for rebase factors) |
+| `SAFE_ADDRESS` | Main Safe multisig address on Ethereum |
+| `SAFE_PROPOSER_ADDRESS` | Proposer EOA address |
+| `SAFE_PROPOSER_PRIVATE_KEY` | Proposer private key (signs Safe proposals) |
+| `CHAIN_<id>_RPC_URL` | Per-chain Ethereum RPC endpoint (one per enabled chain, e.g. `CHAIN_1_RPC_URL`) |
 
-#### Blockchain
-- `ALCHEMY_API_KEY` - Alchemy API key (used for all chains)
-- `BRIDGE_ADDRESS` - MercataBridge contract address
+### Optional environment variables
 
-#### Chain RPC URLs (Dynamically Validated)
-The service automatically validates that RPC URLs are configured for all enabled chains from the bridge contract:
+| Variable | Default | Purpose |
+|:--|:--|:--|
+| `PORT` | `3003` | Express port |
+| `NODE_URL` | — | STRATO node URL (not in `requiredEnvVars` but needed by `validateBridgeConfig`) |
+| `USDST_ADDRESS` | `937efa7e3a77e20bbdbd7c0d32b6514f368c1010` | USDST token |
+| `VOUCHER_CONTRACT_ADDRESS` | `000000000000000000000000000000000000100e` | Voucher token |
+| `SAFE_HOT_WALLET_ADDRESS` | — | Hot-wallet Safe for auto-executing small withdrawals |
+| `SAFE_API_KEY` | — | Safe Transaction Service API key |
+| `GAS_FEE_USDST` | `1` (= 0.01 USDST) | Gas estimate per tx, multiplied by 1e16 |
+| `GAS_FEE_VOUCHER` | `100` (= 1 Voucher) | Gas estimate per tx, multiplied by 1e16 |
+| `MIN_TRANSACTIONS_THRESHOLD` | `200` | Mark unhealthy if remaining txs ≤ this; exit if 0 |
+| `SENDGRID_API_KEY` | — | For withdrawal-approver email notifications |
+| `TRANSACTION_APPROVER_EMAILS` | — | Comma-separated list of approver emails |
 
-- `CHAIN_11155111_RPC_URL` - Sepolia RPC URL (e.g., `https://eth-sepolia.g.alchemy.com/v2`)
-- `CHAIN_1_RPC_URL` - Ethereum mainnet RPC URL (if using mainnet)
-- `CHAIN_${chainId}_RPC_URL` - RPC URL for any additional enabled chains
+> **Note:** `NODE_URL` is not in the `requiredEnvVars` array, but `validateBridgeConfig()` calls Cirrus at `${NODE_URL}/cirrus/search/...` to fetch enabled chains. If `NODE_URL` is unset, validation fails and the process exits before polling starts.
 
-#### Safe Wallet
-- `SAFE_ADDRESS` - Gnosis Safe wallet address
-- `SAFE_PROPOSER_ADDRESS` - Safe Proposer address
-- `SAFE_PROPOSER_PRIVATE_KEY` - Safe Proposer private key
+See [`src/config/index.ts`](src/config/index.ts) for the full config object and defaults.
 
-#### Optional
-- `VOUCHER_CONTRACT_ADDRESS` - Voucher contract address (defaults to `0x000000000000000000000000000000000000100e`)
-- `TRANSACTION_APPROVER_EMAILS` - Comma-separated list of emails for transaction alerts
-- `SENDGRID_API_KEY` - SendGrid API key for sending emails
+---
 
-### Dynamic Configuration
-
-The service automatically:
-- Fetches enabled chains and assets from the bridge contract via Cirrus
-- Validates that all required RPC URLs are configured at startup
-- Uses the Alchemy API key for all chain connections
-- Filters all operations by the specific bridge contract address
-
-## Usage
-
-### Development
-
-Run the service in development mode with hot reloading:
+## Running
 
 ```bash
-npm run dev
+cd services/bridge
+npm install
+cp .env.example .env   # fill in the required variables
+npm start              # runs ts-node on src/index.ts
+npm run build          # compile to dist/ via tsc
 ```
 
-### Production
+> **Note:** `npm run dev` (nodemon) writes state files (`data/lastProcessedBlocks.json`) on every polling cycle, which triggers restart loops. Use `npm start` for local work.
 
-Build and run the service:
+---
 
-```bash
-npm run build
-npm start
+## Health, state, and logging
+
+### Health check
+
+```
+GET /health
 ```
 
-## Architecture
+Returns `200` when the error flag file is empty or missing; `500` when it has content. The `/health` handler calls `healthMonitor.errorFileExists()` ([`healthMonitor.ts`](src/utils/healthMonitor.ts)).
 
-### Service Layer
+The flag is append-only: every `logError` call writes to it. Once set, the service stays unhealthy until you delete or truncate `data/bridge-error.flag` after resolving the root cause.
 
-1. **Bridge Service** (`bridgeService.ts`)
-   - Core bridge contract interactions
-   - Handles deposit and withdrawal confirmations
-   - Manages batch operations for efficiency
+### State files (under `data/`)
 
-2. **Safe Service** (`safeService.ts`)
-   - Centralized Safe multisig wallet operations
-   - Transaction generation and proposal
-   - Status monitoring and execution
+| File | Shape | Purpose |
+|:--|:--|:--|
+| `data/lastProcessedBlocks.json` | `{ [chainId]: blockNumber }` | Per-chain bridge-in cursor. In-memory cache; dual-cursor with on-chain `MercataBridge.chains[chainId].lastProcessedBlock` |
+| `data/bridge-error.flag` | Append-only error log | Non-empty means `/health` reports unhealthy |
 
-3. **Cirrus Service** (`cirrusService.ts`)
-   - Dynamic chain and asset information fetching
-   - Withdrawal status queries
-   - Bridge contract data retrieval
+### Logging
 
-4. **Polling Services**
-   - **Mercata Polling**: Monitors STRATO bridge events
-   - **Alchemy Polling**: Monitors Ethereum bridge events
-   - Real-time transaction status tracking
+Structured console logs via [`src/utils/logger.ts`](src/utils/logger.ts) (plain `console`, not Winston):
 
-### Bridge Out Flow (STRATO → Ethereum)
+- `logInfo(context, message, data?)` — successful operations.
+- `logError(context, error, data?)` — failures; also appends to the error flag file.
 
-1. **Withdrawal Initiation**
-   - Service polls for withdrawals with status "1" (INITIATED)
-   - Groups withdrawals by destination chain and token
-   - Creates Safe transactions for each unique combination
+Redacted patterns: `api_key=` / `api-key=` / `apikey=`, `Bearer <token>`, `Authorization:` headers.
 
-2. **Safe Transaction Processing**
-   - Generates Safe transaction with total amount and destination address
-   - Proposes transaction to Safe multisig for approval
-   - Monitors transaction status (executed/rejected/pending)
-
-3. **Finalization**
-   - **Executed**: Calls `finaliseWithdrawalBatch` on bridge contract
-   - **Rejected**: Calls `abortWithdrawalBatch` on bridge contract
-   - Sends email notifications for completed transactions
-
-### Bridge In Flow (Ethereum → STRATO)
-
-1. **Deposit Detection**
-   - Alchemy polling monitors Ethereum deposit events
-   - Checks if deposit is already processed
-   - Records deposit on STRATO if new
-
-2. **Processing**
-   - Updates last processed block for chain
-   - Handles batch processing for efficiency
-
-### Key Components
-
-- **Dynamic RPC Management**: Uses `getChainRpcUrl(chainId)` for all chain interactions
-- **Safe Integration**: Leverages `@safe-global/protocol-kit` and `@safe-global/api-kit`
-- **OAuth Authentication**: Secure STRATO access with JWT validation
-- **Error Handling**: Comprehensive error handling with detailed logging
-
-## Error Handling
-
-The service includes comprehensive error handling:
-
-- **Network Errors**: Automatic retry mechanisms for RPC calls
-- **Safe Transaction Failures**: Proper error handling for proposal and execution
-- **Cirrus API Errors**: Graceful degradation when Cirrus is unavailable
-- **Configuration Errors**: Startup validation ensures all required config is present
-
-All errors are logged with appropriate context for debugging.
-
-## Monitoring
-
-The service logs important events and errors using Winston logger:
-
-- **Startup**: Chain validation, OAuth initialization
-- **Polling**: Event detection and processing
-- **Safe Operations**: Transaction proposals and executions
-- **Bridge Operations**: Deposit and withdrawal processing
-- **Errors**: Detailed error logging with context
-
-## Security Considerations
-
-- **Private Keys**: Stored securely in environment variables
-- **Safe Multisig**: All bridge operations require Safe approval
-- **OAuth**: Secure authentication with STRATO
-- **Contract Validation**: All operations filter by specific bridge contract address
-- **Error Handling**: Prevents service crashes and data corruption
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Commit your changes
-4. Push to the branch
-5. Create a Pull Request
-
-## License
-
-MIT 
+> **Warning:** Raw credential strings outside those patterns are not auto-redacted. The `SAFE_PROPOSER_PRIVATE_KEY` is particularly sensitive — never log it in context objects.

--- a/mercata/services/bridge/docs/FLOW.md
+++ b/mercata/services/bridge/docs/FLOW.md
@@ -1,0 +1,331 @@
+# Bridge Service — End-to-End Flow
+
+How the service works, from start to finish.
+
+- For **how to change things** → [OPERATIONS.md](OPERATIONS.md)
+- For **module map, config, health** → [README](../README.md)
+
+---
+
+## Contents
+
+1. [Startup](#startup)
+2. [The bridge-in flow (Ethereum → STRATO)](#the-bridge-in-flow-ethereum--strato)
+3. [The bridge-out flow (STRATO → Ethereum)](#the-bridge-out-flow-strato--ethereum)
+4. [The HTTP unblock flow](#the-http-unblock-flow)
+5. [Anatomy of a MercataBridge write](#anatomy-of-a-mercatabridge-write)
+6. [State, idempotency, and recovery](#state-idempotency-and-recovery)
+
+---
+
+## Startup
+
+`src/index.ts` is the entry point. On boot the service:
+
+1. Loads `.env` via `dotenv` and validates required environment variables ([`src/config/index.ts`](../src/config/index.ts)). Missing vars crash the process (`process.exit(2)`).
+2. Starts an Express app on `PORT` (default `3003`) exposing `GET /health` and `POST /request-deposit-action`.
+3. Runs `validateBridgeConfig()` ([`configValidator.ts`](../src/utils/configValidator.ts)):
+   1. Fetches the OIDC discovery document.
+   2. Does a live user-auth probe via `getBAUserToken()`.
+   3. Validates address / private-key / JWT formats.
+   4. Reads `getEnabledChains()` from Cirrus and confirms each chain has a `CHAIN_<id>_RPC_URL`.
+   Validation failure exits with code 1 before any polling starts.
+4. `initOpenIdConfig()` caches the discovery document + JWKS for request-time auth ([`auth/index.ts`](../src/auth/index.ts)).
+5. `startMultiChainDepositPolling()` ([`alchemyPolling.ts`](../src/polling/alchemyPolling.ts)) — starts the Ethereum-side cycle via `setInterval` at `bridgeInInterval` ms (default 1 min). Invoked immediately for the first poll (without awaiting), then repeated on the interval.
+6. `initializeMercataPolling()` ([`mercataPolling.ts`](../src/polling/mercataPolling.ts)) — starts three concurrent STRATO-side cycles (deposit-initiated, withdrawal-request, withdrawal-tx), each via `setInterval`.
+
+From this point the service is four concurrent polling loops plus the HTTP server.
+
+> **Note:** `NODE_URL` is not in the `requiredEnvVars` array, but `validateBridgeConfig()` calls `getEnabledChains()` which hits Cirrus at `${NODE_URL}/cirrus/search/...`. If `NODE_URL` is unset, validation fails and the process exits before polling starts.
+
+> **Note:** A non-OK `eth_blockNumber` response from a chain's RPC is a **warning**, not a startup failure. Missing `CHAIN_<id>_RPC_URL` env vars are a hard error.
+
+---
+
+## The bridge-in flow (Ethereum → STRATO)
+
+Traces one user deposit from the source chain to a confirmed credit on STRATO with a Voucher reward. Two loops cooperate: `startMultiChainDepositPolling` mirrors the on-chain event into STRATO; `startDepositInitiatedPolling` verifies and confirms it.
+
+### 1. Activity discovery
+
+Per `bridgeInInterval` cycle, [`alchemyPolling.ts`](../src/polling/alchemyPolling.ts) reads from Cirrus in parallel:
+
+- `getEnabledChains()` — every `BlockApps-MercataBridge-chains` row where `value->>enabled = true`.
+- `getBridgeInfo()` — the root `BlockApps-MercataBridge` row, exposing `depositsPaused` / `withdrawalsPaused`.
+
+If `depositsPaused` is true, the cycle logs `Deposits are paused` and returns.
+
+### 2. Event fetch
+
+For each enabled chain (in parallel via `Promise.allSettled`):
+
+- Effective cursor = `max(local lastProcessedBlocks.json, on-chain chains.lastProcessedBlock)`. Managed by [`blockTrackingService.ts`](../src/services/blockTrackingService.ts). This runs first (even before the RPC check).
+- `isChainConfigured(externalChainId)` — verifies the per-chain RPC URL is set. Unconfigured chains are skipped silently.
+- `getCurrentBlockNumber(externalChainId)` via `eth_blockNumber`. If the tip hasn't advanced past the cursor, return early.
+- `getChainLogs(...)` — `eth_getLogs` filtered by address (the chain's `depositRouter`) and topic 0 (`DEPOSIT_EVENT_SIGNATURE = 0x5542…f750`).
+- Decode each log: topics give `externalToken`, `externalSender`, `stratoRecipient`; the data slot gives `amount` (first 32 bytes) and `targetStratoToken` (second 32 bytes).
+
+### 3. Rebase (xStock only)
+
+Tokens whose `targetStratoToken` has a non-zero rebase factor in `BlockApps-PriceOracle-rebaseFactors` represent a rebasing external token bridged to a share-counted STRATO token. Bridge-in **divides**:
+
+```text
+adjustedAmount = (originalAmount * 1e18) / factor
+```
+
+`getRebaseFactors()` fetches factors for all deduped target tokens in one request. Tokens with no factor pass through unchanged.
+
+### 4. Mirror to STRATO
+
+[`bridgeService.ts`](../src/services/bridgeService.ts) → `depositBatch()` submits a `FunctionInput` targeting `MercataBridge.depositBatch(...)` via `execute()`. The on-chain deposit enters `bridgeStatus=1` (initiated).
+
+
+| Error pattern                           | Behavior                                                |
+|:--|:--|
+| `MB: dup key` / `MB: duplicate deposit` | Swallowed as info — another replica already mirrored it |
+| Anything else                           | Re-thrown; cursor not advanced                          |
+
+
+### 5. Cursor advance policy
+
+Dual cursor — multiple replicas converge without drift:
+
+
+| Scenario           | Local file | On-chain `setLastProcessedBlock` |
+|:--|:--|:--|
+| No deposits found  | advanced | — (no transaction)               |
+| Deposits processed | advanced | advanced                       |
+
+
+> **Note:** The on-chain cursor rejects rollbacks (`MB: cannot rollback block`), so the call is idempotent.
+
+### 6. Verification
+
+The second loop, `startDepositInitiatedPolling` in [`mercataPolling.ts`](../src/polling/mercataPolling.ts), runs every `withdrawalInterval` (default 1 min):
+
+- `getDepositsByStatus("1")` from Cirrus, with `depositsPaused=false` joined in.
+- `verifyDepositsBatch(deposits)` in [`verificationService.ts`](../src/services/verificationService.ts) groups by chain and batch-fetches receipts + internal traces per chain.
+
+Per-deposit checks:
+
+
+| Path                 | Condition                      | Verification                                                                                                                                        |
+|:--|:--|:--|
+| **ETH (direct)**     | `receipt.to === safe`          | Accept immediately                                                                                                                                  |
+| **ETH (via router)** | `receipt.to === depositRouter` | An internal call must transfer exactly `stratoTokenAmount` to the Safe                                                                              |
+| **ERC20**            | Any receipt log                | A `Transfer` log with `token = externalToken`, `to = safe`, and amount matching `stratoTokenAmount` after decimal normalization + rebase truncation |
+
+
+> **Warning:** If an asset is disabled mid-flight, the deposit will revert on confirmation with `MB: route not enabled`.
+
+Verified deposits → `confirmDepositBatch`. Failed → `reviewDepositBatch` (marks for manual review, not on-chain revert). Per-deposit error isolation: if verification throws for one deposit, the rest of the batch continues.
+
+### 7. Voucher reward
+
+After `confirmDepositBatch` succeeds, [`voucherService.ts`](../src/services/voucherService.ts) → `mintVouchersForDeposits(stratoRecipients)` builds one `Voucher.mint(to, amount)` tx per recipient where `amount = mintCount × 1e18` (default 25 Vouchers each), then submits them in a single `execute()` call. Mint failures are logged but do not fail the confirmation.
+
+### 8. Error handling
+
+
+| Error kind                                                      | Behavior                                                                                       |
+|:--|:--|
+| `MB: bad state` on `confirmDepositBatch` / `reviewDepositBatch` | Swallowed as info — another replica won                                                        |
+| Verification failure for a deposit                              | Lands in `reviewDepositBatch` → manual unblock via [HTTP unblock flow](#the-http-unblock-flow) |
+| Unknown error in the outer `poll()`                             | Logged with full context; loop continues next cycle                                            |
+
+
+---
+
+## The bridge-out flow (STRATO → Ethereum)
+
+Traces one withdrawal request from creation on STRATO to the custody tx executing on the destination chain. Two loops cooperate: `startWithdrawalRequestPolling` builds and proposes the Safe transaction; `startWithdrawalTxPolling` watches for execution and finalizes.
+
+### 1. Balance guard
+
+`startWithdrawalRequestPolling` runs `checkBalances()` ([`balanceCheck.ts`](../src/utils/balanceCheck.ts)) first. Reads the service account's USDST and Voucher balances, divides by `gasFeeUSDST` / `gasFeeVoucher`, and marks the service **unhealthy** (via `logError`) if estimated remaining transactions fall at or below `minTransactionsThreshold` (default `200`). The cycle **continues** — only zero remaining transactions triggers `process.exit(1)`.
+
+> **Warning:** The low-balance `logError` appends to the error flag file, so `/health` returns 500 even though the cycle proceeds. Top up the account and clear the flag to recover.
+
+The other two Mercata-side loops do not run this guard.
+
+### 2. Pick up requests
+
+`getWithdrawalsByStatus("1")` from Cirrus, joined against the bridge root so that `bridge.withdrawalsPaused=eq.false` is enforced server-side.
+
+### 3. Build Safe proposals
+
+`createWithdrawalProposals()` in [`safeHelper.ts`](../src/utils/safeHelper.ts), per chain:
+
+- **Rebase (xStock only)**: multiply — opposite direction from bridge-in:
+  ```text
+  externalAmount = (storedAmount * factor) / 1e18
+  ```
+- **Hot-wallet routing**: per-withdrawal `useHotWallet` flag (set on-chain). If the hot-wallet Safe is configured, check its balance per token; insufficient balance falls back to the main Safe with a log.
+- **Nonce allocation**: `apiKit.getNextNonce(safeAddress)` per safe per chain, then incremented locally per proposal. Main safe and hot-wallet safe have independent nonce streams.
+- **Meta-transaction**: `buildTxDescriptor()` builds ETH (`{to: recipient, value: amount, data: "0x"}`) or ERC20 (`Interface.encodeFunctionData("transfer", [recipient, amount])`) payloads.
+- **Sign**: `protocolKit.getTransactionHash()` + `protocolKit.signHash()` using the proposer's private key.
+
+### 4. Mark on STRATO
+
+`MercataBridge.confirmWithdrawalBatch(ids, custodyTxHashes)` records which Safe tx hash goes with which withdrawal, advancing each to `bridgeStatus=2` (proposed). `MB: bad state` is swallowed — another replica got there first.
+
+### 5. Propose to the Safe API
+
+`apiKit.proposeTransaction(tx)` per proposal. For hot-wallet proposals, the service then calls `hotProtocolKit.executeTransaction(tx)` immediately — hot-wallet withdrawals auto-execute on-chain without waiting for co-signers.
+
+> **Note:** Nonce conflicts (HTTP 409/422 or messages matching `nonce|already exists|conflict`) are handled by the generic proposal error handler — the error is logged and the loop moves to the next proposal. The next cycle fetches a fresh `getNextNonce()` from the Safe API.
+
+### 6. Email approvers
+
+[`emailService.ts`](../src/services/emailService.ts) posts a SendGrid notification per proposal to `TRANSACTION_APPROVER_EMAILS` (if configured). Email failures are logged per-proposal; the batch logs a summary.
+
+### 7. Monitor execution
+
+`startWithdrawalTxPolling` runs every `bridgeOutInterval` (default 1 min):
+
+- `getWithdrawalsByStatus("2")` — the proposed-but-not-finalized set.
+- `getSafeTxHashFromEvents(ids)` looks up each withdrawal's `custodyTxHash` from `BlockApps-MercataBridge-WithdrawalPending`.
+- Group by chain; per chain, `monitorSafeTransactionStatusBatch` iterates sequentially (1 s between requests to avoid Safe API rate-limiting).
+
+Per withdrawal, `checkSafeTxStatus()` classifies:
+
+
+| Status     | Condition                                                          |
+|:--|:--|
+| `executed` | `isExecuted && isSuccessful` on the proposal                       |
+| `rejected` | A different `safeTxHash` with the **same nonce** has been executed |
+| `pending`  | Neither                                                            |
+
+
+### 8. Finalize or abort
+
+
+| Safe status | Bridge call                    | Result                                                   |
+|:--|:--|:--|
+| `executed`  | `finaliseWithdrawalBatch(ids)` | Withdrawal reaches terminal state                        |
+| `rejected`  | `abortWithdrawalBatch(ids)`    | Refunds the user's STRATO-side balance (`WITHDRAWAL_ABORT_DELAY` applies to user-initiated aborts only, not the service) |
+| `pending`   | —                              | Re-checked next cycle                                    |
+
+
+`MB: bad state` and `MB: not abortable` are swallowed as info.
+
+---
+
+## The HTTP unblock flow
+
+`POST /request-deposit-action` lets an operator (or an authenticated user) force an action on a deposit that can't be auto-verified.
+
+1. Request hits the service (in production, the OpenResty sidecar enforces 3 req/s per IP).
+2. `AuthHandler.authorizeRequest()` ([`tokenMiddleware.ts`](../src/auth/tokenMiddleware.ts)) verifies the OIDC bearer token. The verified user address is set on `res.locals.userAddress`.
+3. `DepositActionController.requestDepositAction` reads `{externalChainId, externalTxHash, action, targetToken}` from the body and pairs them with the token-derived `userAddress`. The caller cannot spoof the user.
+4. [`depositActionService.ts`](../src/services/depositActionService.ts) calls `MercataBridge.requestDepositAction(user, externalChainId, externalTxHash, action, targetToken)`.
+
+> **Note:** The meaning of the `action` parameter is contract-defined — see `MercataBridge.sol`.
+
+---
+
+## Anatomy of a MercataBridge write
+
+Unlike the rewards poller (one method), the bridge has eight distinct write methods on `MercataBridge` plus `Voucher.mint`. All share the same submission path through `execute()`.
+
+### Stage 1 — Input
+
+
+| Caller                             | File                                                                 | Method called                                                               |
+|:--|:--|:--|
+| `alchemyPolling` → `bridgeService` | [`bridgeService.ts`](../src/services/bridgeService.ts)               | `depositBatch`                                                              |
+| `mercataPolling` → `bridgeService` | [`bridgeService.ts`](../src/services/bridgeService.ts)               | `confirmDepositBatch`, `reviewDepositBatch`                                 |
+| `mercataPolling` → `bridgeService` | [`bridgeService.ts`](../src/services/bridgeService.ts)               | `confirmWithdrawalBatch`, `finaliseWithdrawalBatch`, `abortWithdrawalBatch` |
+| `blockTrackingService`             | [`blockTrackingService.ts`](../src/services/blockTrackingService.ts) | `setLastProcessedBlock`                                                     |
+| `depositActionService`             | [`depositActionService.ts`](../src/services/depositActionService.ts) | `requestDepositAction`                                                      |
+| `voucherService`                   | [`voucherService.ts`](../src/services/voucherService.ts)             | `Voucher.mint`                                                              |
+
+
+### Stage 2 — Build `FunctionInput` (caller-side)
+
+```ts
+{
+  contractName:    "MercataBridge",       // or "Voucher"
+  contractAddress: config.bridge.address, // or config.voucher.contractAddress
+  method:          "depositBatch",        // varies per call
+  args: {
+    externalChainIds: [...],
+    externalSenders:  [...],
+    // ... remaining arrays
+  },
+}
+```
+
+### Stage 3 — Wrap as `BuiltTx` (`stratoHelper.buildFunctionTx`)
+
+```ts
+{
+  txs: [{ type: "FUNCTION", payload: { /* the FunctionInput */ } }],
+  txParams: { gasLimit, gasPrice },  // fixed in config/index.ts
+}
+```
+
+### Stage 4 — Submit and poll (`stratoHelper.execute`)
+
+
+| Call               | Endpoint                             | Purpose                                                                        |
+|:--|:--|:--|
+| `strato.post(...)` | `/transaction/parallel?resolve=true` | Submit; returns `[{ hash, … }]`                                                |
+| `bloc.post(...)`   | `/transactions/results`              | Polled with each hash until no result is `Pending`. Returns `{ status: Success \| Failure, hash }` |
+
+
+### Stage 5 — On-chain execution
+
+Each method has its own contract-side semantics. Key behaviors:
+
+
+| Method                    | On-chain effect                                                                      |
+|:--|:--|
+| `depositBatch`            | Records deposit with decimal conversion; sets `bridgeStatus=1`. Tokens are **not** minted yet. |
+| `confirmDepositBatch`     | Mints STRATO-side tokens to `stratoRecipient` (or executes auto-save/auto-forge action); sets `bridgeStatus=COMPLETED` |
+| `reviewDepositBatch`      | Flags for manual review                                                              |
+| `confirmWithdrawalBatch`  | Records custody tx hash; `bridgeStatus` 1→2                                          |
+| `finaliseWithdrawalBatch` | Terminal success state                                                               |
+| `abortWithdrawalBatch`    | Refunds the user's STRATO-side balance (`WITHDRAWAL_ABORT_DELAY` applies to user-initiated aborts only, not the service) |
+| `setLastProcessedBlock`   | Advances the per-chain cursor; rejects rollback (`MB: cannot rollback block`)        |
+| `requestDepositAction`    | Contract-defined per `action` parameter                                              |
+
+
+---
+
+## State, idempotency, and recovery
+
+### Where state lives
+
+Two files in `data/` under the service's working directory — see [README § State files](../README.md#state-files-under-data) for the canonical table.
+
+
+| File                       | Purpose                    |
+|:--|:--|
+| `lastProcessedBlocks.json` | Per-chain bridge-in cursor |
+| `bridge-error.flag`        | Health-check sink          |
+
+
+> **Important:** The block cursor is cached in memory by `blockTrackingService.ts`. To rewind the cursor for replay, **stop the service first** — otherwise the file edit will be overwritten on the next successful cycle.
+
+### Idempotency
+
+All four polling loops tolerate replay. Specific patterns:
+
+- **Bridge-in cursor**: the effective cursor is `max(local, on-chain)`, so stale replicas catch up without double-processing.
+- **`MB: dup key` / `MB: duplicate deposit`**: `depositBatch` is idempotent on `(externalChainId, externalTxHash)`. Duplicate submissions are swallowed as info.
+- **`MB: bad state`**: thrown by `confirm*` / `review*` / `finalise*` when the state transition already happened. Swallowed as info.
+- **`MB: not abortable`**: thrown by `abortWithdrawalBatch` when the withdrawal is already in a terminal state (completed or aborted by another replica or a prior cycle). Swallowed as info.
+- **Safe API nonce conflicts**: HTTP 409/422 or messages matching `nonce|already exists|conflict`. Caught by the generic proposal error handler — the error is logged and the loop continues. The next cycle fetches a fresh `getNextNonce()` from the Safe API.
+
+### Common recovery scenarios
+
+
+| Symptom                                        | What to do                                                                                                                                                                                                                  |
+|:--|:--|
+| Cursor rewind needed (normal)                  | Stop service, edit `data/lastProcessedBlocks.json` to lower the chain's entry, restart. The on-chain floor via `setLastProcessedBlock` limits how far back you can go. Re-processing deposits is safe (`MB: dup key` path). |
+| Cursor rewind below on-chain floor (emergency) | Admin vote: `emergencySetLastProcessedBlock(externalChainId, lastProcessedBlock)`. `onlyOwner`, no rollback guard. Will re-fetch and re-verify every receipt in the range.                                                  |
+| Stuck deposit in `bridgeStatus=1`              | Retried automatically next cycle by `verifyDepositsBatch`. If it permanently fails, it lands in `reviewDepositBatch` and requires the [HTTP unblock flow](#the-http-unblock-flow).                                          |
+| Stuck withdrawal in `bridgeStatus=2`           | Re-checked each cycle. If Safe owners reject (execute a different nonce), it becomes `rejected` and hits `abortWithdrawalBatch`. The service calls as admin, so `WITHDRAWAL_ABORT_DELAY` does not apply.                     |
+| `/health` returns 500                          | Inspect `data/bridge-error.flag` for context, fix the root cause, delete or truncate the flag. A single stray `logError` is enough to flip it.                                                                              |
+| Multi-replica idempotency noise                | Expected and safe. If it becomes too loud, consider leader election.                                                                                                                                                        |

--- a/mercata/services/bridge/docs/OPERATIONS.md
+++ b/mercata/services/bridge/docs/OPERATIONS.md
@@ -1,0 +1,205 @@
+# Bridge Service — Operations Runbook
+
+Step-by-step procedures for adding and removing chains and assets. Use this when onboarding a new network or a new token.
+
+- For **how the service works** → [FLOW.md](FLOW.md)
+- For **config and deployment** → [README](../README.md)
+
+---
+
+## Contents
+
+- [Add a chain](#add-a-chain)
+- [Remove a chain](#remove-a-chain)
+- [Add an asset](#add-an-asset)
+- [Remove an asset](#remove-an-asset)
+
+---
+
+> **Note:** The authoritative registry of chains and assets lives on-chain in `MercataBridge.chains` and `MercataBridge.assets`. The service discovers both dynamically via Cirrus every cycle, so there is no "register in the service" step. The two local knobs are `.env` (per-chain RPC URLs, credentials) and restart. For replay, cursor rewind, and stuck-deposit recovery, see [FLOW.md § State, idempotency, and recovery](FLOW.md#state-idempotency-and-recovery).
+
+---
+
+## Add a chain
+
+Use when you want to start bridging a new EVM chain (Base, Arbitrum, another testnet, etc.). Assumes the DepositRouter contract is already deployed on that chain and its address is known.
+
+### 1. Register the chain on-chain (admin vote)
+
+> **Admin on-chain call**
+>
+> - **Contract:** `MercataBridge` (`BRIDGE_ADDRESS`)
+> - **Function:** `setChain(string chainName, address custody, address hotWallet, bool enabled, uint256 externalChainId, uint256 lastProcessedBlock, address router)`
+
+Example args:
+
+- `chainName`: `"Base"`
+- `custody`: the Safe address on that chain (external format, `0x…`).
+- `hotWallet`: the hot-wallet Safe address on that chain, or `0x0000…0000` if none.
+- `enabled`: `true`.
+- `externalChainId`: the chain's EVM id (e.g. `8453` for Base mainnet).
+- `lastProcessedBlock`: starting block to scan from (`0` for full history, or a recent block to skip historical scan).
+- `router`: the DepositRouter contract address on that chain.
+
+Admin UI → Vote On Issues → Create New Issue → select `setChain`, fill args, approve.
+
+### 2. Add the RPC URL to the service env
+
+```bash
+CHAIN_<externalChainId>_RPC_URL=https://eth-<network>.g.alchemy.com/v2/<key>
+```
+
+Any RPC endpoint that supports `eth_getLogs`, `eth_blockNumber`, `eth_getTransactionReceipt`, and internal-trace equivalents works.
+
+> **Note:** `configValidator` will refuse to start if the new chain's RPC URL is missing. A non-OK `eth_blockNumber` response is a warning, not a hard error.
+
+### 3. Restart the service
+
+### 4. Verify
+
+- Startup: `ConfigValidator Found N enabled chains` with N incremented.
+- First `AlchemyPolling` cycle logs per-chain activity; `data/lastProcessedBlocks.json` gets an entry for the new chain id.
+- Send a small test deposit on the new chain via its DepositRouter. Within one `bridgeInInterval` cycle:
+  - `BridgeService Successfully deposited 1 deposits`
+  - `Verification ERC20 check …` (or ETH path)
+  - `BridgeService Successfully confirmed 1 deposits`
+  - `VoucherService Successfully minted 25 vouchers for 1 users`
+
+---
+
+## Remove a chain
+
+The clean way to remove a chain is to disable it on-chain. The service filters `getEnabledChains()` on `value->>enabled=eq.true`, so a disabled chain drops out of all four polling loops on the next cycle.
+
+### 1. Disable on-chain
+
+> **Admin on-chain call**
+>
+> - **Contract:** `MercataBridge` (`BRIDGE_ADDRESS`)
+> - **Function:** `toggleChain(uint256 externalChainId, bool enabled)`
+> - **Args:** `externalChainId` = the chain to disable; `enabled` = `false`.
+
+Admin UI → Vote On Issues → Create New Issue → select `toggleChain`, fill args, approve.
+
+`toggleChain` only mutates the `.enabled` flag. Custody, hot wallet, router, chain name, and last-processed block are all preserved.
+
+### 2. Verify
+
+- Next `AlchemyPolling` cycle no longer polls the chain (no per-chain log line).
+- `ConfigValidator Found N enabled chains` on next restart shows N decremented.
+
+> **Note:** To re-enable, repeat `toggleChain(externalChainId, true)` — the existing cursor, custody, and router addresses are preserved.
+
+---
+
+## Add an asset
+
+Use when you want to start bridging a new token on an already-enabled chain.
+
+### Prerequisites
+
+The STRATO-side token must already exist and be enabled:
+
+1. **Token deployed** from BlockApps Token Factory — Admin UI → Tokens → Create New Token (name, symbol, decimals, initial supply: 0). Note the deployed `stratoToken` address.
+2. **Token enabled** — Admin UI → Token Status → set to ACTIVE (status code 2).
+
+Without these, `setAsset` in step 2 will reference a non-existent or inactive token.
+
+### 1. Permit the token on the DepositRouter (Safe multisig)
+
+This is an Ethereum-side transaction executed via the Safe wallet. In the Safe UI, use the "Use Implementation ABI" option to load the DepositRouter's functions.
+
+> **Ethereum on-chain call**
+>
+> - **Contract:** the chain's DepositRouter (find the address in `MercataBridge.chains[chainId].router` on Cirrus)
+> - **Function:** `batchUpdateTokens(address[] tokens, uint96[] minAmounts, bool[] isPermitteds, address[] targetStratoTokens)`
+> - **Args:**
+>   - `tokens`: `[<erc20-address>]`
+>   - `minAmounts`: `[0]`
+>   - `isPermitteds`: `[true]`
+>   - `targetStratoTokens`: `[<strato-side-token-address>]`
+
+Execute the Safe transaction.
+
+**Verification:** call `canDeposit(<token_address>, 1, <targetStratoToken>)` on the DepositRouter via Etherscan or the Safe read-contract tab — should return `true`. This checks both the token permission and the specific route.
+
+### 2. Register the asset on-chain (admin vote)
+
+> **Admin on-chain call**
+>
+> - **Contract:** `MercataBridge` (`BRIDGE_ADDRESS`)
+> - **Function:** `setAsset(bool enabled, uint256 externalChainId, uint256 externalDecimals, string externalName, string externalSymbol, address externalToken, uint256 maxPerWithdrawal, address stratoToken)`
+
+Example args:
+
+- `enabled`: `true`.
+- `externalChainId`: the chain's EVM id.
+- `externalDecimals`: source-chain token decimals (e.g. `6` for USDC, `18` for most ERC20s).
+- `externalName` / `externalSymbol`: display strings (e.g. `"Rocket Pool ETH"`, `"rETH"`).
+- `externalToken`: source-chain token address (`0x…`).
+- `maxPerWithdrawal`: `0` for unlimited, or a safety cap in the token's integer units.
+- `stratoToken`: STRATO-side token address (no `0x`, lowercase).
+
+Admin UI → Vote On Issues → Create New Issue → select `setAsset`, fill args, approve.
+
+### 3. Grant the bridge mint/burn on the STRATO token (admin vote)
+
+The bridge mints on deposit confirmation and burns on withdrawal. Without these whitelist entries, bridged deposits land on STRATO but the token never actually mints.
+
+> **Admin on-chain call (vote 1 — mint)**
+>
+> - **Contract:** `000000000000000000000000000000000000100c` (AdminRegistry)
+> - **Function:** `addWhitelist(address targetAddress, string functionName, address userAddress)`
+> - **Args:** `targetAddress` = the STRATO-side token (no `0x`); `functionName` = `"mint"`; `userAddress` = `0000000000000000000000000000000000001008` (the bridge).
+
+> **Admin on-chain call (vote 2 — burn)**
+>
+> - Same contract, same function.
+> - **Args:** same `targetAddress` and `userAddress`; `functionName` = `"burn"`.
+
+Approve both.
+
+### 4. Verify
+
+- `getAssetInfo` queries return the new asset (check Cirrus `BlockApps-MercataBridge-assets` directly, or wait for the next bridge-in cycle).
+- Trigger a small test deposit on the source chain:
+  - `AlchemyPolling` parses the log and calls `MercataBridge.depositBatch`.
+  - `Verification ERC20 check …` confirms receipt matching.
+  - `BridgeService Successfully confirmed 1 deposits` + `VoucherService Successfully minted …`.
+- STRATO-side balance of the recipient increases by the expected amount.
+
+---
+
+## Remove an asset
+
+The clean way to remove an asset is to disable it on-chain. However, disabling an asset while deposits are in-flight can break the deposit-verification polling cycle, so resolve in-flight deposits first.
+
+> **Warning:** `getDepositsByStatus("1")` fetches all initiated deposits regardless of asset enablement, then maps each against `getAssetInfo` (which only returns enabled assets). If a deposit exists for a just-disabled asset, the mapping throws `"Asset info not found..."` and crashes the **entire** deposit-verification cycle — blocking all other deposits too. Always drain in-flight deposits before disabling.
+
+### 1. Drain in-flight deposits
+
+Before disabling, check Cirrus for any `bridgeStatus=1` deposits referencing this asset's `externalToken` + `externalChainId`. Wait for the next verification cycle to confirm or review them. If any are stuck, use `POST /request-deposit-action` to resolve them manually (see [FLOW.md § The HTTP unblock flow](FLOW.md#the-http-unblock-flow)).
+
+### 2. Revoke DepositRouter permission (Ethereum Safe)
+
+Revoke via `batchUpdateTokens([token], [0], [false], [targetStratoToken])` on the DepositRouter to stop new deposits from reaching the bridge on the Ethereum side. Do this **before** disabling on-chain so no new deposits arrive while you're draining.
+
+### 3. Disable on-chain
+
+> **Admin on-chain call**
+>
+> - **Contract:** `MercataBridge` (`BRIDGE_ADDRESS`)
+> - **Function:** `toggleAsset(address externalToken, uint256 externalChainId, bool enabled)`
+> - **Args:** `externalToken` = source-chain token address; `externalChainId` = the chain id; `enabled` = `false`.
+
+Admin UI → Vote On Issues → Create New Issue → select `toggleAsset`, fill args, approve.
+
+`toggleAsset` only mutates the `.enabled` flag. All other asset fields (decimals, name, symbol, stratoToken, limits) are preserved.
+
+### 4. Verify
+
+- No `bridgeStatus=1` deposits remain for this asset in Cirrus.
+- Withdrawals for this asset can't be requested from the STRATO UI while it's disabled.
+- The deposit-verification cycle continues normally for other assets (no `"Asset info not found"` errors in logs).
+
+> **Note:** To re-enable, repeat `toggleAsset(externalToken, externalChainId, true)` and re-permit on the DepositRouter — all other config is preserved.


### PR DESCRIPTION
Rewrite and expand the bridge service docs so both AI agents and humans can navigate the service without reading every source file. Follows the same structure as the rewards-poller docs (PR #6889).