### PR TITLE
Update upgrade.js for new contract deployment limitations

### DIFF
--- a/mercata/contracts/deploy/upgrade.js
+++ b/mercata/contracts/deploy/upgrade.js
@@ -4,7 +4,7 @@
 require('dotenv').config();
 const config = require('./config');
 const auth = require('./auth');
-const { rest, importer } = require('blockapps-rest');
+const { rest, importer, util } = require('blockapps-rest');
 const fs = require('fs-extra');
 const path = require('path');
 
@@ -147,6 +147,52 @@ async function verifyProxyAndImplementation(tokenObj, proxyAddress, contractName
 }
 
 /**
+ * Deploy the implementation asynchronously and poll for the receipt.
+ *
+ * As of 04-22-2026, Contract deployments route through the caller's user-contract, so the
+ * synchronous `rest.createContract` response is `{}` (the tx hash / txResult
+ * aren't surfaced). `isAsync: true` + `rest.getBlocResults` gives us the raw tx 
+ * receipt whose `contractsCreated` field is the actual deployed implementation address.
+ */
+async function deployImplementationAsync(tokenObj, contractArgs, baseOptions) {
+  const asyncOptions = { ...baseOptions, isAsync: true };
+  const response = await rest.createContract(tokenObj, contractArgs, asyncOptions);
+  const responseArray = Array.isArray(response) ? response : [response];
+  const hashes = responseArray.map((r) => r && r.hash).filter(Boolean);
+  if (hashes.length === 0) {
+    throw new Error(
+      'rest.createContract returned no tx hash; cannot poll for deployment receipt: ' +
+        JSON.stringify(response)
+    );
+  }
+
+  const finalResults = await util.until(
+    (results) => Array.isArray(results) && results.length > 0 &&
+      results.every((r) => r && r.status && r.status !== 'Pending'),
+    (opts) => rest.getBlocResults(tokenObj, hashes, opts),
+    { config, isAsync: true },
+    60000 // 1 minute polling upper bound
+  );
+
+  const final = Array.isArray(finalResults) ? finalResults[0] : finalResults;
+  if (!final || final.status !== 'Success') {
+    throw new Error(
+      'Implementation deployment failed: ' + JSON.stringify(final || finalResults)
+    );
+  }
+
+  const created = final.txResult && final.txResult.contractsCreated;
+  const address = Array.isArray(created) ? created[0] : created;
+  if (!address) {
+    throw new Error(
+      'Deployment succeeded but no contractsCreated entry in receipt: ' +
+        JSON.stringify(final)
+    );
+  }
+  return address;
+}
+
+/**
  * Main upgrade function
  */
 async function main() {
@@ -281,8 +327,8 @@ async function main() {
       query: { username: 'BlockApps' }
     };
 
-    const implementation = await rest.createContract(tokenObj, contractArgs, deployOptions);
-    console.log(`Implementation deployed at: ${implementation.address}\n`);
+    const implementationAddress = await deployImplementationAsync(tokenObj, contractArgs, deployOptions);
+    console.log(`Implementation deployed at: ${implementationAddress}\n`);
 
     // Step 2: Upgrade each proxy to point to the new implementation
     const results = [];
@@ -295,12 +341,12 @@ async function main() {
       args['OVERRIDE-CHECKS'] || await verifyProxyAndImplementation(tokenObj, proxyAddress, contractName);
 
       console.log(`Upgrading proxy at ${proxyAddress}...`);
-      console.log(`New implementation: ${implementation.address}`);
+      console.log(`New implementation: ${implementationAddress}`);
 
       const callArgs = {
         contract: { address: proxyAddress, name: 'Proxy' },
         method: 'setLogicContract',
-        args: { _logicContract: implementation.address },
+        args: { _logicContract: implementationAddress },
         txParams: {
           gasPrice: config.gasPrice,
           gasLimit: config.gasLimit,
@@ -324,12 +370,12 @@ async function main() {
       }
 
       console.log(`Proxy Address: ${proxyAddress}`);
-      console.log(`New Implementation: ${implementation.address}`);
+      console.log(`New Implementation: ${implementationAddress}`);
       console.log('================================\n');
 
       results.push({
         proxyAddress,
-        newImplementation: implementation.address,
+        newImplementation: implementationAddress,
         contractName,
         contractFile,
         upgradeTime: new Date().toISOString(),


### PR DESCRIPTION
With deployments routed through the `User` contract, the immediate return from `createContract` may not include a usable address object. The authoritative deployed address shows up on the transaction result as `txResult.contractsCreated[0]`. Polling `getBlocResults` is how you wait until that receipt is available and complete.