### PR TITLE
Log errors for asset/chain configs independently, instead of preventi…

### DIFF
--- a/mercata/services/bridge/src/services/cirrusService.ts
+++ b/mercata/services/bridge/src/services/cirrusService.ts
@@ -8,6 +8,7 @@ import {
   AssetInfo,
   BridgeInfo,
 } from "../types";
+import { logError } from "../utils/logger";
 
 const { bridge, oracle } = config;
 const { address: bridgeAddress } = bridge;
@@ -129,27 +130,41 @@ export const getDepositsByStatus = async (
     getEnabledChains(),
   ]);
 
-  return data.map(
+  // Skip (and log) deposits whose asset or chain can't be resolved instead of
+  // throwing — one poison-pill row must not stall the entire batch.
+  return data.flatMap(
     ({ value: v, key: externalChainId, key2: externalTxHash }) => {
       const externalToken = v?.externalToken;
       const asset = assetMapping.get(`${externalToken}:${externalChainId}`);
 
-      if (!asset || !asset?.externalDecimals)
-        throw new Error(
-          `Asset info not found for external token ${externalToken} on chain ${externalChainId}`
+      if (!asset || !asset?.externalDecimals) {
+        logError(
+          "CirrusService",
+          new Error(
+            `Asset info not found for external token ${externalToken} on chain ${externalChainId}`
+          ),
+          { operation: "getDepositsByStatus", externalTxHash, externalChainId }
         );
+        return [];
+      }
 
       const chainInfo = enabledChains.get(Number(externalChainId));
-      if (!chainInfo || !chainInfo?.depositRouter)
-        throw new Error(`Chain info not found for chain ${externalChainId}`);
+      if (!chainInfo || !chainInfo?.depositRouter) {
+        logError(
+          "CirrusService",
+          new Error(`Chain info not found for chain ${externalChainId}`),
+          { operation: "getDepositsByStatus", externalTxHash, externalChainId }
+        );
+        return [];
+      }
 
-      return {
+      return [{
         ...v,
         externalChainId,
         externalTxHash,
         externalDecimals: asset.externalDecimals,
         depositRouter: chainInfo.depositRouter,
-      };
+      }];
     }
   );
 };

--- a/mercata/services/bridge/src/services/safeService.ts
+++ b/mercata/services/bridge/src/services/safeService.ts
@@ -16,12 +16,22 @@ export const createSafeTransactions = async (
 
   const allTransactionProposals: SafeTransactionData[] = [];
 
+  // Isolate per-chain failures: a misconfigured chain (e.g. missing
+  // externalBridgeVault) must not block other chains in the same batch.
   for (const [externalChainId, chainWithdrawals] of withdrawalsByChain) {
-    const chainProposals = await createWithdrawalProposals(
-      externalChainId,
-      chainWithdrawals as NonEmptyArray<WithdrawalInfo>
-    );
-    allTransactionProposals.push(...chainProposals);
+    try {
+      const chainProposals = await createWithdrawalProposals(
+        externalChainId,
+        chainWithdrawals as NonEmptyArray<WithdrawalInfo>
+      );
+      allTransactionProposals.push(...chainProposals);
+    } catch (err) {
+      logError("SafeService", err as Error, {
+        operation: "createWithdrawalProposals",
+        externalChainId,
+        withdrawalCount: chainWithdrawals.length,
+      });
+    }
   }
 
   logInfo(


### PR DESCRIPTION
Log errors for asset/chain configs independently, instead of preventing other assets from going through.

Fix authored by Opus4.7-High-200k in Cursor.

Not yet tested