### PR TITLE
Harden AdminRegistry

### DIFF
--- a/mercata/backend/src/api/controllers/user.controller.ts
+++ b/mercata/backend/src/api/controllers/user.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getAdmin, isUserAdmin, addAdmin, removeAdmin, addGuardian, removeGuardian, castVoteOnIssue, castVoteOnIssueById, dismissIssue, getOpenIssues,
+import { getAdmin, isUserAdmin, addAdmin, removeAdmin, addGuardian, removeGuardian, castVoteOnIssue, castVoteOnIssueById, dismissIssue, executeIssue, withdrawVote, getOpenIssues,
          getExecutedIssues, contractSearch, getContractDetails,
  } from "../services/user.service";
 import { validateUserAddress, validateAddressField } from "../validators/common.validators";
@@ -194,6 +194,56 @@ class UserController {
       res.status(RestStatus.OK).json({ 
         message: "Issue dismissed successfully", 
         issueId,
+        status: result.status,
+        hash: result.hash,
+      });
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async executeIssue(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: actorAddress } = req;
+      const { target, func, args } = req.body;
+      validateAddressField(target);
+
+      const result = await executeIssue(accessToken, actorAddress as string, target, func, args);
+      res.status(RestStatus.OK).json({
+        message: "Issue executed successfully",
+        target,
+        func,
+        args,
+        status: result.status,
+        hash: result.hash,
+      });
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async withdrawVote(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: actorAddress } = req;
+      const { target, func, args } = req.body;
+      validateAddressField(target);
+
+      const result = await withdrawVote(accessToken, actorAddress as string, target, func, args);
+      res.status(RestStatus.OK).json({
+        message: "Vote withdrawn successfully",
+        target,
+        func,
+        args,
         status: result.status,
         hash: result.hash,
       });

--- a/mercata/backend/src/api/controllers/user.controller.ts
+++ b/mercata/backend/src/api/controllers/user.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getAdmin, isUserAdmin, addAdmin, removeAdmin, castVoteOnIssue, castVoteOnIssueById, dismissIssue, getOpenIssues,
+import { getAdmin, isUserAdmin, addAdmin, removeAdmin, addGuardian, removeGuardian, castVoteOnIssue, castVoteOnIssueById, dismissIssue, getOpenIssues,
          getExecutedIssues, contractSearch, getContractDetails,
  } from "../services/user.service";
 import { validateUserAddress, validateAddressField } from "../validators/common.validators";
@@ -76,6 +76,54 @@ class UserController {
       const result = await removeAdmin(accessToken, actorAddress as string, userAddress);
       res.status(RestStatus.OK).json({ 
         message: "Admin removed successfully", 
+        userAddress,
+        status: result.status,
+        hash: result.hash
+      });
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async addGuardian(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: actorAddress } = req;
+      const { userAddress } = req.body;
+
+      validateUserAddress(userAddress);
+
+      const result = await addGuardian(accessToken, actorAddress as string, userAddress);
+      res.status(RestStatus.CREATED).json({
+        message: "Guardian added successfully",
+        userAddress,
+        status: result.status,
+        hash: result.hash
+      });
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async removeGuardian(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: actorAddress } = req;
+      const { userAddress } = req.body;
+
+      validateUserAddress(userAddress);
+
+      const result = await removeGuardian(accessToken, actorAddress as string, userAddress);
+      res.status(RestStatus.OK).json({
+        message: "Guardian removed successfully",
         userAddress,
         status: result.status,
         hash: result.hash

--- a/mercata/backend/src/api/routes/user.routes.ts
+++ b/mercata/backend/src/api/routes/user.routes.ts
@@ -265,6 +265,10 @@ router.post("/admin/vote", authHandler.authorizeRequest(), UserController.castVo
  */
 router.post("/admin/vote/by-id", authHandler.authorizeRequest(), UserController.castVoteOnIssueById);
 
+router.post("/admin/issues/execute", authHandler.authorizeRequest(), UserController.executeIssue);
+
+router.post("/admin/vote/withdraw", authHandler.authorizeRequest(), UserController.withdrawVote);
+
 /**
  * @openapi
  * /user/admin/dismiss:

--- a/mercata/backend/src/api/routes/user.routes.ts
+++ b/mercata/backend/src/api/routes/user.routes.ts
@@ -98,6 +98,59 @@ router.delete("/admin", authHandler.authorizeRequest(), UserController.removeAdm
 
 /**
  * @openapi
+ * /user/admin/guardian:
+ *   post:
+ *     summary: Propose granting guardian access
+ *     tags: [Admin]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userAddress
+ *             properties:
+ *               userAddress:
+ *                 type: string
+ *                 description: Address to promote to guardian
+ *     responses:
+ *       201:
+ *         description: Guardian grant transaction payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties: true
+ *   delete:
+ *     summary: Propose revoking guardian access
+ *     tags: [Admin]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userAddress
+ *             properties:
+ *               userAddress:
+ *                 type: string
+ *                 description: Address to revoke guardian rights from
+ *     responses:
+ *       200:
+ *         description: Guardian revoke transaction payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties: true
+ */
+router.post("/admin/guardian", authHandler.authorizeRequest(), UserController.addGuardian);
+router.delete("/admin/guardian", authHandler.authorizeRequest(), UserController.removeGuardian);
+
+/**
+ * @openapi
  * /user/admin/contract/search:
  *   get:
  *     summary: Search contracts by name or address

--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -7,6 +7,57 @@ import { extractContractName } from "../../utils/utils";
 import JSONBig from "json-bigint";
 const { AdminRegistry, adminRegistry } = constants;
 
+const normalizeIssueArg = (arg: any, typeInfo: any): any => {
+  const tag = typeInfo?.tag?.toLowerCase();
+
+  if (tag === "address" && typeof arg === "string" && /^[0-9a-fA-F]{40}$/.test(arg)) {
+    return `0x${arg}`;
+  }
+
+  if (tag === "array" && Array.isArray(arg)) {
+    return arg.map((entry) => normalizeIssueArg(entry, typeInfo?.entry));
+  }
+
+  return arg;
+};
+
+const normalizeIssueArgs = async (
+  accessToken: string,
+  target: string,
+  func: string,
+  args: any[],
+): Promise<any[]> => {
+  if (!Array.isArray(args)) {
+    console.log("[AdminVoteDebug] issue args were not an array", { target, func, args });
+    return args;
+  }
+
+  const contractDetails = await getContractDetails(accessToken, target);
+  const functionInfo = (contractDetails as any)?._functions?.[func];
+  const funcArgs = functionInfo?._funcArgs as Array<[string, { type?: any }]> | undefined;
+
+  if (!Array.isArray(funcArgs)) {
+    console.log("[AdminVoteDebug] missing function metadata for issue args", {
+      target,
+      func,
+      args,
+      functionNames: Object.keys((contractDetails as any)?._functions || {}),
+    });
+    return args;
+  }
+
+  const normalizedArgs = args.map((arg, index) => normalizeIssueArg(arg, funcArgs[index]?.[1]?.type));
+  console.log("[AdminVoteDebug] normalized issue args", {
+    target,
+    func,
+    args,
+    normalizedArgs,
+    funcArgs: funcArgs.map(([name, metadata]) => ({ name, type: metadata?.type })),
+  });
+
+  return normalizedArgs;
+};
+
 export const isUserAdmin = async (
   accessToken: string,
   userAddress: string
@@ -223,6 +274,9 @@ export const executeIssue = async (
   func: string,
   args: any[],
 ): Promise<{ status: string; hash: string }> => {
+  console.log("[AdminVoteDebug] executeIssue service input", { userAddress, target, func, args });
+  const normalizedArgs = await normalizeIssueArgs(accessToken, target, func, args);
+
   const tx = await buildFunctionTx({
     contractName: extractContractName(AdminRegistry),
     contractAddress: adminRegistry,
@@ -230,9 +284,10 @@ export const executeIssue = async (
     args: {
       _target: target,
       _func: func,
-      _args: args,
+      _args: normalizedArgs,
     },
   }, userAddress, accessToken);
+  console.log("[AdminVoteDebug] executeIssue tx args", tx.txs?.[0]?.payload?.args);
 
   const { status, hash } = await postAndWaitForTx(accessToken, () =>
     strato.post(accessToken, StratoPaths.transactionParallel, tx)
@@ -248,6 +303,9 @@ export const withdrawVote = async (
   func: string,
   args: any[],
 ): Promise<{ status: string; hash: string }> => {
+  console.log("[AdminVoteDebug] withdrawVote service input", { userAddress, target, func, args });
+  const normalizedArgs = await normalizeIssueArgs(accessToken, target, func, args);
+
   const tx = await buildFunctionTx({
     contractName: extractContractName(AdminRegistry),
     contractAddress: adminRegistry,
@@ -255,9 +313,10 @@ export const withdrawVote = async (
     args: {
       _target: target,
       _func: func,
-      _args: args,
+      _args: normalizedArgs,
     },
   }, userAddress, accessToken);
+  console.log("[AdminVoteDebug] withdrawVote tx args", tx.txs?.[0]?.payload?.args);
 
   const { status, hash } = await postAndWaitForTx(accessToken, () =>
     strato.post(accessToken, StratoPaths.transactionParallel, tx)

--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -112,6 +112,58 @@ export const removeAdmin = async (
   }
 };
 
+// Add a new guardian to the registry
+export const addGuardian = async (
+  accessToken: string,
+  userAddress: string,
+  guardianAddress: string
+): Promise<{ status: string; hash: string }> => {
+  try {
+    const tx = await buildFunctionTx({
+      contractName: extractContractName(AdminRegistry),
+      contractAddress: adminRegistry,
+      method: "addGuardian",
+      args: {
+        _guardian: guardianAddress,
+      },
+    }, userAddress, accessToken);
+
+    const { status, hash } = await postAndWaitForTx(accessToken, () =>
+      strato.post(accessToken, StratoPaths.transactionParallel, tx)
+    );
+
+    return { status, hash };
+  } catch (error) {
+    throw error;
+  }
+};
+
+// Remove a guardian from the registry
+export const removeGuardian = async (
+  accessToken: string,
+  userAddress: string,
+  guardianAddress: string
+): Promise<{ status: string; hash: string }> => {
+  try {
+    const tx = await buildFunctionTx({
+      contractName: extractContractName(AdminRegistry),
+      contractAddress: adminRegistry,
+      method: "removeGuardian",
+      args: {
+        _guardian: guardianAddress,
+      },
+    }, userAddress, accessToken);
+
+    const { status, hash } = await postAndWaitForTx(accessToken, () =>
+      strato.post(accessToken, StratoPaths.transactionParallel, tx)
+    );
+
+    return { status, hash };
+  } catch (error) {
+    throw error;
+  }
+};
+
 // Cast a vote on an issue in the registry
 export const castVoteOnIssue = async (
   accessToken: string,
@@ -212,6 +264,24 @@ export const castVoteOnIssueById = async (
       return await removeAdmin(accessToken, userAddress, adminAddress);
     }
 
+    // If func is _addGuardian, call the addGuardian endpoint directly
+    if (func === '_addGuardian') {
+      const guardianAddress = Array.isArray(args) ? args[0] : args._guardian;
+      if (!guardianAddress) {
+        throw new Error('Guardian address not found in args');
+      }
+      return await addGuardian(accessToken, userAddress, guardianAddress);
+    }
+
+    // If func is _removeGuardian, call the removeGuardian endpoint directly
+    if (func === '_removeGuardian') {
+      const guardianAddress = Array.isArray(args) ? args[0] : args._guardian;
+      if (!guardianAddress) {
+        throw new Error('Guardian address not found in args');
+      }
+      return await removeGuardian(accessToken, userAddress, guardianAddress);
+    }
+
     // Get contract name from Cirrus
     const contractResponse = await cirrus.get(accessToken, "contract", {
       params: {
@@ -277,7 +347,7 @@ export const getOpenIssues = async (
     const response = await cirrus.get(accessToken, "/" + AdminRegistry, {
       params: {
         address: `eq.${adminRegistry}`,
-        select: `*,admins:${AdminRegistry}-admins(address:value),votes:${AdminRegistry}-votes(block_timestamp,issueId:key,index:key2,voter:value),thresholds:${AdminRegistry}-votingThresholds(target:key,func:key2,threshold:value)`,
+        select: `*,admins:${AdminRegistry}-admins(address:value),guardians:${AdminRegistry}-guardians(address:value),votes:${AdminRegistry}-votes(block_timestamp,issueId:key,index:key2,voter:value),thresholds:${AdminRegistry}-votingThresholds(target:key,func:key2,threshold:value)`,
         ['votes.value']: 'neq.""',
         ['votes.value->>length']: 'is.null',
       },
@@ -291,8 +361,9 @@ export const getOpenIssues = async (
       return {};
     }
 
-    const { admins: adminsRaw, votes, defaultVotingThresholdBps, thresholds } = response.data[0];
+    const { admins: adminsRaw, guardians: guardiansRaw, votes, defaultVotingThresholdBps, thresholds } = response.data[0];
     const admins = adminsRaw.filter((admin: any) => admin.address && admin.address !== 'Unknown'); // remove blank admins
+    const guardians = (guardiansRaw || []).filter((guardian: any) => guardian.address && guardian.address !== 'Unknown'); // remove blank guardians
 
     const issueIds = new Set(votes.map((v: any) => v.issueId));
 
@@ -322,6 +393,7 @@ export const getOpenIssues = async (
 
     return { 
       admins, 
+      guardians,
       votes, 
       globalThreshold: defaultVotingThresholdBps, 
       thresholds, 

--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -216,6 +216,56 @@ export const dismissIssue = async (
   return { status, hash };
 };
 
+export const executeIssue = async (
+  accessToken: string,
+  userAddress: string,
+  target: string,
+  func: string,
+  args: any[],
+): Promise<{ status: string; hash: string }> => {
+  const tx = await buildFunctionTx({
+    contractName: extractContractName(AdminRegistry),
+    contractAddress: adminRegistry,
+    method: "executeIssue",
+    args: {
+      _target: target,
+      _func: func,
+      _args: args,
+    },
+  }, userAddress, accessToken);
+
+  const { status, hash } = await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, tx)
+  );
+
+  return { status, hash };
+};
+
+export const withdrawVote = async (
+  accessToken: string,
+  userAddress: string,
+  target: string,
+  func: string,
+  args: any[],
+): Promise<{ status: string; hash: string }> => {
+  const tx = await buildFunctionTx({
+    contractName: extractContractName(AdminRegistry),
+    contractAddress: adminRegistry,
+    method: "withdrawVote",
+    args: {
+      _target: target,
+      _func: func,
+      _args: args,
+    },
+  }, userAddress, accessToken);
+
+  const { status, hash } = await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, tx)
+  );
+
+  return { status, hash };
+};
+
 // Cast a vote on an issue by issueId
 export const castVoteOnIssueById = async (
   accessToken: string,
@@ -340,6 +390,16 @@ export const castVoteOnIssueById = async (
   }
 };
 
+const parseTimelock = (row: any) => {
+  const raw = row?.timelock || row?.value || {};
+  return {
+    issueId: row?.issueId || row?.key,
+    queuedAt: Number(row?.queuedAt ?? raw?.queuedAt ?? 0),
+    executableAt: Number(row?.executableAt ?? raw?.executableAt ?? 0),
+    expiresAt: Number(row?.expiresAt ?? raw?.expiresAt ?? 0),
+  };
+};
+
 export const getOpenIssues = async (
   accessToken: string,
 ): Promise<object> => {
@@ -361,17 +421,37 @@ export const getOpenIssues = async (
       return {};
     }
 
-    const { admins: adminsRaw, guardians: guardiansRaw, votes, defaultVotingThresholdBps, thresholds } = response.data[0];
+    const { admins: adminsRaw = [], guardians: guardiansRaw = [], votes: votesRaw = [], defaultVotingThresholdBps, thresholds = [] } = response.data[0];
+    const votes = Array.isArray(votesRaw) ? votesRaw : [];
     const admins = adminsRaw.filter((admin: any) => admin.address && admin.address !== 'Unknown'); // remove blank admins
     const guardians = (guardiansRaw || []).filter((guardian: any) => guardian.address && guardian.address !== 'Unknown'); // remove blank guardians
 
     const issueIds = new Set(votes.map((v: any) => v.issueId));
 
-    const issuesResponse = await cirrus.get(accessToken, "/" + AdminRegistry + "-IssueCreated", {
-      params: {
-        issueId: `in.(${[...issueIds].join(',')})`
-      },
-    });
+    const [issuesResponse, timelocksResponse] = await Promise.all([
+      issueIds.size > 0
+        ? cirrus.get(accessToken, "/" + AdminRegistry + "-IssueCreated", {
+            params: {
+              issueId: `in.(${[...issueIds].join(',')})`
+            },
+          })
+        : Promise.resolve({ data: [] }),
+      issueIds.size > 0
+        ? cirrus.get(accessToken, "/" + AdminRegistry + "-timelocks", {
+            params: {
+              key: `in.(${[...issueIds].join(',')})`,
+              select: "issueId:key,timelock:value,queuedAt:value->>queuedAt,executableAt:value->>executableAt,expiresAt:value->>expiresAt",
+            },
+          })
+        : Promise.resolve({ data: [] }),
+    ]);
+
+    const timelocksMap = new Map(
+      (timelocksResponse?.data || [])
+        .map(parseTimelock)
+        .filter((timelock: any) => timelock.issueId)
+        .map((timelock: any) => [timelock.issueId, timelock])
+    );
 
     // Deduplicate issues by issueId, keeping the most recent one based on block_number
     const issuesMap = new Map();
@@ -380,7 +460,10 @@ export const getOpenIssues = async (
       if (!existingIssue || 
           (issue.block_number && existingIssue.block_number && 
            Number(issue.block_number) > Number(existingIssue.block_number))) {
-        issuesMap.set(issue.issueId, issue);
+        issuesMap.set(issue.issueId, {
+          ...issue,
+          timelock: timelocksMap.get(issue.issueId) || { queuedAt: 0, executableAt: 0, expiresAt: 0 },
+        });
       }
     });
     const uniqueIssues = Array.from(issuesMap.values()).sort((a, b) => {
@@ -390,6 +473,8 @@ export const getOpenIssues = async (
       }
       return 0;
     });
+    const queuedIssues = uniqueIssues.filter((issue: any) => Number(issue.timelock?.executableAt || 0) > 0);
+    const openIssues = uniqueIssues.filter((issue: any) => Number(issue.timelock?.executableAt || 0) === 0);
 
     return { 
       admins, 
@@ -397,7 +482,8 @@ export const getOpenIssues = async (
       votes, 
       globalThreshold: defaultVotingThresholdBps, 
       thresholds, 
-      issues: uniqueIssues 
+      issues: openIssues,
+      queuedIssues,
     };
   } catch (error) {
     console.log(error);

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -12,7 +12,7 @@ contract record AdminRegistry is Ownable {
     }
 
     address[] public record admins;
-    
+
     mapping (address => uint) public record adminMap;
     
     mapping (string => address[]) public record votes; // votes[issueId] = [voter1, voter2, ...]
@@ -111,10 +111,6 @@ contract record AdminRegistry is Ownable {
             }
 
             if (_shouldExecute(issueId, _target, _func, _args)) {
-                if (admins.length == 1) {
-                    variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
-                    return (true, ret);
-                }
                 _queueIssue(sender, issueId, _target, _func, _args);
                 return (false, issueId);
             } else {

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -3,7 +3,7 @@ import "../../abstract/ERC20/access/Ownable.sol";
 
 contract record AdminRegistry is Ownable {
     uint public constant MINIMUM_DELAY = 86400; // 24 hours
-    uint public constant GRACE_PERIOD = 1209600; // 14 days
+    uint public constant GRACE_PERIOD = 86400; // 24 hours
     uint public constant MIN_VOTING_THRESHOLD_BPS = 5000; // 50%
     uint public constant MIN_ADMIN_COUNT = 3;
 
@@ -26,6 +26,8 @@ contract record AdminRegistry is Ownable {
     mapping (string => Timelock) public record timelocks; // timelocks[issueId] = Timelock(queuedAt, executableAt, expiresAt)
     
     mapping (address => mapping (string => mapping (address => bool))) public record whitelist; 
+
+    mapping (address => mapping (string => bool)) public record instantFunctions;
     
     mapping (address => mapping (string => uint)) public record votingThresholds;
 
@@ -85,9 +87,11 @@ contract record AdminRegistry is Ownable {
     }
 
     function castVoteOnIssue(address _target, string _func, variadic _args) public returns (bool, variadic) {
-        if (adminMap[msg.sender] != 0 || adminMap[_target] != 0) {
+        bool senderCanGovern = adminMap[msg.sender] != 0 || isGuardian(msg.sender);
+        bool targetCanGovern = adminMap[_target] != 0 || isGuardian(_target);
+        if (senderCanGovern || targetCanGovern) {
             address sender = msg.sender;
-            if (adminMap[msg.sender] == 0) {
+            if (!senderCanGovern) {
                 if (_target != tx.origin) {
                     bool authorizationGranted = false;
                     try {
@@ -101,22 +105,28 @@ contract record AdminRegistry is Ownable {
                 _target = msg.sender;
             }
             string issueId = _getIssueId(_target, _func, _args);
-            require(timelocks[issueId].executableAt == 0, "Cannot vote on queued issue");
-            bool hasVoted = votesMap[issueId][sender] != 0;
-
-            _createIssue(sender, issueId, _target, _func, _args);
-
-            if (!hasVoted) {
-                votes[issueId].push(sender);
-                votesMap[issueId][sender] = votes[issueId].length;
-                emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
-            }
-
-            if (_shouldExecute(issueId, _target, _func, _args)) {
-                _queueIssue(sender, issueId, _target, _func, _args);
-                return (false, issueId);
+            if (_shouldExecuteInstantly(sender, _target, _func)) {
+                variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
+                return (true, ret);
             } else {
-                return (false, issueId);
+                require(adminMap[sender] != 0, "Only admins can vote on non-instant issues");
+                require(timelocks[issueId].executableAt == 0, "Cannot vote on queued issue");
+                bool hasVoted = votesMap[issueId][sender] != 0;
+
+                _createIssue(sender, issueId, _target, _func, _args);
+
+                if (!hasVoted) {
+                    votes[issueId].push(sender);
+                    votesMap[issueId][sender] = votes[issueId].length;
+                    emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
+                }
+
+                if (_shouldExecute(issueId, _target, _func, _args)) {
+                    _queueIssue(sender, issueId, _target, _func, _args);
+                    return (false, issueId);
+                } else {
+                    return (false, issueId);
+                }
             }
         } else {
             // Non-admin path: only execute if whitelisted
@@ -131,6 +141,15 @@ contract record AdminRegistry is Ownable {
             variadic ret = _executeIssue(sender, issueId, target, _func, _args);
             return (true, ret);
         }
+    }
+
+    function isGuardian(address _account) public virtual returns (bool) {
+        // TODO for the agent that will add Guardian logic: remove this function prob and just replace its usage with whatever data path exposes guardian statuses
+        return false;
+    }
+
+    function _shouldExecuteInstantly(address _sender, address _target, string _func) internal returns (bool) {
+        return instantFunctions[_target][_func] && (adminMap[_sender] != 0 || isGuardian(_sender));
     }
 
     function _shouldExecute(string _issueId, address _target, string _func, variadic _args) internal returns (bool) {
@@ -274,8 +293,11 @@ contract record AdminRegistry is Ownable {
                 _func != "_removeVote" &&
                 _func != "_queueIssue" &&
                 _func != "_shouldExecute" &&
+                _func != "_shouldExecuteInstantly" &&
                 _func != "_swapAdmin" &&
                 _func != "executeIssue" &&
+                _func != "isGuardian" &&
+                _func != "setInstantFunction" &&
                 _func != "setVotingThreshold" &&
                 _func != "setDefaultVotingThresholdBps" &&
                 _func != "withdrawVote" &&
@@ -289,6 +311,11 @@ contract record AdminRegistry is Ownable {
 
     function removeWhitelist(address _target, string _func, address _user) external onlyOwner {
         whitelist[_target][_func][_user] = false;
+    }
+
+    function setInstantFunction(address _target, string _func, bool _enabled) external onlyOwner {
+        require(_target != address(this), "Cannot add governance functions for instant execution");
+        instantFunctions[_target][_func] = _enabled;
     }
 
     function setVotingThreshold(address _target, string _func, uint _votingThresholdBps) external onlyOwner {

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -2,8 +2,10 @@ import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 
 contract record AdminRegistry is Ownable {
-    uint public constant MINIMUM_DELAY = 172800; // 2 days
+    uint public constant MINIMUM_DELAY = 86400; // 24 hours
     uint public constant GRACE_PERIOD = 1209600; // 14 days
+    uint public constant MIN_VOTING_THRESHOLD_BPS = 5000; // 50%
+    uint public constant MIN_ADMIN_COUNT = 3;
 
     struct Timelock {
         uint queuedAt;
@@ -236,7 +238,7 @@ contract record AdminRegistry is Ownable {
     }
 
     function _removeAdmin(address _admin) external onlyOwner {
-        require(admins.length > 1, "Cannot remove the last admin");
+        require(admins.length > MIN_ADMIN_COUNT, "Below min admin count");
         uint index = adminMap[_admin];
         require(index > 0, "Account is not an admin");
         address swap = admins[admins.length - 1];
@@ -290,13 +292,13 @@ contract record AdminRegistry is Ownable {
     }
 
     function setVotingThreshold(address _target, string _func, uint _votingThresholdBps) external onlyOwner {
-        require(_votingThresholdBps > 0, "Voting threshold must be greater than 0");
+        require(_votingThresholdBps >= MIN_VOTING_THRESHOLD_BPS, "Threshold too low");
         require(_votingThresholdBps <= 10000, "Voting threshold must be less than 100%");
         votingThresholds[_target][_func] = _votingThresholdBps;
     }
 
     function setDefaultVotingThresholdBps(uint _defaultVotingThresholdBps) external onlyOwner {
-        require(_defaultVotingThresholdBps > 0, "Default voting threshold must be greater than 0");
+        require(_defaultVotingThresholdBps >= MIN_VOTING_THRESHOLD_BPS, "Threshold too low");
         require(_defaultVotingThresholdBps <= 10000, "Default voting threshold must be less than 100%");
         defaultVotingThresholdBps = _defaultVotingThresholdBps;
     }

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -33,12 +33,20 @@ contract record AdminRegistry is Ownable {
 
     uint public defaultVotingThresholdBps = 6000; // 3/5
 
+    address[] public record guardians;
+    mapping (address => uint) public record guardianMap;
+    mapping (address => mapping (string => bool)) public record guardianAllowlist;
+
     event IssueCreated(address sender, address creator, string issueId, address target, string func, variadic args);
     event IssueVoted(address sender, address voter, string issueId, address target, string func, variadic args);
     event IssueQueued(address sender, address queueExecutor, string issueId, address target, string func, uint executableAt, uint expiresAt, variadic args);
     event IssueExecuted(address sender, address executor, string issueId, address target, string func, variadic args);
     event IssueVoteWithdrawn(address sender, address voter, string issueId);
     event IssueDismissed(address sender, string issueId);
+    event GuardianAdded(address guardian);
+    event GuardianRemoved(address guardian);
+    event GuardianAllowlistSet(address target, string func, bool allowed);
+    event InstantFunctionSet(address target, string func, bool enabled);
 
     bool public initialized = false;
 
@@ -72,7 +80,19 @@ contract record AdminRegistry is Ownable {
         castVoteOnIssue(this, "_swapAdmin", _adminToReplace, _newAdmin);
     }
 
-    function isAdminAddress(address _admin) external returns (bool) {
+    function addGuardian(address _guardian) external {
+        castVoteOnIssue(this, "_addGuardian", _guardian);
+    }
+
+    function removeGuardian(address _guardian) external {
+        castVoteOnIssue(this, "_removeGuardian", _guardian);
+    }
+
+    function setGuardianAllowed(address _target, string _func, bool _allowed) external {
+        castVoteOnIssue(this, "_setGuardianAllowed", _target, _func, _allowed);
+    }
+
+    function isAdminAddress(address _admin) public returns (bool) {
         return adminMap[_admin] > 0;
     }
 
@@ -144,12 +164,14 @@ contract record AdminRegistry is Ownable {
     }
 
     function isGuardian(address _account) public virtual returns (bool) {
-        // TODO for the agent that will add Guardian logic: remove this function prob and just replace its usage with whatever data path exposes guardian statuses
-        return false;
+        return guardianMap[_account] > 0;
     }
 
     function _shouldExecuteInstantly(address _sender, address _target, string _func) internal returns (bool) {
-        return instantFunctions[_target][_func] && (adminMap[_sender] != 0 || isGuardian(_sender));
+        if (!instantFunctions[_target][_func]) return false;
+        if (isAdminAddress(_sender)) return true;
+        if (isGuardian(_sender)) return guardianAllowlist[_target][_func];
+        return false;
     }
 
     function _shouldExecute(string _issueId, address _target, string _func, variadic _args) internal returns (bool) {
@@ -252,6 +274,7 @@ contract record AdminRegistry is Ownable {
     function _addAdmin(address _admin) external onlyOwner {
         require(_admin != address(0), "Invalid admin address");
         require(adminMap[_admin] == 0, "Account is already an admin");
+        require(guardianMap[_admin] == 0, "Guardian cannot be an admin");
         admins.push(_admin);
         adminMap[_admin] = admins.length;
     }
@@ -279,19 +302,53 @@ contract record AdminRegistry is Ownable {
         adminMap[_adminToReplace] = 0;
     }
 
+    function _addGuardian(address _guardian) external onlyOwner {
+        require(_guardian != address(0), "Invalid guardian address");
+        require(guardianMap[_guardian] == 0, "Account is already a guardian");
+        require(adminMap[_guardian] == 0, "Admin cannot be a guardian");
+        guardians.push(_guardian);
+        guardianMap[_guardian] = guardians.length;
+        emit GuardianAdded(_guardian);
+    }
+
+    function _removeGuardian(address _guardian) external onlyOwner {
+        uint index = guardianMap[_guardian];
+        require(index > 0, "Account is not a guardian");
+        address swap = guardians[guardians.length - 1];
+        guardians[index - 1] = swap;
+        guardianMap[swap] = index;
+        guardianMap[_guardian] = 0;
+        guardians[guardians.length - 1] = address(0);
+        guardians.length -= 1;
+        emit GuardianRemoved(_guardian);
+    }
+
+    function _setGuardianAllowed(address _target, string _func, bool _allowed) external onlyOwner {
+        require(_target != address(this), "Cannot allowlist AdminRegistry self-calls");
+        if (_allowed && !instantFunctions[_target][_func]) {
+            instantFunctions[_target][_func] = true;
+            emit InstantFunctionSet(_target, _func, true);
+        }
+        guardianAllowlist[_target][_func] = _allowed;
+        emit GuardianAllowlistSet(_target, _func, _allowed);
+    }
+
     function addWhitelist(address _target, string _func, address _user) external onlyOwner {
         if (_target == address(this)) {
             require(
                 _func != "addWhitelist" &&
                 _func != "removeWhitelist" &&
                 _func != "_addAdmin" &&
+                _func != "_addGuardian" &&
                 _func != "_clearIssue" &&
                 _func != "_clearTimelock" &&
                 _func != "_createIssue" &&
                 _func != "_executeIssue" &&
                 _func != "_removeAdmin" &&
+                _func != "_removeGuardian" &&
                 _func != "_removeVote" &&
                 _func != "_queueIssue" &&
+                _func != "_setGuardianAllowed" &&
                 _func != "_shouldExecute" &&
                 _func != "_shouldExecuteInstantly" &&
                 _func != "_swapAdmin" &&
@@ -316,6 +373,7 @@ contract record AdminRegistry is Ownable {
     function setInstantFunction(address _target, string _func, bool _enabled) external onlyOwner {
         require(_target != address(this), "Cannot add governance functions for instant execution");
         instantFunctions[_target][_func] = _enabled;
+        emit InstantFunctionSet(_target, _func, _enabled);
     }
 
     function setVotingThreshold(address _target, string _func, uint _votingThresholdBps) external onlyOwner {

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -2,22 +2,38 @@ import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 
 contract record AdminRegistry is Ownable {
+    uint public constant MINIMUM_DELAY = 172800; // 2 days
+    uint public constant GRACE_PERIOD = 1209600; // 14 days
+
+    struct Timelock {
+        uint queuedAt;
+        uint executableAt;
+        uint expiresAt;
+    }
+
     address[] public record admins;
+    
     mapping (address => uint) public record adminMap;
-
-    mapping (string => address[]) public record votes;
-    mapping (string => mapping (address => uint)) public record votesMap;
-    mapping (string => bool) public record currentIssues;
-
-    mapping (address => mapping (string => mapping (address => bool))) public record whitelist;
-
+    
+    mapping (string => address[]) public record votes; // votes[issueId] = [voter1, voter2, ...]
+    
+    mapping (string => mapping (address => uint)) public record votesMap; // votesMap[issueId][voter] = index of voter in votes[issueId]
+    
+    mapping (string => bool) public record currentIssues; // currentIssues[issueId] = true if issue is active, false otherwise
+    
+    mapping (string => Timelock) public record timelocks; // timelocks[issueId] = Timelock(queuedAt, executableAt, expiresAt)
+    
+    mapping (address => mapping (string => mapping (address => bool))) public record whitelist; 
+    
     mapping (address => mapping (string => uint)) public record votingThresholds;
 
     uint public defaultVotingThresholdBps = 6000; // 3/5
 
     event IssueCreated(address sender, address creator, string issueId, address target, string func, variadic args);
     event IssueVoted(address sender, address voter, string issueId, address target, string func, variadic args);
+    event IssueQueued(address sender, address queueExecutor, string issueId, address target, string func, uint executableAt, uint expiresAt, variadic args);
     event IssueExecuted(address sender, address executor, string issueId, address target, string func, variadic args);
+    event IssueVoteWithdrawn(address sender, address voter, string issueId);
     event IssueDismissed(address sender, string issueId);
 
     bool public initialized = false;
@@ -58,15 +74,11 @@ contract record AdminRegistry is Ownable {
 
     function dismissIssue(string _issueId) external {
         require(currentIssues[_issueId], "Issue does not exist or is not active");
+        require(timelocks[_issueId].executableAt == 0, "Cannot dismiss queued issue");
         require(votes[_issueId].length == 1, "Only issues with a single vote can be dismissed");
         require(votes[_issueId][0] == msg.sender, "Only the proposer can dismiss their issue");
 
-        for (uint i = 0; i < votes[_issueId].length; i++) {
-            votesMap[_issueId][votes[_issueId][i]] = 0;
-            votes[_issueId][i] = address(0);
-        }
-        votes[_issueId].length = 0;
-        delete currentIssues[_issueId];
+        _clearIssue(_issueId);
         emit IssueDismissed(msg.sender, _issueId);
     }
 
@@ -87,6 +99,7 @@ contract record AdminRegistry is Ownable {
                 _target = msg.sender;
             }
             string issueId = _getIssueId(_target, _func, _args);
+            require(timelocks[issueId].executableAt == 0, "Cannot vote on queued issue");
             bool hasVoted = votesMap[issueId][sender] != 0;
 
             _createIssue(sender, issueId, _target, _func, _args);
@@ -98,8 +111,12 @@ contract record AdminRegistry is Ownable {
             }
 
             if (_shouldExecute(issueId, _target, _func, _args)) {
-                variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
-                return (true, ret);
+                if (admins.length == 1) {
+                    variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
+                    return (true, ret);
+                }
+                _queueIssue(sender, issueId, _target, _func, _args);
+                return (false, issueId);
             } else {
                 return (false, issueId);
             }
@@ -119,7 +136,12 @@ contract record AdminRegistry is Ownable {
     }
 
     function _shouldExecute(string _issueId, address _target, string _func, variadic _args) internal returns (bool) {
-        uint issueVotes = votes[_issueId].length;
+        uint issueVotes = 0;
+        for (uint i = 0; i < votes[_issueId].length; i++) {
+            if (adminMap[votes[_issueId][i]] != 0) {
+                issueVotes++;
+            }
+        }
 
         uint votingThresholdBps = votingThresholds[_target][_func];
         if (votingThresholdBps == 0) votingThresholdBps = defaultVotingThresholdBps;
@@ -134,6 +156,31 @@ contract record AdminRegistry is Ownable {
         }
     }
 
+    function executeIssue(address _target, string _func, variadic _args) external returns (variadic) {
+        string issueId = _getIssueId(_target, _func, _args);
+        Timelock storage timelock = timelocks[issueId];
+        require(timelock.executableAt != 0, "Issue is not queued");
+        require(block.timestamp >= timelock.executableAt, "Timelock delay has not elapsed");
+        require(block.timestamp <= timelock.expiresAt, "Queued issue has expired");
+        require(_shouldExecute(issueId, _target, _func, _args), "Voting threshold is no longer met");
+        return _executeIssue(msg.sender, issueId, _target, _func, _args);
+    }
+
+    function withdrawVote(address _target, string _func, variadic _args) external {
+        string issueId = _getIssueId(_target, _func, _args);
+        require(currentIssues[issueId], "Issue does not exist or is not active");
+        require(votesMap[issueId][msg.sender] != 0, "Caller has not voted on this issue");
+
+        _removeVote(issueId, msg.sender);
+        emit IssueVoteWithdrawn(msg.sender, msg.sender, issueId);
+
+        if (votes[issueId].length == 0) {
+            _clearIssue(issueId);
+        } else if (timelocks[issueId].executableAt != 0 && !_shouldExecute(issueId, _target, _func, _args)) {
+            _clearTimelock(issueId);
+        }
+    }
+
     function getIssueId(address _target, string _func, variadic _args) external returns (string) {
         return _getIssueId(_target, _func, _args);
     }
@@ -142,16 +189,47 @@ contract record AdminRegistry is Ownable {
         return keccak256(_target, _func, _args);
     }
 
+    function _queueIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal {
+        require(timelocks[_issueId].executableAt == 0, "Issue is already queued");
+        uint executableAt = block.timestamp + MINIMUM_DELAY;
+        timelocks[_issueId] = Timelock(block.timestamp, executableAt, executableAt + GRACE_PERIOD);
+        emit IssueQueued(msg.sender, _sender, _issueId, _target, _func, executableAt, timelocks[_issueId].expiresAt, _args);
+    }
+
     function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
         variadic ret = _target.call(_func, _args);
+        _clearIssue(_issueId);
+        emit IssueExecuted(msg.sender, _sender, _issueId, _target, _func, _args);
+        return ret;
+    }
+
+    function _removeVote(string _issueId, address _voter) internal {
+        uint voteIndex = votesMap[_issueId][_voter];
+        require(voteIndex != 0, "Voter has not voted on this issue");
+
+        uint index = voteIndex - 1;
+        address swap = votes[_issueId][votes[_issueId].length - 1];
+        votes[_issueId][index] = swap;
+        votesMap[_issueId][swap] = index + 1;
+        votesMap[_issueId][_voter] = 0;
+        votes[_issueId][votes[_issueId].length - 1] = address(0);
+        votes[_issueId].length -= 1;
+    }
+
+    function _clearIssue(string _issueId) internal {
         for (uint i = 0; i < votes[_issueId].length; i++) {
             votesMap[_issueId][votes[_issueId][i]] = 0;
             votes[_issueId][i] = address(0);
         }
         votes[_issueId].length = 0;
         delete currentIssues[_issueId];
-        emit IssueExecuted(msg.sender, _sender, _issueId, _target, _func, _args);
-        return ret;
+        _clearTimelock(_issueId);
+    }
+
+    function _clearTimelock(string _issueId) internal {
+        timelocks[_issueId].queuedAt = 0;
+        timelocks[_issueId].executableAt = 0;
+        timelocks[_issueId].expiresAt = 0;
     }
 
     function _addAdmin(address _admin) external onlyOwner {
@@ -190,13 +268,19 @@ contract record AdminRegistry is Ownable {
                 _func != "addWhitelist" &&
                 _func != "removeWhitelist" &&
                 _func != "_addAdmin" &&
+                _func != "_clearIssue" &&
+                _func != "_clearTimelock" &&
                 _func != "_createIssue" &&
                 _func != "_executeIssue" &&
                 _func != "_removeAdmin" &&
+                _func != "_removeVote" &&
+                _func != "_queueIssue" &&
                 _func != "_shouldExecute" &&
                 _func != "_swapAdmin" &&
+                _func != "executeIssue" &&
                 _func != "setVotingThreshold" &&
                 _func != "setDefaultVotingThresholdBps" &&
+                _func != "withdrawVote" &&
                 _func != "createContract" &&
                 _func != "createSaltedContract",
                 "Cannot whitelist internal governance functions"

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -3,8 +3,7 @@ import "../../abstract/ERC20/access/Ownable.sol";
 
 contract record AdminRegistry is Ownable {
     uint public constant MINIMUM_DELAY = 86400; // 24 hours
-    uint public constant GRACE_PERIOD = 86400; // 24 hours
-    uint public constant MIN_VOTING_THRESHOLD_BPS = 5000; // 50%
+    uint public constant GRACE_PERIOD = 604800; // 7 days
     uint public constant MIN_ADMIN_COUNT = 3;
 
     struct Timelock {
@@ -377,13 +376,11 @@ contract record AdminRegistry is Ownable {
     }
 
     function setVotingThreshold(address _target, string _func, uint _votingThresholdBps) external onlyOwner {
-        require(_votingThresholdBps >= MIN_VOTING_THRESHOLD_BPS, "Threshold too low");
         require(_votingThresholdBps <= 10000, "Voting threshold must be less than 100%");
         votingThresholds[_target][_func] = _votingThresholdBps;
     }
 
     function setDefaultVotingThresholdBps(uint _defaultVotingThresholdBps) external onlyOwner {
-        require(_defaultVotingThresholdBps >= MIN_VOTING_THRESHOLD_BPS, "Threshold too low");
         require(_defaultVotingThresholdBps <= 10000, "Default voting threshold must be less than 100%");
         defaultVotingThresholdBps = _defaultVotingThresholdBps;
     }

--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -395,6 +395,24 @@ contract record MercataBridge is Ownable {
     }
 
     /**
+     * @dev Pauses deposit operations. Guardian-safe no-arg shim.
+     * @notice Cannot be used to unpause. Use setPause(bool, bool) for that.
+     */
+    function pauseDeposits() external onlyOwner {
+        depositsPaused = true;
+        emit PauseToggled(true, withdrawalsPaused);
+    }
+
+    /**
+     * @dev Pauses withdrawal operations. Guardian-safe no-arg shim.
+     * @notice Cannot be used to unpause. Use setPause(bool, bool) for that.
+     */
+    function pauseWithdrawals() external onlyOwner {
+        withdrawalsPaused = true;
+        emit PauseToggled(depositsPaused, true);
+    }
+
+    /**
      * @dev Sets the token factory address
      * @notice Only the owner can update the token factory address
      * @param newFactory The new token factory address (must not be zero address)

--- a/mercata/contracts/concrete/CDP/CDPEngine.sol
+++ b/mercata/contracts/concrete/CDP/CDPEngine.sol
@@ -684,6 +684,19 @@ contract record CDPEngine is Ownable {
         emit PausedGlobal(isPaused);
     }
 
+    /** Owner-only: pause a specific asset (guardian-safe no-arg shim) */
+    function pauseAsset(address asset) external onlyOwner {
+        require(isSupportedAsset[asset], "CDPEngine: unsupported asset");
+        collateralConfigs[asset].isPaused = true;
+        emit Paused(asset, true);
+    }
+
+    /** Owner-only: pause the entire CDP engine (guardian-safe no-arg shim) */
+    function pauseGlobal() external onlyOwner {
+        globalPaused = true;
+        emit PausedGlobal(true);
+    }
+
     /** Owner-only: toggle support for a collateral asset (pseudo-remove/add) */
     /// @param asset The asset to toggle support for.
     /// @param supported Whether the asset should be supported.

--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -147,6 +147,11 @@ contract record Pool is Ownable {
         isPaused = _isPaused;
     }
 
+    function pause() external onlyOwner {
+        require(!isDisabled, "Pool pause cannot be set while isDisabled = true");
+        isPaused = true;
+    }
+
     function setDisabled(bool _isDisabled) external onlyOwner {
         isPaused = _isDisabled ? true : isPaused;
         isDisabled = _isDisabled;

--- a/mercata/contracts/concrete/Pools/StablePool.sol
+++ b/mercata/contracts/concrete/Pools/StablePool.sol
@@ -161,6 +161,11 @@ contract record StablePool is Ownable {
         isPaused = _isPaused;
     }
 
+    function pause() external onlyOwner {
+        require(!isDisabled, "Pool pause cannot be set while isDisabled = true");
+        isPaused = true;
+    }
+
     function setDisabled(bool _isDisabled) external onlyOwner {
         isPaused = _isDisabled ? true : isPaused;
         isDisabled = _isDisabled;

--- a/mercata/contracts/deploy/upgrade.js
+++ b/mercata/contracts/deploy/upgrade.js
@@ -193,6 +193,42 @@ async function deployImplementationAsync(tokenObj, contractArgs, baseOptions) {
 }
 
 /**
+ * Call a contract method asynchronously and poll for the receipt.
+ *
+ * As of 04-22-2026, contract calls also route through the caller's user-contract,
+ * so the synchronous `rest.call` resolver crashes reading `a.data.contents` (data is null).
+ * `isAsync: true` + `rest.getBlocResults` bypasses the broken resolver and gives us the
+ * raw tx receipt so we can assert success ourselves.
+ */
+async function callAsync(tokenObj, callArgs, baseOptions) {
+  const asyncOptions = { ...baseOptions, isAsync: true };
+  const response = await rest.call(tokenObj, callArgs, asyncOptions);
+  const responseArray = Array.isArray(response) ? response : [response];
+  const hashes = responseArray.map((r) => r && r.hash).filter(Boolean);
+  if (hashes.length === 0) {
+    throw new Error(
+      'rest.call returned no tx hash; cannot poll for receipt: ' + JSON.stringify(response)
+    );
+  }
+
+  const finalResults = await util.until(
+    (results) => Array.isArray(results) && results.length > 0 &&
+      results.every((r) => r && r.status && r.status !== 'Pending'),
+    (opts) => rest.getBlocResults(tokenObj, hashes, opts),
+    { config, isAsync: true },
+    60000
+  );
+
+  const final = Array.isArray(finalResults) ? finalResults[0] : finalResults;
+  if (!final || final.status !== 'Success') {
+    throw new Error(
+      'Contract call failed: ' + JSON.stringify(final || finalResults)
+    );
+  }
+  return final;
+}
+
+/**
  * Main upgrade function
  */
 async function main() {
@@ -358,16 +394,21 @@ async function main() {
         cacheNonce: true,
       };
 
-      const upgradeResult = await rest.call(tokenObj, callArgs, callOptions);
+      // Async + poll: the sync resolver crashes on user-contract-routed calls (reads
+      // `.contents` on a null `data` field). We lose direct access to the solidity
+      // return value (vote issue id, if any) but confirm success via the receipt.
+      const upgradeReceipt = await callAsync(tokenObj, callArgs, callOptions);
 
-      if (upgradeResult[0]) {
-          console.log('\n======  Upgrade  Pending  ======');
-          console.log("Proxy Uploaded and Upgrade Requested.")
-          console.log("Governance Vote Required.\nVote Issue ID: " + upgradeResult[0]);
+      // If setLogicContract went through governance, the tx still succeeds here but
+      // the new implementation only takes effect after the vote resolves. Surface
+      // whatever the receipt tells us so the operator can follow up.
+      const voteHint = upgradeReceipt && upgradeReceipt.txResult && upgradeReceipt.txResult.message;
+      console.log('\n====== Upgrade Submitted ======');
+      console.log(`Tx status: ${upgradeReceipt.status}`);
+      if (voteHint) {
+        console.log(`Note (may indicate governance vote required): ${voteHint}`);
       }
-      else {
-          console.log('\n====== Upgrade Successful ======');
-      }
+      console.log('If this proxy is under governance, confirm the vote resolves before treating the upgrade as live.');
 
       console.log(`Proxy Address: ${proxyAddress}`);
       console.log(`New Implementation: ${implementationAddress}`);

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -516,10 +516,13 @@ contract Describe_AdminRegistry is Authorizable {
         guardianRegistry.initialize(initialAdmins);
         TestERC20 guardianToken = new TestERC20("Guardian Token", "GT", address(guardianRegistry));
 
-        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
-        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
+        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
         fastForward(86400);
-        guardianRegistry.executeIssue(address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        guardianRegistry.executeIssue(address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
+
+        require(guardianRegistry.instantFunctions(address(guardianToken), "mint"), "setGuardianAllowed(true) should auto-enable instant");
+        require(guardianRegistry.guardianAllowlist(address(guardianToken), "mint"), "guardianAllowlist should be true");
 
         string memory issueId = guardianRegistry.getIssueId(address(guardianToken), "mint", admin3, 1000e18);
         guardianToken.mint(admin3, 1000e18);
@@ -539,10 +542,10 @@ contract Describe_AdminRegistry is Authorizable {
         guardianRegistry.initialize(initialAdmins);
         TestERC20 guardianToken = new TestERC20("Guardian Token", "GT", address(guardianRegistry));
 
-        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
-        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
+        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
         fastForward(86400);
-        guardianRegistry.executeIssue(address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        guardianRegistry.executeIssue(address(guardianRegistry), "_setGuardianAllowed", address(guardianToken), "mint", true);
 
         string memory issueId = guardianRegistry.getIssueId(address(guardianToken), "mint", admin3, 1000e18);
         (bool executed, variadic result) = guardianRegistry.castVoteOnIssue(address(guardianToken), "mint", admin3, 1000e18);
@@ -1022,6 +1025,442 @@ contract Describe_AdminRegistry is Authorizable {
             reverted = true;
         }
         require(reverted, "Should revert when trying to dismiss non-existent issue");
+    }
+
+    // ============ GUARDIAN TESTS ============
+
+    function it_guardian_add_requires_quorum_and_timelock() {
+        adminRegistry.addGuardian(address(user2));
+        require(!adminRegistry.isGuardian(address(user2)), "Should not be guardian with one vote");
+        require(adminRegistry.guardianMap(address(user2)) == 0, "guardianMap should be 0");
+
+        user1.do(address(adminRegistry), "addGuardian", address(user2));
+        string memory issueId = adminRegistry.getIssueId(address(adminRegistry), "_addGuardian", address(user2));
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+        require(!adminRegistry.isGuardian(address(user2)), "Should not be guardian before timelock");
+
+        executeQueued(address(adminRegistry), "_addGuardian", address(user2));
+        require(adminRegistry.isGuardian(address(user2)), "Should be guardian after execution");
+        require(adminRegistry.guardianMap(address(user2)) > 0, "guardianMap should be set");
+        require(adminRegistry.guardians(0) == address(user2), "guardians array should include user2");
+    }
+
+    function it_guardian_remove_requires_quorum_and_timelock() {
+        adminRegistry.addGuardian(address(user2));
+        user1.do(address(adminRegistry), "addGuardian", address(user2));
+        executeQueued(address(adminRegistry), "_addGuardian", address(user2));
+        require(adminRegistry.isGuardian(address(user2)), "Precondition: guardian added");
+
+        adminRegistry.removeGuardian(address(user2));
+        require(adminRegistry.isGuardian(address(user2)), "Should remain guardian with one vote");
+        user1.do(address(adminRegistry), "removeGuardian", address(user2));
+        executeQueued(address(adminRegistry), "_removeGuardian", address(user2));
+        require(!adminRegistry.isGuardian(address(user2)), "Should not be guardian after execution");
+        require(adminRegistry.guardianMap(address(user2)) == 0, "guardianMap should be cleared");
+    }
+
+    function it_guardian_add_rejects_admin() {
+        adminRegistry.addGuardian(admin1);
+        user1.do(address(adminRegistry), "addGuardian", admin1);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_addGuardian", admin1);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject adding admin as guardian");
+        require(!adminRegistry.isGuardian(admin1), "Admin should not become guardian");
+    }
+
+    function it_admin_add_rejects_guardian() {
+        adminRegistry.addGuardian(address(user2));
+        user1.do(address(adminRegistry), "addGuardian", address(user2));
+        executeQueued(address(adminRegistry), "_addGuardian", address(user2));
+        require(adminRegistry.isGuardian(address(user2)), "Precondition: user2 is guardian");
+
+        adminRegistry.addAdmin(address(user2));
+        user1.do(address(adminRegistry), "addAdmin", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_addAdmin", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject adding guardian as admin");
+        require(!adminRegistry.isAdminAddress(address(user2)), "Guardian should not become admin");
+    }
+
+    function it_guardian_allowlist_cannot_target_adminregistry() {
+        adminRegistry.setGuardianAllowed(address(adminRegistry), "_addAdmin", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(adminRegistry), "_addAdmin", true);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_setGuardianAllowed", address(adminRegistry), "_addAdmin", true);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject self-targeting guardian allowlist");
+        require(!adminRegistry.guardianAllowlist(address(adminRegistry), "_addAdmin"), "Self-target allowlist should remain false");
+    }
+
+    function it_whitelist_forbidden_list_refuses_addGuardian() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_addGuardian", address(user2));
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "addWhitelist", address(adminRegistry), "_addGuardian", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_addGuardian", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject whitelisting _addGuardian");
+        require(!adminRegistry.whitelist(address(adminRegistry), "_addGuardian", address(user2)), "Whitelist should remain false");
+    }
+
+    function it_whitelist_forbidden_list_refuses_removeGuardian() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_removeGuardian", address(user2));
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "addWhitelist", address(adminRegistry), "_removeGuardian", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_removeGuardian", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject whitelisting _removeGuardian");
+        require(!adminRegistry.whitelist(address(adminRegistry), "_removeGuardian", address(user2)), "Whitelist should remain false");
+    }
+
+    function it_whitelist_forbidden_list_refuses_setGuardianAllowed() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_setGuardianAllowed", address(user2));
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "addWhitelist", address(adminRegistry), "_setGuardianAllowed", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "addWhitelist", address(adminRegistry), "_setGuardianAllowed", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject whitelisting _setGuardianAllowed");
+        require(!adminRegistry.whitelist(address(adminRegistry), "_setGuardianAllowed", address(user2)), "Whitelist should remain false");
+    }
+
+    function it_setGuardianAllowed_true_auto_enables_instant() {
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Precondition: instant off");
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Precondition: allowlist off");
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Instant should be auto-enabled");
+        require(adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist should be set");
+    }
+
+    function it_setGuardianAllowed_false_preserves_instant() {
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Precondition: instant on");
+        require(adminRegistry.guardianAllowlist(address(token), "mint"), "Precondition: allowlist on");
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", false);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", false);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", false);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Instant should be preserved on demotion");
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist should be cleared");
+    }
+
+    function it_setInstantFunction_false_does_not_clear_guardianAllowlist() {
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Instant should be off");
+        require(adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist should be preserved");
+    }
+
+    function it_admin_only_instant_excludes_guardian() {
+        // Enable instant only (no guardian allowlist)
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Precondition: instant on");
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Precondition: allowlist off");
+
+        // Add user2 as guardian
+        adminRegistry.addGuardian(address(user2));
+        user1.do(address(adminRegistry), "addGuardian", address(user2));
+        executeQueued(address(adminRegistry), "_addGuardian", address(user2));
+        require(adminRegistry.isGuardian(address(user2)), "Precondition: user2 is guardian");
+
+        // Admin executes instantly (1-of-N)
+        token.mint(admin3, 1000e18);
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Admin should execute admin-only instant");
+
+        // Guardian on a different issueId reverts
+        bool reverted = false;
+        try {
+            user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 500e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Guardian should not execute admin-only instant");
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Guardian mint should not have executed");
+    }
+
+    // ============ GUARDIAN AUTHORITY BOUNDARY TESTS ============
+
+    function addGuardianViaQuorum(address _guardian) internal {
+        adminRegistry.addGuardian(_guardian);
+        user1.do(address(adminRegistry), "addGuardian", _guardian);
+        executeQueued(address(adminRegistry), "_addGuardian", _guardian);
+        require(adminRegistry.isGuardian(_guardian), "Precondition: guardian added");
+    }
+
+    function it_guardian_cannot_propose_admin_management() {
+        addGuardianViaQuorum(address(user2));
+
+        bool addReverted = false;
+        try {
+            user2.do(address(adminRegistry), "addAdmin", admin3);
+        } catch {
+            addReverted = true;
+        }
+        require(addReverted, "Guardian must not propose addAdmin");
+
+        bool removeReverted = false;
+        try {
+            user2.do(address(adminRegistry), "removeAdmin", admin1);
+        } catch {
+            removeReverted = true;
+        }
+        require(removeReverted, "Guardian must not propose removeAdmin");
+
+        bool swapReverted = false;
+        try {
+            user2.do(address(adminRegistry), "swapAdmin", admin1, admin3);
+        } catch {
+            swapReverted = true;
+        }
+        require(swapReverted, "Guardian must not propose swapAdmin");
+
+        string memory addIssueId = adminRegistry.getIssueId(address(adminRegistry), "_addAdmin", admin3);
+        require(!adminRegistry.currentIssues(addIssueId), "Guardian should not create admin proposals");
+    }
+
+    function it_guardian_cannot_propose_guardian_management() {
+        addGuardianViaQuorum(address(user2));
+
+        bool addGuardianReverted = false;
+        try {
+            user2.do(address(adminRegistry), "addGuardian", address(user3));
+        } catch {
+            addGuardianReverted = true;
+        }
+        require(addGuardianReverted, "Guardian must not propose addGuardian");
+
+        bool removeGuardianReverted = false;
+        try {
+            user2.do(address(adminRegistry), "removeGuardian", address(user2));
+        } catch {
+            removeGuardianReverted = true;
+        }
+        require(removeGuardianReverted, "Guardian must not propose self-removal");
+
+        bool setAllowedReverted = false;
+        try {
+            user2.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        } catch {
+            setAllowedReverted = true;
+        }
+        require(setAllowedReverted, "Guardian must not propose setGuardianAllowed");
+
+        string memory addIssueId = adminRegistry.getIssueId(address(adminRegistry), "_addGuardian", address(user3));
+        require(!adminRegistry.currentIssues(addIssueId), "Guardian should not create guardian proposals");
+    }
+
+    function it_guardian_cannot_propose_setInstantFunction() {
+        addGuardianViaQuorum(address(user2));
+
+        bool reverted = false;
+        try {
+            user2.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Guardian must not propose setInstantFunction");
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "instantFunctions should remain false");
+    }
+
+    function it_guardian_cannot_vote_on_non_instant_issue() {
+        addGuardianViaQuorum(address(user2));
+
+        bool reverted = false;
+        try {
+            user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Guardian must not vote on non-instant function");
+
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
+        require(!adminRegistry.currentIssues(issueId), "Issue should not be created by guardian");
+        require(adminRegistry.votesMap(issueId, address(user2)) == 0, "Guardian vote must not be recorded");
+    }
+
+    function it_addGuardian_rejects_zero_address() {
+        adminRegistry.addGuardian(zeroAddress);
+        user1.do(address(adminRegistry), "addGuardian", zeroAddress);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_addGuardian", zeroAddress);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject zero address guardian");
+        require(!adminRegistry.isGuardian(zeroAddress), "Zero address should not be guardian");
+    }
+
+    function it_addGuardian_rejects_duplicate() {
+        addGuardianViaQuorum(address(user2));
+
+        adminRegistry.addGuardian(address(user2));
+        user1.do(address(adminRegistry), "addGuardian", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_addGuardian", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject duplicate guardian");
+        require(adminRegistry.guardianMap(address(user2)) == 1, "guardianMap index should remain 1");
+        require(adminRegistry.guardians(1) == address(0), "guardians array length should remain 1");
+    }
+
+    function it_removeGuardian_rejects_non_guardian() {
+        adminRegistry.removeGuardian(address(user2));
+        user1.do(address(adminRegistry), "removeGuardian", address(user2));
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_removeGuardian", address(user2));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should reject removing non-guardian");
+    }
+
+    function it_setGuardianAllowed_true_when_instant_already_enabled() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Precondition: instant on");
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Precondition: allowlist off");
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Instant should remain on");
+        require(adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist should be set");
+    }
+
+    function it_guardian_access_restored_after_instant_re_enabled() {
+        addGuardianViaQuorum(address(user2));
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        // Guardian initially can execute
+        user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 100e18);
+        require(ERC20(token).balanceOf(admin3) == 100e18, "Guardian should mint after allowlist enabled");
+
+        // Admin disables instant (allowlist preserved)
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", false);
+
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Instant disabled");
+        require(adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist preserved");
+
+        // Guardian access blocked while instant is off
+        bool blocked = false;
+        try {
+            user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 200e18);
+        } catch {
+            blocked = true;
+        }
+        require(blocked, "Guardian should be blocked while instant disabled");
+        require(ERC20(token).balanceOf(admin3) == 100e18, "Balance unchanged while blocked");
+
+        // Admin re-enables instant — guardian regains access without re-allowlisting
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+
+        user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 300e18);
+        require(ERC20(token).balanceOf(admin3) == 400e18, "Guardian should regain access");
+    }
+
+    function it_guardian_remove_blocks_subsequent_execution() {
+        addGuardianViaQuorum(address(user2));
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", true);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", true);
+
+        user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Guardian should mint while authorized");
+
+        adminRegistry.removeGuardian(address(user2));
+        user1.do(address(adminRegistry), "removeGuardian", address(user2));
+        executeQueued(address(adminRegistry), "_removeGuardian", address(user2));
+        require(!adminRegistry.isGuardian(address(user2)), "Precondition: guardian removed");
+
+        bool reverted = false;
+        try {
+            user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Removed guardian must not execute");
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Removed guardian mint should not execute");
+    }
+
+    function it_setGuardianAllowed_false_when_already_false() {
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Precondition: allowlist off");
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Precondition: instant off");
+
+        adminRegistry.setGuardianAllowed(address(token), "mint", false);
+        user1.do(address(adminRegistry), "setGuardianAllowed", address(token), "mint", false);
+        executeQueued(address(adminRegistry), "_setGuardianAllowed", address(token), "mint", false);
+
+        require(!adminRegistry.guardianAllowlist(address(token), "mint"), "Allowlist should remain false");
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Instant should remain false (no auto-enable on disable)");
     }
 
 }

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -111,10 +111,13 @@ contract Describe_AdminRegistry is Authorizable {
         TestERC20 singleAdminToken = new TestERC20("Single Admin Token", "SAT", address(singleRegistry));
         string memory issueId = singleRegistry.getIssueId(address(singleAdminToken), "mint", admin3, 1000e18);
         (bool executed, variadic result) = singleRegistry.castVoteOnIssue(address(singleAdminToken), "mint", admin3, 1000e18);
-        require(executed, "Single admin issue should execute immediately");
-        require(ERC20(singleAdminToken).balanceOf(admin3) == 1000e18, "Single admin token should mint immediately");
+        require(!executed, "Single admin issue should queue");
+        require(ERC20(singleAdminToken).balanceOf(admin3) == 0, "Single admin token should not mint before delay");
         (, uint executableAt,) = singleRegistry.timelocks(issueId);
-        require(executableAt == 0, "Single admin issue should not be queued");
+        require(executableAt == block.timestamp + 172800, "Single admin issue should be queued");
+        fastForward(172800);
+        singleRegistry.executeIssue(address(singleAdminToken), "mint", admin3, 1000e18);
+        require(ERC20(singleAdminToken).balanceOf(admin3) == 1000e18, "Single admin token should mint after delay");
     }
 
     // ============ BASIC VOTING TESTS ============
@@ -562,9 +565,9 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin");
 
         // Step 3: Admin1 calls the same issue again (adding admin3)
-        // Now with only 1 admin, 1 vote = 100%, so it executes immediately
-        (bool executed, variadic result) = adminRegistry.castVoteOnIssue(address(adminRegistry), "_addAdmin", admin3);
-        require(executed, "Single admin issue should execute immediately");
+        // Now with only 1 admin, 1 vote = 100% (exceeds 67% threshold), so it queues
+        adminRegistry.addAdmin(admin3);
+        executeQueued(address(adminRegistry), "_addAdmin", admin3);
 
         // Verify admin3 was added
         require(adminRegistry.isAdminAddress(admin3), "Admin3 should now be an admin");
@@ -631,9 +634,11 @@ contract Describe_AdminRegistry is Authorizable {
         // Step 2: Try to remove the last admin (admin1) - this should revert
         bool reverted = false;
         try {
-            // Since we're now the only admin, our single vote executes immediately
-            // But the _removeAdmin function should revert during execution
+            // Since we're now the only admin, our single vote queues immediately
+            // But the _removeAdmin function should revert before execution
             adminRegistry.removeAdmin(admin1);
+            fastForward(172800);
+            adminRegistry.executeIssue(address(adminRegistry), "_removeAdmin", admin1);
         } catch {
             reverted = true;
         }

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -59,6 +59,31 @@ contract Describe_AdminRegistry is Authorizable {
         token = new TestERC20("Test Token", "TEST", address(adminRegistry));
     }
 
+    function voteToQueue(address _target, string _func, variadic _args) internal returns (string) {
+        string memory issueId = adminRegistry.getIssueId(_target, _func, _args);
+        adminRegistry.castVoteOnIssue(_target, _func, _args);
+        user1.do(address(adminRegistry), "castVoteOnIssue", _target, _func, _args);
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+        return issueId;
+    }
+
+    function executeQueued(address _target, string _func, variadic _args) internal returns (variadic) {
+        fastForward(172800);
+        return adminRegistry.executeIssue(_target, _func, _args);
+    }
+
+    function issueExecutableAt(string _issueId) internal returns (uint) {
+        (, uint executableAt,) = adminRegistry.timelocks(_issueId);
+        return executableAt;
+    }
+
+    function assertTimelock(string _issueId, uint _queuedAt, uint _executableAt, uint _expiresAt) internal {
+        (uint queuedAt, uint executableAt, uint expiresAt) = adminRegistry.timelocks(_issueId);
+        require(queuedAt == _queuedAt, "Unexpected queuedAt");
+        require(executableAt == _executableAt, "Unexpected executableAt");
+        require(expiresAt == _expiresAt, "Unexpected expiresAt");
+    }
+
     // ============ CONSTRUCTOR TESTS ============
 
     function it_admin_registry_sets_initial_admins() {
@@ -82,6 +107,14 @@ contract Describe_AdminRegistry is Authorizable {
         singleRegistry.initialize(singleAdmin);
         require(singleRegistry.isAdminAddress(admin1), "Should have one admin");
         require(!singleRegistry.isAdminAddress(admin2), "Should not have second admin");
+
+        TestERC20 singleAdminToken = new TestERC20("Single Admin Token", "SAT", address(singleRegistry));
+        string memory issueId = singleRegistry.getIssueId(address(singleAdminToken), "mint", admin3, 1000e18);
+        (bool executed, variadic result) = singleRegistry.castVoteOnIssue(address(singleAdminToken), "mint", admin3, 1000e18);
+        require(executed, "Single admin issue should execute immediately");
+        require(ERC20(singleAdminToken).balanceOf(admin3) == 1000e18, "Single admin token should mint immediately");
+        (, uint executableAt,) = singleRegistry.timelocks(issueId);
+        require(executableAt == 0, "Single admin issue should not be queued");
     }
 
     // ============ BASIC VOTING TESTS ============
@@ -115,9 +148,13 @@ contract Describe_AdminRegistry is Authorizable {
         uint voteIndex2 = adminRegistry.votesMap(issueId, admin1);
         require(voteIndex2 == voteIndex1, "Vote count should not increase when same admin votes twice");
 
-        // Now add a second DIFFERENT admin's vote - should execute
+        // Now add a second DIFFERENT admin's vote - should queue
         (bool executed3, variadic result3) = user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
-        require(executed3, "Should execute with two different admin votes");
+        require(!executed3, "Should queue with two different admin votes");
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted before delay");
+
+        executeQueued(address(token), "mint", admin3, 1000e18);
         require(ERC20(token).balanceOf(admin3) == 1000e18, "Token should be minted after two votes");
     }
 
@@ -298,9 +335,13 @@ contract Describe_AdminRegistry is Authorizable {
         (bool executed1, variadic result1) = adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
         require(!executed1, "Should not execute with only one vote");
 
-        // Second vote - should execute (using user1 as second admin)
+        // Second vote - should queue (using user1 as second admin)
         (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
-        require(executed2, "Should execute with two votes");
+        require(!executed2, "Should queue with two votes");
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted before delay");
+
+        executeQueued(address(token), "mint", admin3, 1000e18);
         require(ERC20(token).balanceOf(admin3) == 1000e18, "Token should be minted after execution");
     }
 
@@ -311,10 +352,12 @@ contract Describe_AdminRegistry is Authorizable {
         (bool executed1, variadic result1) = adminRegistry.castVoteOnIssue(address(adminRegistry), "createContract", "TestContract", src, "hello");
         require(!executed1, "Should not execute contract creation with one vote");
 
-        // Second vote - should execute
+        // Second vote - should queue
         (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "createContract", "TestContract", src, "hello");
-        require(executed2, "Should execute contract creation with two votes");
-        address newContract = address(result2);
+        require(!executed2, "Should queue contract creation with two votes");
+
+        variadic result3 = executeQueued(address(adminRegistry), "createContract", "TestContract", src, "hello");
+        address newContract = address(result3);
         require(newContract != address(0), "New contract should be created");
 
         string memory val = newContract.call("val");
@@ -329,10 +372,12 @@ contract Describe_AdminRegistry is Authorizable {
         (bool executed1, variadic result1) = adminRegistry.castVoteOnIssue(address(adminRegistry), "createSaltedContract", salt, "TestContract", src, "hello");
         require(!executed1, "Should not execute salted contract creation with one vote");
 
-        // Second vote - should execute
+        // Second vote - should queue
         (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "createSaltedContract", salt, "TestContract", src, "hello");
-        require(executed2, "Should execute salted contract creation with two votes");
-        address newContract = address(result2);
+        require(!executed2, "Should queue salted contract creation with two votes");
+
+        variadic result3 = executeQueued(address(adminRegistry), "createSaltedContract", salt, "TestContract", src, "hello");
+        address newContract = address(result3);
         require(newContract != address(0), "New contract should be created");
 
         string memory val = newContract.call("val");
@@ -344,9 +389,11 @@ contract Describe_AdminRegistry is Authorizable {
         (bool executed1, variadic result1) = adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
         require(!executed1, "Should not execute threshold update with one vote");
 
-        // Second vote - should execute
+        // Second vote - should queue
         (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
-        require(executed2, "Should execute threshold update with two votes");
+        require(!executed2, "Should queue threshold update with two votes");
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
+        require(adminRegistry.votingThresholds(address(token), "mint") == 5000, "Threshold should update after delay");
     }
 
     function it_admin_registry_handles_whitelist_operations() {
@@ -355,14 +402,18 @@ contract Describe_AdminRegistry is Authorizable {
         require(!executed1, "Should not execute whitelist add with one vote");
 
         (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "addWhitelist", address(token), "mint", admin3);
-        require(executed2, "Should execute whitelist add with two votes");
+        require(!executed2, "Should queue whitelist add with two votes");
+        executeQueued(address(adminRegistry), "addWhitelist", address(token), "mint", admin3);
+        require(adminRegistry.whitelist(address(token), "mint", admin3), "Whitelist should be added after delay");
 
         // Remove from whitelist
         (bool executed3, variadic result3) = adminRegistry.castVoteOnIssue(address(adminRegistry), "removeWhitelist", address(token), "mint", admin3);
         require(!executed3, "Should not execute whitelist remove with one vote");
 
         (bool executed4, variadic result4) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "removeWhitelist", address(token), "mint", admin3);
-        require(executed4, "Should execute whitelist remove with two votes");
+        require(!executed4, "Should queue whitelist remove with two votes");
+        executeQueued(address(adminRegistry), "removeWhitelist", address(token), "mint", admin3);
+        require(!adminRegistry.whitelist(address(token), "mint", admin3), "Whitelist should be removed after delay");
     }
 
     function it_admin_registry_handles_admin_management() {
@@ -371,6 +422,8 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.admins(2) == address(0), "Admin was added before enough votes were cast");
 
         user1.do(address(adminRegistry), "addAdmin", admin3);
+        require(adminRegistry.admins(2) == address(0), "Admin was added before timelock elapsed");
+        executeQueued(address(adminRegistry), "_addAdmin", admin3);
         require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "New admin was not added correctly");
         require(adminRegistry.isAdminAddress(admin3), "Admin3 should be admin after voting");
 
@@ -379,6 +432,8 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "Admin was removed before enough votes were cast");
 
         user1.do(address(adminRegistry), "removeAdmin", admin3);
+        require(adminRegistry.admins(2) != address(0), "Admin was removed before timelock elapsed");
+        executeQueued(address(adminRegistry), "_removeAdmin", admin3);
         require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin was not removed correctly");
         require(!adminRegistry.isAdminAddress(admin3), "Admin3 should not be admin after removal");
 
@@ -387,6 +442,7 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin was swapped before enough votes were cast");
 
         user1.do(address(adminRegistry), "swapAdmin", admin1, admin3);
+        executeQueued(address(adminRegistry), "_swapAdmin", admin1, admin3);
         require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin swap should maintain same count");
     }
 
@@ -400,12 +456,14 @@ contract Describe_AdminRegistry is Authorizable {
         // Vote on first issue
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
+        executeQueued(address(token), "mint", admin3, 1000e18);
 
         require(ERC20(token).balanceOf(admin3) == 1000e18, "First issue should be executed");
 
         // Vote on second issue
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 2000e18);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 2000e18);
+        executeQueued(address(token), "mint", admin3, 2000e18);
 
         require(ERC20(token).balanceOf(admin3) == 3000e18, "Second issue should be executed");
     }
@@ -429,9 +487,11 @@ contract Describe_AdminRegistry is Authorizable {
         uint voteIndex2 = adminRegistry.votesMap(issueId, admin1);
         require(voteIndex2 == voteIndex1, "Same admin voting twice should be idempotent");
 
-        // Third vote from different admin - should execute
+        // Third vote from different admin - should queue
         (bool executed3, variadic result3) = user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
-        require(executed3, "Should execute with two different admin votes");
+        require(!executed3, "Should queue with two different admin votes");
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+        executeQueued(address(token), "mint", admin3, 1000e18);
         require(ERC20(token).balanceOf(admin3) == 1000e18, "Token should be minted");
     }
 
@@ -453,6 +513,7 @@ contract Describe_AdminRegistry is Authorizable {
         // First add user2 to whitelist for token mint function
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(token), "mint", address(user2));
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "addWhitelist", address(token), "mint", address(user2));
+        executeQueued(address(adminRegistry), "addWhitelist", address(token), "mint", address(user2));
 
         // Now user2 should be able to vote on token mint issues
         (bool executed, variadic result) = user2.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
@@ -464,10 +525,13 @@ contract Describe_AdminRegistry is Authorizable {
         // Set custom threshold to 50% (5000 basis points)
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(token), "mint", 5000);
 
-        // With 2 admins, 50% threshold should require 1 vote
+        // With 2 admins, 50% threshold should require 1 vote to queue
         (bool executed, variadic result) = adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
-        require(executed, "Should execute with 50% threshold and 1 vote");
+        require(!executed, "Should queue with 50% threshold and 1 vote");
+        executeQueued(address(token), "mint", admin3, 1000e18);
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Token should be minted after delay");
     }
 
     function it_admin_registry_executes_old_issue_when_admin_count_decreases() {
@@ -491,15 +555,16 @@ contract Describe_AdminRegistry is Authorizable {
         // Step 2: Vote to remove user1 (the second admin) - this requires both admins to vote
         adminRegistry.removeAdmin(address(user1));
         user1.do(address(adminRegistry), "removeAdmin", address(user1));
+        executeQueued(address(adminRegistry), "_removeAdmin", address(user1));
 
         // Verify user1 is no longer an admin
         require(!adminRegistry.isAdminAddress(address(user1)), "User1 should no longer be an admin");
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin");
 
         // Step 3: Admin1 calls the same issue again (adding admin3)
-        // Now with only 1 admin, 1 vote = 100% (exceeds 67% threshold)
-        adminRegistry.addAdmin(admin3);
-        // Should execute this time
+        // Now with only 1 admin, 1 vote = 100%, so it executes immediately
+        (bool executed, variadic result) = adminRegistry.castVoteOnIssue(address(adminRegistry), "_addAdmin", admin3);
+        require(executed, "Single admin issue should execute immediately");
 
         // Verify admin3 was added
         require(adminRegistry.isAdminAddress(admin3), "Admin3 should now be an admin");
@@ -533,10 +598,13 @@ contract Describe_AdminRegistry is Authorizable {
     function it_cannot_execute_internal_functions() {
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(adminRegistry), "_getIssueId", 5000);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(adminRegistry), "_getIssueId", 5000);
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(adminRegistry), "_getIssueId", 5000);
 
         bool reverted = false;
         try {
             adminRegistry.castVoteOnIssue(address(adminRegistry), "_getIssueId", address(0xdeadbeef), "parmesan", 7);
+            fastForward(172800);
+            adminRegistry.executeIssue(address(adminRegistry), "_getIssueId", address(0xdeadbeef), "parmesan", 7);
         } catch {
             reverted = true;
         }
@@ -554,6 +622,7 @@ contract Describe_AdminRegistry is Authorizable {
         // Step 1: Remove user1 (second admin) - this should succeed
         adminRegistry.removeAdmin(address(user1));
         user1.do(address(adminRegistry), "removeAdmin", address(user1));
+        executeQueued(address(adminRegistry), "_removeAdmin", address(user1));
 
         // Verify user1 is no longer an admin and only admin1 remains
         require(!adminRegistry.isAdminAddress(address(user1)), "User1 should no longer be an admin");
@@ -562,8 +631,8 @@ contract Describe_AdminRegistry is Authorizable {
         // Step 2: Try to remove the last admin (admin1) - this should revert
         bool reverted = false;
         try {
-            // Since we're now the only admin, our single vote would normally execute immediately
-            // But the _removeAdmin function should revert before execution
+            // Since we're now the only admin, our single vote executes immediately
+            // But the _removeAdmin function should revert during execution
             adminRegistry.removeAdmin(admin1);
         } catch {
             reverted = true;
@@ -601,10 +670,12 @@ contract Describe_AdminRegistry is Authorizable {
         // Add a third admin
         adminRegistry.addAdmin(admin3);
         user1.do(address(adminRegistry), "addAdmin", admin3);
+        executeQueued(address(adminRegistry), "_addAdmin", admin3);
 
         // Set threshold to 100% so 2 votes won't execute (need 3 votes with 3 admins)
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
 
         // Create an issue with proposer's vote
         string memory issueId = adminRegistry.getIssueId(address(token), "mint", nonAdmin, 1000e18);
@@ -630,6 +701,132 @@ contract Describe_AdminRegistry is Authorizable {
             reverted = true;
         }
         require(reverted, "Should revert when trying to dismiss issue with multiple votes");
+    }
+
+    function it_admin_registry_cannot_execute_before_timelock_delay() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        require(issueExecutableAt(issueId) == block.timestamp + 172800, "Executable timestamp should include delay");
+
+        bool reverted = false;
+        try {
+            adminRegistry.executeIssue(address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should not execute before timelock delay");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted before delay");
+    }
+
+    function it_admin_registry_timelock_struct_defaults_to_zero() {
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
+        assertTimelock(issueId, 0, 0, 0);
+
+        adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+        assertTimelock(issueId, 0, 0, 0);
+    }
+
+    function it_admin_registry_timelock_struct_records_queue_window() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        uint queuedAt = block.timestamp;
+        assertTimelock(issueId, queuedAt, queuedAt + 172800, queuedAt + 172800 + 1209600);
+
+        string memory otherIssueId = adminRegistry.getIssueId(address(token), "mint", admin3, 2000e18);
+        assertTimelock(otherIssueId, 0, 0, 0);
+    }
+
+    function it_admin_registry_cannot_vote_on_queued_issue() {
+        voteToQueue(address(token), "mint", admin3, 1000e18);
+
+        bool reverted = false;
+        try {
+            adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should not allow votes on queued issue");
+    }
+
+    function it_admin_registry_clear_timelock_zeroes_struct_fields_after_vote_withdrawal() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+
+        adminRegistry.withdrawVote(address(token), "mint", admin3, 1000e18);
+
+        assertTimelock(issueId, 0, 0, 0);
+        require(adminRegistry.currentIssues(issueId), "Issue should remain active after unqueue");
+        require(adminRegistry.votesMap(issueId, admin1) == 0, "Withdrawn vote should be cleared");
+        require(adminRegistry.votesMap(issueId, address(user1)) > 0, "Remaining vote should stay recorded");
+    }
+
+    function it_admin_registry_clear_issue_zeroes_timelock_struct_after_execution() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        require(issueExecutableAt(issueId) != 0, "Issue should be queued");
+
+        executeQueued(address(token), "mint", admin3, 1000e18);
+
+        assertTimelock(issueId, 0, 0, 0);
+        require(!adminRegistry.currentIssues(issueId), "Issue should be cleared after execution");
+        require(adminRegistry.votesMap(issueId, admin1) == 0, "Admin1 vote should be cleared");
+        require(adminRegistry.votesMap(issueId, address(user1)) == 0, "User1 vote should be cleared");
+    }
+
+    function it_admin_registry_requeue_after_clear_timelock_restarts_delay() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        (, uint firstExecutableAt,) = adminRegistry.timelocks(issueId);
+
+        adminRegistry.withdrawVote(address(token), "mint", admin3, 1000e18);
+        assertTimelock(issueId, 0, 0, 0);
+
+        fastForward(1);
+        adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+
+        uint requeuedAt = block.timestamp;
+        assertTimelock(issueId, requeuedAt, requeuedAt + 172800, requeuedAt + 172800 + 1209600);
+        require(issueExecutableAt(issueId) > firstExecutableAt, "Requeued issue should restart delay");
+    }
+
+    function it_admin_registry_can_withdraw_vote_from_queued_issue() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        adminRegistry.withdrawVote(address(token), "mint", admin3, 1000e18);
+
+        require(adminRegistry.currentIssues(issueId), "Issue should remain active with one vote");
+        require(adminRegistry.votesMap(issueId, admin1) == 0, "Withdrawn vote should be cleared");
+        require(adminRegistry.votesMap(issueId, address(user1)) > 0, "Other vote should remain");
+        require(issueExecutableAt(issueId) == 0, "Issue should unqueue when threshold is no longer met");
+
+        fastForward(172800);
+        bool reverted = false;
+        try {
+            adminRegistry.executeIssue(address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Unqueued issue should not execute");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted after vote withdrawal");
+    }
+
+    function it_admin_registry_rechecks_voting_threshold_before_execution() {
+        adminRegistry.addAdmin(address(user2));
+        user1.do(address(adminRegistry), "addAdmin", address(user2));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user2));
+
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
+        adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", admin3, 1000e18);
+        require(issueExecutableAt(issueId) != 0, "Issue should queue with two of three votes");
+
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+
+        bool reverted = false;
+        try {
+            adminRegistry.executeIssue(address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Issue should not execute when threshold is no longer met");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted after threshold change");
     }
 
     function it_admin_registry_cannot_dismiss_nonexistent_issue() {

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -26,6 +26,18 @@ contract User {
     }
 }
 
+contract GuardianAdminRegistry is AdminRegistry {
+    address guardian;
+
+    constructor(address _guardian) {
+        guardian = _guardian;
+    }
+
+    function isGuardian(address _account) public override returns (bool) {
+        return _account == guardian;
+    }
+}
+
 contract Describe_AdminRegistry is Authorizable {
     AdminRegistry adminRegistry;
     TestERC20 token;
@@ -68,7 +80,7 @@ contract Describe_AdminRegistry is Authorizable {
     }
 
     function executeQueued(address _target, string _func, variadic _args) internal returns (variadic) {
-        fastForward(172800);
+        fastForward(86400);
         return adminRegistry.executeIssue(_target, _func, _args);
     }
 
@@ -114,8 +126,8 @@ contract Describe_AdminRegistry is Authorizable {
         require(!executed, "Single admin issue should queue");
         require(ERC20(singleAdminToken).balanceOf(admin3) == 0, "Single admin token should not mint before delay");
         (, uint executableAt,) = singleRegistry.timelocks(issueId);
-        require(executableAt == block.timestamp + 172800, "Single admin issue should be queued");
-        fastForward(172800);
+        require(executableAt == block.timestamp + 86400, "Single admin issue should be queued");
+        fastForward(86400);
         singleRegistry.executeIssue(address(singleAdminToken), "mint", admin3, 1000e18);
         require(ERC20(singleAdminToken).balanceOf(admin3) == 1000e18, "Single admin token should mint after delay");
     }
@@ -237,12 +249,48 @@ contract Describe_AdminRegistry is Authorizable {
         require(threshold == 0, "Initial voting threshold should be 0");
     }
 
+    function it_admin_registry_rejects_voting_threshold_below_floor() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "Should reject voting threshold below floor");
+        require(adminRegistry.votingThresholds(address(token), "mint") == 0, "Threshold should not update");
+    }
+
+    function it_admin_registry_rejects_default_voting_threshold_below_floor() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "Should reject default voting threshold below floor");
+        require(adminRegistry.defaultVotingThresholdBps() == 6000, "Default threshold should not update");
+    }
+
     // ============ WHITELIST TESTS ============
 
     function it_admin_registry_has_whitelist_mapping() {
         // Test that whitelist mapping exists and is accessible
         bool whitelisted = adminRegistry.whitelist(address(token), "mint", address(user3));
         require(!whitelisted, "Initial whitelist should be false");
+    }
+
+    function it_admin_registry_has_instant_functions_mapping() {
+        require(!adminRegistry.instantFunctions(address(token), "mint"), "Initial instant function should be false");
     }
 
     // ============ VOTES TESTS ============
@@ -419,6 +467,113 @@ contract Describe_AdminRegistry is Authorizable {
         require(!adminRegistry.whitelist(address(token), "mint", admin3), "Whitelist should be removed after delay");
     }
 
+    function it_admin_registry_handles_instant_function_operations() {
+        (bool executed1, variadic result1) = adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        require(!executed1, "Should not set instant function with one vote");
+
+        (bool executed2, variadic result2) = user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        require(!executed2, "Should queue instant function update with two votes");
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        require(adminRegistry.instantFunctions(address(token), "mint"), "Instant function should be enabled after delay");
+    }
+
+    function it_admin_registry_executes_instant_function_without_vote_or_queue() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+        executeQueued(address(adminRegistry), "setInstantFunction", address(token), "mint", true);
+
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
+        (bool executed, variadic result) = adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+
+        require(executed, "Instant function should execute immediately");
+        require(ERC20(token).balanceOf(admin3) == 1000e18, "Token should be minted immediately");
+        require(!adminRegistry.currentIssues(issueId), "Instant function should not leave an active issue");
+        require(adminRegistry.votesMap(issueId, admin1) == 0, "Instant function should not record a vote");
+        require(issueExecutableAt(issueId) == 0, "Instant function should not queue");
+    }
+
+    function it_admin_registry_rejects_instant_governance_functions() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setInstantFunction", address(adminRegistry), "setVotingThreshold", true);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setInstantFunction", address(adminRegistry), "setVotingThreshold", true);
+
+        bool reverted = false;
+        try {
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "setInstantFunction", address(adminRegistry), "setVotingThreshold", true);
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "Should reject instant governance functions");
+        require(!adminRegistry.instantFunctions(address(adminRegistry), "setVotingThreshold"), "Governance function should not become instant");
+    }
+
+    function it_admin_registry_allows_guardian_to_execute_instant_function() {
+        address[] memory initialAdmins = new address[](2);
+        initialAdmins[0] = address(user1);
+        initialAdmins[1] = address(user3);
+        GuardianAdminRegistry guardianRegistry = new GuardianAdminRegistry(this);
+        guardianRegistry.initialize(initialAdmins);
+        TestERC20 guardianToken = new TestERC20("Guardian Token", "GT", address(guardianRegistry));
+
+        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        fastForward(86400);
+        guardianRegistry.executeIssue(address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+
+        string memory issueId = guardianRegistry.getIssueId(address(guardianToken), "mint", admin3, 1000e18);
+        guardianToken.mint(admin3, 1000e18);
+
+        require(ERC20(guardianToken).balanceOf(admin3) == 1000e18, "Guardian should mint through instant function");
+        require(!guardianRegistry.currentIssues(issueId), "Guardian instant function should not leave an active issue");
+        require(guardianRegistry.votesMap(issueId, this) == 0, "Guardian instant function should not record a vote");
+        (, uint executableAt,) = guardianRegistry.timelocks(issueId);
+        require(executableAt == 0, "Guardian instant function should not queue");
+    }
+
+    function it_admin_registry_allows_guardian_to_execute_instant_function_directly() {
+        address[] memory initialAdmins = new address[](2);
+        initialAdmins[0] = address(user1);
+        initialAdmins[1] = address(user3);
+        GuardianAdminRegistry guardianRegistry = new GuardianAdminRegistry(this);
+        guardianRegistry.initialize(initialAdmins);
+        TestERC20 guardianToken = new TestERC20("Guardian Token", "GT", address(guardianRegistry));
+
+        user1.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        user3.do(address(guardianRegistry), "castVoteOnIssue", address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+        fastForward(86400);
+        guardianRegistry.executeIssue(address(guardianRegistry), "setInstantFunction", address(guardianToken), "mint", true);
+
+        string memory issueId = guardianRegistry.getIssueId(address(guardianToken), "mint", admin3, 1000e18);
+        (bool executed, variadic result) = guardianRegistry.castVoteOnIssue(address(guardianToken), "mint", admin3, 1000e18);
+
+        require(executed, "Guardian should directly execute instant function");
+        require(ERC20(guardianToken).balanceOf(admin3) == 1000e18, "Guardian should mint through direct instant function");
+        require(!guardianRegistry.currentIssues(issueId), "Direct guardian instant function should not leave an active issue");
+        require(guardianRegistry.votesMap(issueId, this) == 0, "Direct guardian instant function should not record a vote");
+        (, uint executableAt,) = guardianRegistry.timelocks(issueId);
+        require(executableAt == 0, "Direct guardian instant function should not queue");
+    }
+
+    function it_admin_registry_rejects_guardian_non_instant_function() {
+        address[] memory initialAdmins = new address[](2);
+        initialAdmins[0] = address(user1);
+        initialAdmins[1] = address(user3);
+        GuardianAdminRegistry guardianRegistry = new GuardianAdminRegistry(this);
+        guardianRegistry.initialize(initialAdmins);
+        TestERC20 guardianToken = new TestERC20("Guardian Token", "GT", address(guardianRegistry));
+
+        bool reverted = false;
+        try {
+            guardianToken.mint(admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+
+        require(reverted, "Guardian should not vote on non-instant functions");
+        require(ERC20(guardianToken).balanceOf(admin3) == 0, "Guardian non-instant function should not execute");
+    }
+
     function it_admin_registry_handles_admin_management() {
         // Add admin using the proper addAdmin function
         adminRegistry.addAdmin(admin3);
@@ -430,23 +585,31 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "New admin was not added correctly");
         require(adminRegistry.isAdminAddress(admin3), "Admin3 should be admin after voting");
 
+        // Add a fourth admin so removal can stay above MIN_ADMIN_COUNT
+        adminRegistry.addAdmin(address(user2));
+        user1.do(address(adminRegistry), "addAdmin", address(user2));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user2));
+        require(adminRegistry.admins(3) != address(0) && adminRegistry.admins(4) == address(0), "Fourth admin was not added correctly");
+        require(adminRegistry.isAdminAddress(address(user2)), "User2 should be admin after voting");
+
         // Remove admin using the proper removeAdmin function
         adminRegistry.removeAdmin(admin3);
-        require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "Admin was removed before enough votes were cast");
+        require(adminRegistry.admins(3) != address(0) && adminRegistry.admins(4) == address(0), "Admin was removed before enough votes were cast");
 
         user1.do(address(adminRegistry), "removeAdmin", admin3);
+        user2.do(address(adminRegistry), "removeAdmin", admin3);
         require(adminRegistry.admins(2) != address(0), "Admin was removed before timelock elapsed");
         executeQueued(address(adminRegistry), "_removeAdmin", admin3);
-        require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin was not removed correctly");
+        require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "Admin was not removed correctly");
         require(!adminRegistry.isAdminAddress(admin3), "Admin3 should not be admin after removal");
 
         // Swap admin using the proper swapAdmin function
         adminRegistry.swapAdmin(admin1, admin3);
-        require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin was swapped before enough votes were cast");
+        require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "Admin was swapped before enough votes were cast");
 
         user1.do(address(adminRegistry), "swapAdmin", admin1, admin3);
         executeQueued(address(adminRegistry), "_swapAdmin", admin1, admin3);
-        require(adminRegistry.admins(1) != address(0) && adminRegistry.admins(2) == address(0), "Admin swap should maintain same count");
+        require(adminRegistry.admins(2) != address(0) && adminRegistry.admins(3) == address(0), "Admin swap should maintain same count");
     }
 
     function it_admin_registry_handles_complex_issue_execution() {
@@ -538,34 +701,39 @@ contract Describe_AdminRegistry is Authorizable {
     }
 
     function it_admin_registry_executes_old_issue_when_admin_count_decreases() {
-        // Scenario: Issue created with 2 admins fails to reach quorum (1 vote out of 2 = 50% < 67%)
-        // Then an admin is removed, leaving 1 admin
-        // The same issue called again should now execute (1 vote out of 1 = 100%)
+        // Scenario: Issue created with 4 admins fails to reach quorum (2 votes out of 4 = 50% < 60%)
+        // Then an admin is removed, leaving 3 admins.
+        // The same issue called again should now queue (2 votes out of 3 = 66%).
 
-        // Step 1: Admin1 votes to add admin3 (1 out of 2 admins = 50%, needs 67%)
+        adminRegistry.addAdmin(address(user2));
+        user1.do(address(adminRegistry), "addAdmin", address(user2));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user2));
+
+        adminRegistry.addAdmin(address(user3));
+        user1.do(address(adminRegistry), "addAdmin", address(user3));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user3));
+
+        // Step 1: Admin1 and user1 vote to add admin3 (2 out of 4 admins = 50%, needs 60%)
         string memory issueId = adminRegistry.getIssueId(address(adminRegistry), "_addAdmin", admin3);
         adminRegistry.addAdmin(admin3);
-        // Verify it did not execute yet (would need to check the return value if we used castVoteOnIssue)
-        // Instead we just verify admin3 is not added yet
-
-        // Verify admin3 is not yet an admin
+        user1.do(address(adminRegistry), "addAdmin", admin3);
         require(!adminRegistry.isAdminAddress(admin3), "Admin3 should not be admin yet");
 
-        // Verify the vote was recorded
         uint voteIndex1 = adminRegistry.votesMap(issueId, admin1);
         require(voteIndex1 > 0, "Admin1's vote should be recorded");
+        require(adminRegistry.votesMap(issueId, address(user1)) > 0, "User1's vote should be recorded");
 
-        // Step 2: Vote to remove user1 (the second admin) - this requires both admins to vote
-        adminRegistry.removeAdmin(address(user1));
-        user1.do(address(adminRegistry), "removeAdmin", address(user1));
-        executeQueued(address(adminRegistry), "_removeAdmin", address(user1));
+        // Step 2: Remove one admin while staying at the minimum admin count
+        adminRegistry.removeAdmin(address(user3));
+        user1.do(address(adminRegistry), "removeAdmin", address(user3));
+        user2.do(address(adminRegistry), "removeAdmin", address(user3));
+        executeQueued(address(adminRegistry), "_removeAdmin", address(user3));
 
-        // Verify user1 is no longer an admin
-        require(!adminRegistry.isAdminAddress(address(user1)), "User1 should no longer be an admin");
+        require(!adminRegistry.isAdminAddress(address(user3)), "User3 should no longer be an admin");
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin");
 
         // Step 3: Admin1 calls the same issue again (adding admin3)
-        // Now with only 1 admin, 1 vote = 100% (exceeds 67% threshold), so it queues
+        // Now with 3 admins, the existing two votes exceed the 60% threshold, so it queues
         adminRegistry.addAdmin(admin3);
         executeQueued(address(adminRegistry), "_addAdmin", admin3);
 
@@ -606,7 +774,7 @@ contract Describe_AdminRegistry is Authorizable {
         bool reverted = false;
         try {
             adminRegistry.castVoteOnIssue(address(adminRegistry), "_getIssueId", address(0xdeadbeef), "parmesan", 7);
-            fastForward(172800);
+            fastForward(86400);
             adminRegistry.executeIssue(address(adminRegistry), "_getIssueId", address(0xdeadbeef), "parmesan", 7);
         } catch {
             reverted = true;
@@ -614,39 +782,48 @@ contract Describe_AdminRegistry is Authorizable {
         require(reverted, "Should revert when delegatecalling into an internal function");
     }
 
-    function it_admin_registry_prevents_removal_of_last_admin() {
-        // Scenario: Start with 2 admins, remove one, then try to remove the last one
-        // Should revert with "Cannot remove the last admin"
+    function it_admin_registry_prevents_removal_below_min_admin_count() {
+        // Scenario: Start with 4 admins, remove one, then try to remove below MIN_ADMIN_COUNT
 
         // Verify we start with 2 admins
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should be an admin");
         require(adminRegistry.isAdminAddress(address(user1)), "User1 should be an admin");
 
-        // Step 1: Remove user1 (second admin) - this should succeed
-        adminRegistry.removeAdmin(address(user1));
-        user1.do(address(adminRegistry), "removeAdmin", address(user1));
-        executeQueued(address(adminRegistry), "_removeAdmin", address(user1));
+        adminRegistry.addAdmin(address(user2));
+        user1.do(address(adminRegistry), "addAdmin", address(user2));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user2));
 
-        // Verify user1 is no longer an admin and only admin1 remains
-        require(!adminRegistry.isAdminAddress(address(user1)), "User1 should no longer be an admin");
+        adminRegistry.addAdmin(address(user3));
+        user1.do(address(adminRegistry), "addAdmin", address(user3));
+        executeQueued(address(adminRegistry), "_addAdmin", address(user3));
+
+        // Step 1: Remove one admin - this should succeed because it leaves 3 admins
+        adminRegistry.removeAdmin(address(user3));
+        user1.do(address(adminRegistry), "removeAdmin", address(user3));
+        user2.do(address(adminRegistry), "removeAdmin", address(user3));
+        executeQueued(address(adminRegistry), "_removeAdmin", address(user3));
+
+        // Verify user3 is no longer an admin and 3 admins remain
+        require(!adminRegistry.isAdminAddress(address(user3)), "User3 should no longer be an admin");
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin");
+        require(adminRegistry.isAdminAddress(address(user1)), "User1 should still be an admin");
+        require(adminRegistry.isAdminAddress(address(user2)), "User2 should still be an admin");
 
-        // Step 2: Try to remove the last admin (admin1) - this should revert
+        // Step 2: Try to remove below the minimum - this should revert at execution
         bool reverted = false;
         try {
-            // Since we're now the only admin, our single vote queues immediately
-            // But the _removeAdmin function should revert before execution
-            adminRegistry.removeAdmin(admin1);
-            fastForward(172800);
-            adminRegistry.executeIssue(address(adminRegistry), "_removeAdmin", admin1);
+            adminRegistry.removeAdmin(address(user2));
+            user1.do(address(adminRegistry), "removeAdmin", address(user2));
+            fastForward(86400);
+            adminRegistry.executeIssue(address(adminRegistry), "_removeAdmin", address(user2));
         } catch {
             reverted = true;
         }
 
-        require(reverted, "Should revert when trying to remove the last admin");
+        require(reverted, "Should revert when trying to remove below min admin count");
 
-        // Verify admin1 is still an admin
-        require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin after failed removal");
+        // Verify user2 is still an admin
+        require(adminRegistry.isAdminAddress(address(user2)), "User2 should still be an admin after failed removal");
     }
 
     // ============ ISSUE DISMISSAL TESTS ============
@@ -710,7 +887,7 @@ contract Describe_AdminRegistry is Authorizable {
 
     function it_admin_registry_cannot_execute_before_timelock_delay() {
         string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
-        require(issueExecutableAt(issueId) == block.timestamp + 172800, "Executable timestamp should include delay");
+        require(issueExecutableAt(issueId) == block.timestamp + 86400, "Executable timestamp should include delay");
 
         bool reverted = false;
         try {
@@ -733,7 +910,7 @@ contract Describe_AdminRegistry is Authorizable {
     function it_admin_registry_timelock_struct_records_queue_window() {
         string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
         uint queuedAt = block.timestamp;
-        assertTimelock(issueId, queuedAt, queuedAt + 172800, queuedAt + 172800 + 1209600);
+        assertTimelock(issueId, queuedAt, queuedAt + 86400, queuedAt + 86400 + 86400);
 
         string memory otherIssueId = adminRegistry.getIssueId(address(token), "mint", admin3, 2000e18);
         assertTimelock(otherIssueId, 0, 0, 0);
@@ -786,7 +963,7 @@ contract Describe_AdminRegistry is Authorizable {
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
 
         uint requeuedAt = block.timestamp;
-        assertTimelock(issueId, requeuedAt, requeuedAt + 172800, requeuedAt + 172800 + 1209600);
+        assertTimelock(issueId, requeuedAt, requeuedAt + 86400, requeuedAt + 86400 + 86400);
         require(issueExecutableAt(issueId) > firstExecutableAt, "Requeued issue should restart delay");
     }
 
@@ -799,7 +976,7 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.votesMap(issueId, address(user1)) > 0, "Other vote should remain");
         require(issueExecutableAt(issueId) == 0, "Issue should unqueue when threshold is no longer met");
 
-        fastForward(172800);
+        fastForward(86400);
         bool reverted = false;
         try {
             adminRegistry.executeIssue(address(token), "mint", admin3, 1000e18);

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -249,36 +249,20 @@ contract Describe_AdminRegistry is Authorizable {
         require(threshold == 0, "Initial voting threshold should be 0");
     }
 
-    function it_admin_registry_rejects_voting_threshold_below_floor() {
+    function it_admin_registry_allows_voting_threshold_below_half() {
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
 
-        bool reverted = false;
-        try {
-            fastForward(86400);
-            adminRegistry.executeIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
-        } catch {
-            reverted = true;
-        }
-
-        require(reverted, "Should reject voting threshold below floor");
-        require(adminRegistry.votingThresholds(address(token), "mint") == 0, "Threshold should not update");
+        executeQueued(address(adminRegistry), "setVotingThreshold", address(token), "mint", 4999);
+        require(adminRegistry.votingThresholds(address(token), "mint") == 4999, "Threshold should update");
     }
 
-    function it_admin_registry_rejects_default_voting_threshold_below_floor() {
+    function it_admin_registry_allows_default_voting_threshold_below_half() {
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
 
-        bool reverted = false;
-        try {
-            fastForward(86400);
-            adminRegistry.executeIssue(address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
-        } catch {
-            reverted = true;
-        }
-
-        require(reverted, "Should reject default voting threshold below floor");
-        require(adminRegistry.defaultVotingThresholdBps() == 6000, "Default threshold should not update");
+        executeQueued(address(adminRegistry), "setDefaultVotingThresholdBps", 4999);
+        require(adminRegistry.defaultVotingThresholdBps() == 4999, "Default threshold should update");
     }
 
     // ============ WHITELIST TESTS ============
@@ -902,6 +886,25 @@ contract Describe_AdminRegistry is Authorizable {
         require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted before delay");
     }
 
+    function it_admin_registry_cannot_execute_after_timelock_grace_period_expires() {
+        string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
+        (uint queuedAt, uint executableAt, uint expiresAt) = adminRegistry.timelocks(issueId);
+        require(executableAt == queuedAt + 86400, "Executable timestamp should include delay");
+        require(expiresAt == executableAt + 604800, "Expiration timestamp should include grace period");
+
+        fastForward(86400 + 604800 + 1);
+
+        bool reverted = false;
+        try {
+            adminRegistry.executeIssue(address(token), "mint", admin3, 1000e18);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should not execute after timelock grace period expires");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted after expiration");
+        assertTimelock(issueId, queuedAt, executableAt, expiresAt);
+    }
+
     function it_admin_registry_timelock_struct_defaults_to_zero() {
         string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
         assertTimelock(issueId, 0, 0, 0);
@@ -913,7 +916,7 @@ contract Describe_AdminRegistry is Authorizable {
     function it_admin_registry_timelock_struct_records_queue_window() {
         string memory issueId = voteToQueue(address(token), "mint", admin3, 1000e18);
         uint queuedAt = block.timestamp;
-        assertTimelock(issueId, queuedAt, queuedAt + 86400, queuedAt + 86400 + 86400);
+        assertTimelock(issueId, queuedAt, queuedAt + 86400, queuedAt + 86400 + 604800);
 
         string memory otherIssueId = adminRegistry.getIssueId(address(token), "mint", admin3, 2000e18);
         assertTimelock(otherIssueId, 0, 0, 0);
@@ -966,7 +969,7 @@ contract Describe_AdminRegistry is Authorizable {
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
 
         uint requeuedAt = block.timestamp;
-        assertTimelock(issueId, requeuedAt, requeuedAt + 86400, requeuedAt + 86400 + 86400);
+        assertTimelock(issueId, requeuedAt, requeuedAt + 86400, requeuedAt + 86400 + 604800);
         require(issueExecutableAt(issueId) > firstExecutableAt, "Requeued issue should restart delay");
     }
 

--- a/mercata/contracts/tests/Bridge/MercataBridge.test.sol
+++ b/mercata/contracts/tests/Bridge/MercataBridge.test.sol
@@ -343,6 +343,34 @@ contract Describe_MercataBridge is Authorizable {
         require(bridge.withdrawalsPaused(), "Withdrawals should be paused");
     }
 
+    function it_bridge_pause_shims_set_true_only() {
+        // Start clean
+        bridge.setPause(false, false);
+        require(!bridge.depositsPaused() && !bridge.withdrawalsPaused(), "Precondition: both unpaused");
+
+        // pauseDeposits sets only deposits
+        bridge.pauseDeposits();
+        require(bridge.depositsPaused(), "pauseDeposits should set depositsPaused true");
+        require(!bridge.withdrawalsPaused(), "pauseDeposits should not touch withdrawalsPaused");
+
+        // Idempotent
+        bridge.pauseDeposits();
+        require(bridge.depositsPaused(), "pauseDeposits should remain true on repeat");
+
+        // pauseWithdrawals sets only withdrawals
+        bridge.setPause(false, false);
+        bridge.pauseWithdrawals();
+        require(bridge.withdrawalsPaused(), "pauseWithdrawals should set withdrawalsPaused true");
+        require(!bridge.depositsPaused(), "pauseWithdrawals should not touch depositsPaused");
+
+        // Both shims combined
+        bridge.pauseDeposits();
+        require(bridge.depositsPaused() && bridge.withdrawalsPaused(), "Both shims together should pause both");
+
+        // Reset
+        bridge.setPause(false, false);
+    }
+
     function it_bridge_can_set_usdst_address() {
         address newUSDST = address(0xBBBB);
         bridge.setUSDSTAddress(newUSDST);

--- a/mercata/contracts/tests/CDP/CDPEngine.test.sol
+++ b/mercata/contracts/tests/CDP/CDPEngine.test.sol
@@ -729,6 +729,35 @@ contract Describe_CDPEngine is Authorizable {
         require(!cdpEngine.globalPaused(), "Engine should be unpaused");
     }
 
+    function it_cdp_engine_pause_shims_set_true_only() {
+        // pauseAsset shim
+        cdpEngine.pauseAsset(collateralTokenAddress);
+        (, , , , , , , , bool _paused) = cdpEngine.collateralConfigs(collateralTokenAddress);
+        require(_paused == true, "pauseAsset should set isPaused true");
+
+        // Idempotent
+        cdpEngine.pauseAsset(collateralTokenAddress);
+        (, , , , , , , , bool _paused2) = cdpEngine.collateralConfigs(collateralTokenAddress);
+        require(_paused2 == true, "pauseAsset should remain true on repeat");
+
+        // pauseGlobal shim
+        cdpEngine.pauseGlobal();
+        require(cdpEngine.globalPaused(), "pauseGlobal should set globalPaused true");
+
+        // Unsupported asset reverts
+        bool reverted = false;
+        try {
+            cdpEngine.pauseAsset(address(0xdead));
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "pauseAsset should reject unsupported asset");
+
+        // Reset for other tests
+        cdpEngine.setPaused(collateralTokenAddress, false);
+        cdpEngine.setPausedGlobal(false);
+    }
+
     // // ============ SUPPORTED ASSET TOGGLE TESTS ============
 
     function it_cdp_engine_can_toggle_supported_asset_and_block_deposit_and_mint() {

--- a/mercata/contracts/tests/Pool/Pool.test.sol
+++ b/mercata/contracts/tests/Pool/Pool.test.sol
@@ -1978,6 +1978,28 @@ function it_single_token_a_zap_matches_swap_then_add_with_fees() {
         require(pool.isDisabled() == true, "setDisabled(true) should set isDisabled");
     }
 
+    function it_pool_pause_shim_sets_true_only() {
+        require(pool.isPaused() == false, "Pool should start unpaused");
+
+        pool.pause();
+        require(pool.isPaused() == true, "pause() should set isPaused true");
+
+        // Idempotent: pausing an already-paused pool succeeds
+        pool.pause();
+        require(pool.isPaused() == true, "pause() should remain true on repeat");
+
+        // Cannot pause while disabled
+        pool.setPaused(false);
+        pool.setDisabled(true);
+        bool reverted = false;
+        try {
+            pool.pause();
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "pause() should revert when isDisabled");
+    }
+
     function it_pool_pause_state_persists_across_operations() {
         // Setup: add initial liquidity
         uint256 amountA = 1000e18;

--- a/mercata/contracts/tests/Pool/StablePool.test.sol
+++ b/mercata/contracts/tests/Pool/StablePool.test.sol
@@ -402,6 +402,28 @@ contract Describe_StablePool is Authorizable {
         require(pool.isDisabled() == true, "setDisabled(true) should set isDisabled");
     }
 
+    function it_pool_pause_shim_sets_true_only() {
+        require(pool.isPaused() == false, "Pool should start unpaused");
+
+        pool.pause();
+        require(pool.isPaused() == true, "pause() should set isPaused true");
+
+        // Idempotent
+        pool.pause();
+        require(pool.isPaused() == true, "pause() should remain true on repeat");
+
+        // Cannot pause while disabled
+        pool.setPaused(false);
+        pool.setDisabled(true);
+        bool reverted = false;
+        try {
+            pool.pause();
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "pause() should revert when isDisabled");
+    }
+
     function it_pool_pause_state_persists_across_operations() {
         uint256 amountA = 2000e18;
         uint256 amountB = 2000e18;

--- a/mercata/ui/src/components/admin/AddGuardianModal.tsx
+++ b/mercata/ui/src/components/admin/AddGuardianModal.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+type AddGuardianFormValues = {
+  userAddress: string;
+};
+
+interface AddGuardianModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAddGuardian: (userAddress: string) => Promise<void>;
+  guardians: Array<{ address: string }>;
+  admins: Array<{ address: string }>;
+}
+
+const AddGuardianModal: React.FC<AddGuardianModalProps> = ({
+  open,
+  onOpenChange,
+  onAddGuardian,
+  guardians,
+  admins,
+}) => {
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<AddGuardianFormValues>({
+    defaultValues: {
+      userAddress: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (values: AddGuardianFormValues) => {
+    const trimmedAddress = values.userAddress.trim();
+
+    setIsSubmitting(true);
+    try {
+      await onAddGuardian(trimmedAddress);
+
+      toast({
+        title: 'Issue to Add Guardian Created',
+        description: 'Your guardian issue has been submitted for voting.',
+      });
+
+      form.reset({ userAddress: '' });
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Add guardian failed:', err);
+      toast({
+        title: 'Failed to add guardian',
+        description: err instanceof Error ? err.message : 'Please check the address and try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !isSubmitting && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Add Guardian</DialogTitle>
+          <DialogDescription>
+            Enter the address of the user you want to grant guardian rights.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {/* User Address */}
+            <FormField
+              control={form.control}
+              name="userAddress"
+              rules={{
+                required: 'User address is required',
+                validate: (v) => {
+                  const trimmed = v.trim();
+                  if (trimmed.length === 0) return 'User address cannot be empty';
+                  if (!/^[a-fA-F0-9]{40}$/.test(trimmed)) {
+                    return 'Please enter a valid 40-character hexadecimal address';
+                  }
+                  const isAlreadyGuardian = guardians.some(
+                    (guardian) => guardian.address.toLowerCase() === trimmed.toLowerCase()
+                  );
+                  if (isAlreadyGuardian) {
+                    return 'This address is already a guardian';
+                  }
+                  const isAdmin = admins.some(
+                    (admin) => admin.address.toLowerCase() === trimmed.toLowerCase()
+                  );
+                  if (isAdmin) {
+                    return 'An admin cannot be a guardian';
+                  }
+                  return true;
+                },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>User Address</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      className="font-mono"
+                    />
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting || !form.formState.isValid}
+                className="bg-strato-blue hover:bg-strato-blue/90"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Adding Guardian...
+                  </>
+                ) : (
+                  'Add Guardian'
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddGuardianModal;

--- a/mercata/ui/src/components/admin/CastVoteModal.tsx
+++ b/mercata/ui/src/components/admin/CastVoteModal.tsx
@@ -13,12 +13,19 @@ interface CastVoteModalProps {
     issueId: string;
     target: string;
     func: string;
-    args: any[];
+    args: unknown[];
     votesCast: number;
     votesNeeded: number;
     threshold: number;
+    timelock?: {
+      queuedAt: number;
+      executableAt: number;
+      expiresAt: number;
+    };
   } | null;
   onCastVote: (issueId: string) => Promise<void> | void;
+  onExecuteIssue?: (target: string, func: string, args: unknown[]) => Promise<void> | void;
+  onWithdrawVote?: (target: string, func: string, args: unknown[]) => Promise<void> | void;
   onDismissIssue?: (issueId: string) => Promise<void> | void;
   votes?: Array<{ issueId: string; index: number; voter: string }>;
   userAddress?: string | null;
@@ -29,6 +36,8 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
   onOpenChange,
   issue,
   onCastVote,
+  onExecuteIssue,
+  onWithdrawVote,
   onDismissIssue,
   votes = [],
   userAddress,
@@ -36,6 +45,8 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDismissing, setIsDismissing] = useState(false);
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
 
   const handleSubmit = async () => {
     if (!issue) return;
@@ -73,13 +84,63 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
     }
   };
 
+  const handleWithdraw = async () => {
+    if (!issue || !onWithdrawVote) return;
+
+    setIsWithdrawing(true);
+    try {
+      await onWithdrawVote(issue.target, issue.func, issue.args);
+      
+      toast({
+        title: 'Vote Withdrawn Successfully',
+        description: 'Your vote has been withdrawn.',
+      });
+
+      onOpenChange(false);
+    } finally {
+      setIsWithdrawing(false);
+    }
+  };
+
+  const handleExecute = async () => {
+    if (!issue || !onExecuteIssue) return;
+
+    setIsExecuting(true);
+    try {
+      await onExecuteIssue(issue.target, issue.func, issue.args);
+
+      toast({
+        title: 'Issue Executed Successfully',
+        description: 'The queued issue has been executed.',
+      });
+
+      onOpenChange(false);
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  const issueVotes = issue ? votes.filter(v => v.issueId === issue.issueId) : [];
+  const hasUserVoted = !!userAddress && issueVotes.some(v => v.voter === userAddress);
+  const isQueued = Number(issue?.timelock?.executableAt || 0) > 0;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const executableAt = Number(issue?.timelock?.executableAt || 0);
+  const expiresAt = Number(issue?.timelock?.expiresAt || 0);
+  const canExecute = !!onExecuteIssue && isQueued && nowSeconds >= executableAt && nowSeconds <= expiresAt;
+  const isExpired = isQueued && expiresAt > 0 && nowSeconds > expiresAt;
+
+  const formatTime = (timestamp?: number) => {
+    if (!timestamp) return '-';
+    return new Date(timestamp * 1000).toLocaleString();
+  };
+
   // Check if dismiss button should be enabled
   const canDismiss = issue && onDismissIssue && userAddress && votes.length > 0
     ? (() => {
-        const issueVotes = votes.filter(v => v.issueId === issue.issueId);
         return issueVotes.length === 1 && issueVotes[0]?.voter === userAddress;
       })()
     : false;
+  const canWithdraw = !!onWithdrawVote && hasUserVoted;
 
   // Get tooltip message for disabled button
   const getTooltipMessage = (): string | null => {
@@ -87,7 +148,6 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
       return null;
     }
     
-    const issueVotes = votes.filter(v => v.issueId === issue.issueId);
     if (issueVotes.length === 0) {
       return null;
     }
@@ -108,7 +168,7 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
   if (!issue) return null;
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !isSubmitting && onOpenChange(o)}>
+    <Dialog open={open} onOpenChange={(o) => !isSubmitting && !isDismissing && !isWithdrawing && !isExecuting && onOpenChange(o)}>
       <DialogContent className="sm:max-w-[600px] max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Vote on Issue</DialogTitle>
@@ -180,6 +240,26 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
               <div className="text-2xl font-bold text-strato-blue">{issue.threshold}%</div>
             </div>
           </div>
+
+          {isQueued && (
+            <div className="space-y-2">
+              <div className="text-sm font-semibold text-foreground">Queue Status</div>
+              <div className="grid grid-cols-1 gap-2 p-3 bg-muted/50 rounded-lg border border-border text-sm">
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Queued</span>
+                  <span className="font-mono text-right">{formatTime(issue.timelock?.queuedAt)}</span>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Executable</span>
+                  <span className="font-mono text-right">{formatTime(issue.timelock?.executableAt)}</span>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Expires</span>
+                  <span className="font-mono text-right">{formatTime(issue.timelock?.expiresAt)}</span>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Actions */}
@@ -193,7 +273,7 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
                       type="button"
                       variant="outline"
                       onClick={handleDismiss}
-                      disabled={!onDismissIssue || !canDismiss || isDismissing || isSubmitting}
+                      disabled={!onDismissIssue || !canDismiss || isQueued || isDismissing || isSubmitting || isWithdrawing || isExecuting}
                       className="text-red-600 border-red-600 hover:bg-red-50"
                     >
                       {isDismissing ? (
@@ -216,26 +296,44 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
             </TooltipProvider>
           </div>
           <div className="flex gap-3">
+            {hasUserVoted && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleWithdraw}
+                disabled={!canWithdraw || isSubmitting || isDismissing || isWithdrawing || isExecuting}
+                className="text-red-600 border-red-600 hover:bg-red-50"
+              >
+                {isWithdrawing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Withdrawing...
+                  </>
+                ) : (
+                  'Withdraw Vote'
+                )}
+              </Button>
+            )}
             <Button
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isSubmitting || isDismissing}
+              disabled={isSubmitting || isDismissing || isWithdrawing || isExecuting}
             >
               Cancel
             </Button>
             <Button
-              onClick={handleSubmit}
-              disabled={isSubmitting || isDismissing}
+              onClick={isQueued ? handleExecute : handleSubmit}
+              disabled={(isQueued ? !canExecute : hasUserVoted) || isSubmitting || isDismissing || isWithdrawing || isExecuting}
               className="bg-strato-blue hover:bg-strato-blue/90"
             >
-              {isSubmitting ? (
+              {isSubmitting || isExecuting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Casting Vote...
+                  {isExecuting ? 'Executing...' : 'Casting Vote...'}
                 </>
               ) : (
-                'Confirm Vote'
+                isQueued ? (canExecute ? 'Execute' : isExpired ? 'Expired' : 'Queued') : hasUserVoted ? 'Vote Cast' : 'Confirm Vote'
               )}
             </Button>
           </div>

--- a/mercata/ui/src/components/admin/RemoveGuardianModal.tsx
+++ b/mercata/ui/src/components/admin/RemoveGuardianModal.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+type RemoveGuardianFormValues = {
+  userAddress: string;
+};
+
+interface RemoveGuardianModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRemoveGuardian: (userAddress: string) => Promise<void>;
+  guardians: Array<{ address: string }>;
+}
+
+const RemoveGuardianModal: React.FC<RemoveGuardianModalProps> = ({
+  open,
+  onOpenChange,
+  onRemoveGuardian,
+  guardians,
+}) => {
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<RemoveGuardianFormValues>({
+    defaultValues: {
+      userAddress: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (values: RemoveGuardianFormValues) => {
+    setIsSubmitting(true);
+    try {
+      await onRemoveGuardian(values.userAddress);
+
+      toast({
+        title: 'Issue to Remove Guardian Created',
+        description: 'Your guardian issue has been submitted for voting.',
+      });
+
+      form.reset({ userAddress: '' });
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Remove guardian failed:', err);
+      toast({
+        title: 'Failed to remove guardian',
+        description: err instanceof Error ? err.message : 'Please check the address and try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !isSubmitting && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Remove Guardian</DialogTitle>
+          <DialogDescription>
+            Select the guardian you want to revoke guardian rights from.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {/* User Address */}
+            <FormField
+              control={form.control}
+              name="userAddress"
+              rules={{
+                required: 'Please select a guardian to remove',
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Select Guardian to Remove</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="font-mono">
+                        <SelectValue placeholder="Select a guardian..." />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {guardians.length === 0 ? (
+                        <SelectItem value="no-guardians" disabled>
+                          No guardians available
+                        </SelectItem>
+                      ) : (
+                        guardians.map((guardian) => (
+                          <SelectItem
+                            key={guardian.address}
+                            value={guardian.address}
+                            className="font-mono"
+                          >
+                            {guardian.address}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting || !form.formState.isValid}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Removing Guardian...
+                  </>
+                ) : (
+                  'Remove Guardian'
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RemoveGuardianModal;

--- a/mercata/ui/src/components/admin/VoteTab.tsx
+++ b/mercata/ui/src/components/admin/VoteTab.tsx
@@ -17,15 +17,19 @@ import CreateAdminIssueModal from './CreateAdminIssueModal';
 import CastVoteModal from './CastVoteModal';
 import AddAdminModal from './AddAdminModal';
 import RemoveAdminModal from './RemoveAdminModal';
+import AddGuardianModal from './AddGuardianModal';
+import RemoveGuardianModal from './RemoveGuardianModal';
 import { parseJsonBigInt } from '@/utils/numberUtils';
 import { ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE, ADMIN_VOTE_OPEN_ISSUES_PER_PAGE } from '@/lib/constants';
 
 const VoteTab = () => {
-  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues, castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin } = useUser();
+  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues, castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian } = useUser();
   const [createOpen, setCreateOpen] = useState(false);
   const [voteModalOpen, setVoteModalOpen] = useState(false);
   const [addAdminOpen, setAddAdminOpen] = useState(false);
   const [removeAdminOpen, setRemoveAdminOpen] = useState(false);
+  const [addGuardianOpen, setAddGuardianOpen] = useState(false);
+  const [removeGuardianOpen, setRemoveGuardianOpen] = useState(false);
   const [executedPage, setExecutedPage] = useState(1);
   const [openIssuesPage, setOpenIssuesPage] = useState(1);
   const [selectedIssue, setSelectedIssue] = useState<{
@@ -79,6 +83,14 @@ const VoteTab = () => {
     await removeAdmin(userAddress);
   };
 
+  const handleAddGuardian = async (userAddress: string) => {
+    await addGuardian(userAddress);
+  };
+
+  const handleRemoveGuardian = async (userAddress: string) => {
+    await removeGuardian(userAddress);
+  };
+
   if (openIssuesLoading) {
     return (
       <Card>
@@ -99,6 +111,7 @@ const VoteTab = () => {
   }
 
   const admins: any[] = (openIssues && openIssues['admins']) || [];
+  const guardians: any[] = (openIssues && openIssues['guardians']) || [];
   const allIssues: any[] = (openIssues && openIssues['issues']) || [];
   const votes: any[] = (openIssues && openIssues['votes']) || [];
   const thresholds: any[] = (openIssues && openIssues['thresholds']) || [];
@@ -171,6 +184,71 @@ const VoteTab = () => {
                     )}
                   </div>
                   {admin.address === userAddress && (
+                    <span className="text-[10px] md:text-xs bg-strato-blue text-white px-1.5 md:px-2 py-0.5 md:py-1 rounded shrink-0">You</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* List of Guardians */}
+      <Card className="dark:bg-card overflow-hidden">
+        <CardHeader className="flex flex-col md:flex-row md:items-center justify-between gap-3 px-4 md:px-6">
+          <div className="space-y-0.5 md:space-y-1">
+            <CardTitle className="text-base md:text-xl dark:text-foreground">Guardians</CardTitle>
+            <CardDescription className="text-xs md:text-sm dark:text-muted-foreground">Addresses authorized to pause allowlisted protocol functions</CardDescription>
+          </div>
+
+          <div className="flex flex-row gap-2 shrink-0">
+            <Button
+              size="sm"
+              onClick={() => setAddGuardianOpen(true)}
+              className="bg-strato-blue hover:bg-strato-blue/90 text-xs md:text-sm"
+            >
+              Add Guardian
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setRemoveGuardianOpen(true)}
+              disabled={guardians.length === 0}
+              className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs md:text-sm"
+            >
+              Remove Guardian
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          <div className="mb-3 md:mb-4">
+            <span className="text-xs md:text-sm text-muted-foreground">
+              {guardians.length} guardian{guardians.length !== 1 ? 's' : ''} registered
+            </span>
+          </div>
+
+          {guardians.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground text-sm">No guardians found</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-3">
+              {guardians.map((guardian: { address: string }, index: number) => (
+                <div
+                  key={`${guardian.address}-${index}`}
+                  className="flex items-center justify-between p-2 md:p-3 border rounded-lg bg-muted/50 hover:bg-muted transition-colors border-border"
+                >
+                  <div className="flex items-center gap-1.5 md:space-x-2 min-w-0">
+                    <span className="font-mono text-xs md:text-sm dark:text-foreground truncate">
+                      {guardian && guardian.address !== 'Unknown'
+                        ? `${guardian.address.slice(0, 6)}...${guardian.address.slice(-4)}`
+                        : guardian.address
+                      }
+                    </span>
+                    {guardian?.address && guardian.address !== 'Unknown' && (
+                      <CopyButton address={guardian.address} />
+                    )}
+                  </div>
+                  {guardian.address === userAddress && (
                     <span className="text-[10px] md:text-xs bg-strato-blue text-white px-1.5 md:px-2 py-0.5 md:py-1 rounded shrink-0">You</span>
                   )}
                 </div>
@@ -536,6 +614,19 @@ const VoteTab = () => {
         onOpenChange={setRemoveAdminOpen}
         onRemoveAdmin={handleRemoveAdmin}
         admins={admins}
+      />
+      <AddGuardianModal
+        open={addGuardianOpen}
+        onOpenChange={setAddGuardianOpen}
+        onAddGuardian={handleAddGuardian}
+        guardians={guardians}
+        admins={admins}
+      />
+      <RemoveGuardianModal
+        open={removeGuardianOpen}
+        onOpenChange={setRemoveGuardianOpen}
+        onRemoveGuardian={handleRemoveGuardian}
+        guardians={guardians}
       />
     </div>
   );

--- a/mercata/ui/src/components/admin/VoteTab.tsx
+++ b/mercata/ui/src/components/admin/VoteTab.tsx
@@ -22,8 +22,51 @@ import RemoveGuardianModal from './RemoveGuardianModal';
 import { parseJsonBigInt } from '@/utils/numberUtils';
 import { ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE, ADMIN_VOTE_OPEN_ISSUES_PER_PAGE } from '@/lib/constants';
 
+type Timelock = {
+  queuedAt: number;
+  executableAt: number;
+  expiresAt: number;
+};
+
+type AdminRecord = {
+  address: string;
+};
+
+type VoteRecord = {
+  issueId: string;
+  index: number;
+  voter: string;
+};
+
+type ThresholdRecord = {
+  target: string;
+  func: string;
+  threshold: number | string;
+};
+
+type IssueRecord = {
+  issueId: string;
+  target: string;
+  func: string;
+  args: string | unknown[];
+  timelock?: Timelock;
+  executor?: string;
+  block_number?: number | string;
+};
+
+type SelectedIssue = {
+  issueId: string;
+  target: string;
+  func: string;
+  args: unknown[];
+  votesCast: number;
+  votesNeeded: number;
+  threshold: number;
+  timelock?: Timelock;
+};
+
 const VoteTab = () => {
-  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues, castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian } = useUser();
+  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues, castVoteOnIssue, castVoteOnIssueById, executeIssue, withdrawVote, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian } = useUser();
   const [createOpen, setCreateOpen] = useState(false);
   const [voteModalOpen, setVoteModalOpen] = useState(false);
   const [addAdminOpen, setAddAdminOpen] = useState(false);
@@ -32,15 +75,8 @@ const VoteTab = () => {
   const [removeGuardianOpen, setRemoveGuardianOpen] = useState(false);
   const [executedPage, setExecutedPage] = useState(1);
   const [openIssuesPage, setOpenIssuesPage] = useState(1);
-  const [selectedIssue, setSelectedIssue] = useState<{
-    issueId: string;
-    target: string;
-    func: string;
-    args: any[];
-    votesCast: number;
-    votesNeeded: number;
-    threshold: number;
-  } | null>(null);
+  const [executingIssueId, setExecutingIssueId] = useState<string | null>(null);
+  const [selectedIssue, setSelectedIssue] = useState<SelectedIssue | null>(null);
 
   useEffect(() => {
     getOpenIssues();
@@ -56,15 +92,7 @@ const VoteTab = () => {
     setExecutedPage(1);
   };
 
-  const handleOpenVoteModal = (issueData: {
-    issueId: string;
-    target: string;
-    func: string;
-    args: any[];
-    votesCast: number;
-    votesNeeded: number;
-    threshold: number;
-  }) => {
+  const handleOpenVoteModal = (issueData: SelectedIssue) => {
     setSelectedIssue(issueData);
     setVoteModalOpen(true);
   };
@@ -72,6 +100,24 @@ const VoteTab = () => {
   const handleCastVoteOnIssueById = async (issueId: string) => {
     await castVoteOnIssueById(issueId);
     // Reset to page 1 to show the recently executed issue
+    setExecutedPage(1);
+  };
+
+  const handleExecuteIssue = async (issue: IssueRecord) => {
+    const issueId = issue.issueId;
+    const issueArgs = parseJsonBigInt(typeof issue.args === 'string' ? issue.args : JSON.stringify(issue.args), { fallback: [] }) as unknown[];
+
+    setExecutingIssueId(issueId);
+    try {
+      await executeIssue(issue.target, issue.func, issueArgs);
+      setExecutedPage(1);
+    } finally {
+      setExecutingIssueId(null);
+    }
+  };
+
+  const handleExecuteSelectedIssue = async (target: string, func: string, args: unknown[]) => {
+    await executeIssue(target, func, args);
     setExecutedPage(1);
   };
 
@@ -110,13 +156,14 @@ const VoteTab = () => {
     );
   }
 
-  const admins: any[] = (openIssues && openIssues['admins']) || [];
-  const guardians: any[] = (openIssues && openIssues['guardians']) || [];
-  const allIssues: any[] = (openIssues && openIssues['issues']) || [];
-  const votes: any[] = (openIssues && openIssues['votes']) || [];
-  const thresholds: any[] = (openIssues && openIssues['thresholds']) || [];
+  const admins: AdminRecord[] = (openIssues && openIssues['admins']) || [];
+  const guardians: AdminRecord[] = (openIssues && openIssues['guardians']) || [];
+  const allIssues: IssueRecord[] = (openIssues && openIssues['issues']) || [];
+  const queuedIssues: IssueRecord[] = (openIssues && openIssues['queuedIssues']) || [];
+  const votes: VoteRecord[] = (openIssues && openIssues['votes']) || [];
+  const thresholds: ThresholdRecord[] = (openIssues && openIssues['thresholds']) || [];
   const globalThreshold: number = (openIssues && openIssues['globalThreshold']) || 6000;
-  const executed: object[] = (executedIssues && executedIssues['executed']) || [];
+  const executed: IssueRecord[] = (executedIssues && executedIssues['executed']) || [];
   const executedTotal: number = (executedIssues && executedIssues['executedTotal']) || 0;
   const executedTotalPages = Math.ceil(executedTotal / ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE);
   
@@ -125,6 +172,24 @@ const VoteTab = () => {
   const openIssuesStartIndex = (openIssuesPage - 1) * ADMIN_VOTE_OPEN_ISSUES_PER_PAGE;
   const openIssuesEndIndex = openIssuesStartIndex + ADMIN_VOTE_OPEN_ISSUES_PER_PAGE;
   const issues = allIssues.slice(openIssuesStartIndex, openIssuesEndIndex);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  const getIssueDetails = (issue: IssueRecord) => {
+    const issueId = issue.issueId;
+    const address = issue.target;
+    const issueArgs = parseJsonBigInt(typeof issue.args === 'string' ? issue.args : JSON.stringify(issue.args), { fallback: [] }) as unknown[];
+    const threshold = Number(thresholds.find((v) => v.target === address && v.func === issue.func)?.threshold || globalThreshold)/100;
+    const votesNeeded = Math.ceil((admins.length * threshold)/100);
+    const votesCast = votes.filter((v) => v.issueId === issueId).length;
+    const hasUserVoted = votes.some((v) => v.issueId === issueId && v.voter === userAddress);
+
+    return { issueId, address, issueArgs, threshold, votesNeeded, votesCast, hasUserVoted };
+  };
+
+  const formatTime = (timestamp?: number) => {
+    if (!timestamp) return '-';
+    return new Date(timestamp * 1000).toLocaleString();
+  };
 
   return (
     <div className="space-y-6">
@@ -167,7 +232,7 @@ const VoteTab = () => {
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-3">
-              {admins.map((admin: {address: string}, index: number) => (
+              {admins.map((admin, index: number) => (
                 <div 
                   key={`${admin.address}-${index}`}
                   className="flex items-center justify-between p-2 md:p-3 border rounded-lg bg-muted/50 hover:bg-muted transition-colors border-border"
@@ -308,13 +373,8 @@ const VoteTab = () => {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {issues.map((issue: any, index) => {
-                    const issueId = issue.issueId;
-                    const address = issue.target;
-                    const issueArgs = parseJsonBigInt(typeof issue.args === 'string' ? issue.args : JSON.stringify(issue.args), { fallback: [] }) as any[];
-                    const threshold = (thresholds.find((v) => v.target === address && v.func === issue.func)?.threshold || globalThreshold)/100;
-                    const votesNeeded = Math.ceil((admins.length * threshold)/100);
-                    const hasUserVoted = votes.some((v) => v.issueId === issueId && v.voter === userAddress);
+                    {issues.map((issue, index) => {
+                    const { issueId, address, issueArgs, threshold, votesNeeded, votesCast, hasUserVoted } = getIssueDetails(issue);
 
                     return (
                       <TableRow key={`${issueId}-${index}`} className={`border-border hover:bg-muted/50 ${hasUserVoted ? 'bg-green-500/10' : ''}`}>
@@ -365,9 +425,10 @@ const VoteTab = () => {
                                 target: address,
                                 func: issue.func,
                                 args: issueArgs,
-                                votesCast: votes.filter((v) => v.issueId === issueId).length,
+                                votesCast,
                                 votesNeeded,
-                                threshold
+                                threshold,
+                                timelock: issue.timelock,
                               })}
                               className="bg-strato-blue hover:bg-strato-blue/90 text-[10px] md:text-xs px-2 md:px-3 dark:text-white whitespace-nowrap"
                             >
@@ -436,6 +497,139 @@ const VoteTab = () => {
         </CardContent>
       </Card>
 
+      <Card className="dark:bg-card overflow-hidden">
+        <CardHeader className="px-4 md:px-6">
+          <CardTitle className="text-base md:text-xl dark:text-foreground whitespace-nowrap">Queued Issues</CardTitle>
+          <CardDescription className="text-xs md:text-sm dark:text-muted-foreground">
+            Issues waiting for the timelock before execution
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-4 md:px-6">
+          <div className="mb-3 md:mb-4">
+            <span className="text-xs md:text-sm text-muted-foreground">
+              {queuedIssues.length > 0 ? `${queuedIssues.length} queued issue${queuedIssues.length !== 1 ? 's' : ''}` : 'No queued issues'}
+            </span>
+          </div>
+          {queuedIssues.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground text-sm">No queued issues found</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto -mx-4 md:mx-0">
+              <Table>
+                <TableHeader>
+                  <TableRow className="dark:border-border dark:hover:bg-transparent">
+                    <TableHead className="text-xs md:text-sm pl-4 md:pl-4 dark:text-muted-foreground whitespace-nowrap">Issue ID</TableHead>
+                    <TableHead className="text-xs md:text-sm dark:text-muted-foreground hidden md:table-cell">Contract</TableHead>
+                    <TableHead className="text-xs md:text-sm dark:text-muted-foreground hidden md:table-cell">Function</TableHead>
+                    <TableHead className="text-xs md:text-sm dark:text-muted-foreground whitespace-nowrap">Executable</TableHead>
+                    <TableHead className="text-xs md:text-sm dark:text-muted-foreground whitespace-nowrap">Expires</TableHead>
+                    <TableHead className="text-xs md:text-sm pr-4 md:pr-4 dark:text-muted-foreground">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {queuedIssues.map((issue, index) => {
+                    const { issueId, address, issueArgs, threshold, votesNeeded, votesCast, hasUserVoted } = getIssueDetails(issue);
+                    const executableAt = Number(issue.timelock?.executableAt || 0);
+                    const expiresAt = Number(issue.timelock?.expiresAt || 0);
+                    const canExecute = executableAt > 0 && nowSeconds >= executableAt && nowSeconds <= expiresAt;
+                    const isExpired = expiresAt > 0 && nowSeconds > expiresAt;
+
+                    return (
+                      <TableRow key={`${issueId}-${index}`} className={`border-border hover:bg-muted/50 ${hasUserVoted ? 'bg-green-500/10' : ''}`}>
+                        <TableCell className="font-medium text-xs md:text-sm pl-4 md:pl-4 dark:text-foreground">
+                          <div className="flex items-center gap-1 md:space-x-2">
+                            {hasUserVoted && (
+                              <CheckCircle2 className="h-3 w-3 md:h-4 md:w-4 text-green-600 dark:text-green-400 flex-shrink-0" />
+                            )}
+                            <span className="truncate">
+                              {issueId && issueId !== 'Unknown'
+                                ? `${issueId.slice(0, 6)}...${issueId.slice(-4)}`
+                                : issueId
+                              }
+                            </span>
+                            {issueId && issueId !== 'Unknown' && (
+                              <CopyButton address={issueId} />
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs hidden md:table-cell dark:text-foreground">
+                          <div className="flex items-center space-x-2">
+                            <span>
+                              {address && address !== 'Unknown'
+                                ? `${address.slice(0, 6)}...${address.slice(-4)}`
+                                : address
+                              }
+                            </span>
+                            {address && address !== 'Unknown' && (
+                              <CopyButton address={address} />
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-sm hidden md:table-cell dark:text-foreground">
+                          {issue.func}
+                        </TableCell>
+                        <TableCell className="text-xs md:text-sm dark:text-foreground whitespace-nowrap">
+                          {formatTime(executableAt)}
+                        </TableCell>
+                        <TableCell className="text-xs md:text-sm dark:text-foreground whitespace-nowrap">
+                          {formatTime(expiresAt)}
+                        </TableCell>
+                        <TableCell className="pr-4 md:pr-4">
+                          <div className="flex flex-col items-start gap-1">
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleOpenVoteModal({
+                                  issueId,
+                                  target: address,
+                                  func: issue.func,
+                                  args: issueArgs,
+                                  votesCast,
+                                  votesNeeded,
+                                  threshold,
+                                  timelock: issue.timelock,
+                                })}
+                                className="text-[10px] md:text-xs px-2 md:px-3 whitespace-nowrap"
+                              >
+                                View Vote
+                              </Button>
+                              {canExecute && (
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleExecuteIssue(issue)}
+                                  disabled={executingIssueId === issueId}
+                                  className="bg-strato-blue hover:bg-strato-blue/90 text-[10px] md:text-xs px-2 md:px-3 dark:text-white whitespace-nowrap"
+                                >
+                                  {executingIssueId === issueId ? (
+                                    <>
+                                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                      Executing...
+                                    </>
+                                  ) : (
+                                    'Execute'
+                                  )}
+                                </Button>
+                              )}
+                            </div>
+                            {!canExecute && (
+                              <span className="text-[10px] md:text-xs text-muted-foreground whitespace-nowrap">
+                                {isExpired ? 'Expired' : 'Timelock pending'}
+                              </span>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* List Executed Issues */}
       <Card className="dark:bg-card overflow-hidden">
         <CardHeader className="px-4 md:px-6">
@@ -481,10 +675,10 @@ const VoteTab = () => {
                     </TableRow>
                   </TableHeader>
                   <TableBody className={executedIssuesLoading ? "opacity-50 pointer-events-none" : ""}>
-                    {executed.map((issue: any, index) => {
+                    {executed.map((issue: IssueRecord, index) => {
                       const issueId = issue.issueId;
                       const address = issue.target;
-                      const issueArgs = parseJsonBigInt(typeof issue.args === 'string' ? issue.args : JSON.stringify(issue.args), { fallback: [] }) as any[];
+                      const issueArgs = parseJsonBigInt(typeof issue.args === 'string' ? issue.args : JSON.stringify(issue.args), { fallback: [] }) as unknown[];
                       return (
                         <TableRow key={`${issueId}-${index}`} className="dark:border-border dark:hover:bg-muted/50">
                           <TableCell className="font-mono text-xs pl-4 dark:text-foreground">
@@ -517,7 +711,7 @@ const VoteTab = () => {
                             {issue.func}
                           </TableCell>
                           <TableCell className="font-mono text-xs max-w-[200px] truncate dark:text-foreground">
-                            {issueArgs.join(', ')}
+                            {issueArgs.map(String).join(', ')}
                           </TableCell>
                           <TableCell className="font-mono text-xs pr-4 dark:text-foreground">
                             <div className="flex items-center space-x-2">
@@ -599,6 +793,8 @@ const VoteTab = () => {
         onOpenChange={setVoteModalOpen}
         issue={selectedIssue}
         onCastVote={handleCastVoteOnIssueById}
+        onExecuteIssue={handleExecuteSelectedIssue}
+        onWithdrawVote={withdrawVote}
         onDismissIssue={dismissIssue}
         votes={votes}
         userAddress={userAddress}

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -28,7 +28,7 @@ interface UserContextType {
   contractDetailsResults: object;
   contractDetailsResultsLoading: boolean;
   getContractDetails: (address: string) => Promise<void>;
-  castVoteOnIssue: (target: string, func: string, args: string[]) => Promise<void>;
+  castVoteOnIssue: (target: string, func: string, args: unknown[]) => Promise<void>;
   castVoteOnIssueById: (issueId: string) => Promise<void>;
   executeIssue: (target: string, func: string, args: unknown[]) => Promise<void>;
   withdrawVote: (target: string, func: string, args: unknown[]) => Promise<void>;
@@ -49,6 +49,22 @@ type UnsignedWalletTx = {
     network: string;
   };
 };
+
+const serializeAdminIssueArg = (arg: unknown): unknown => {
+  if (typeof arg === "bigint") return arg.toString();
+  if (Array.isArray(arg)) return arg.map(serializeAdminIssueArg);
+  if (arg && typeof arg === "object") {
+    return Object.fromEntries(
+      Object.entries(arg as Record<string, unknown>).map(([key, value]) => [
+        key,
+        serializeAdminIssueArg(value),
+      ])
+    );
+  }
+  return arg;
+};
+
+const serializeAdminIssueArgs = (args: unknown[]) => args.map(serializeAdminIssueArg);
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
@@ -125,7 +141,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
   const castVoteOnIssue = async (target: string, func: string, args: unknown[]) => {
     try {
-      await api.post('/user/admin/vote', { target, func, args });
+      await api.post('/user/admin/vote', { target, func, args: serializeAdminIssueArgs(args) });
       await getOpenIssues();
       // Show the recently executed issue
       await getExecutedIssues(1, ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE);
@@ -149,7 +165,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
   const executeIssue = async (target: string, func: string, args: unknown[]) => {
     try {
-      await api.post('/user/admin/issues/execute', { target, func, args });
+      await api.post('/user/admin/issues/execute', { target, func, args: serializeAdminIssueArgs(args) });
       await getOpenIssues();
       await getExecutedIssues(1, ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE);
     } catch (error) {
@@ -160,7 +176,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
   const withdrawVote = async (target: string, func: string, args: unknown[]) => {
     try {
-      await api.post('/user/admin/vote/withdraw', { target, func, args });
+      await api.post('/user/admin/vote/withdraw', { target, func, args: serializeAdminIssueArgs(args) });
       await getOpenIssues();
     } catch (error) {
       await getOpenIssues();

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -30,12 +30,25 @@ interface UserContextType {
   getContractDetails: (address: string) => Promise<void>;
   castVoteOnIssue: (target: string, func: string, args: string[]) => Promise<void>;
   castVoteOnIssueById: (issueId: string) => Promise<void>;
+  executeIssue: (target: string, func: string, args: unknown[]) => Promise<void>;
+  withdrawVote: (target: string, func: string, args: unknown[]) => Promise<void>;
   dismissIssue: (issueId: string) => Promise<void>;
   addAdmin: (userAddress: string) => Promise<void>;
   removeAdmin: (userAddress: string) => Promise<void>;
   addGuardian: (userAddress: string) => Promise<void>;
   removeGuardian: (userAddress: string) => Promise<void>;
 }
+
+type UnsignedWalletTx = {
+  data: {
+    to: string;
+    functionName: string;
+    args: string[];
+    nonce: string | number | bigint;
+    gasLimit: string | number | bigint;
+    network: string;
+  };
+};
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
@@ -110,7 +123,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
-  const castVoteOnIssue = async (target: string, func: string, args: any[]) => {
+  const castVoteOnIssue = async (target: string, func: string, args: unknown[]) => {
     try {
       await api.post('/user/admin/vote', { target, func, args });
       await getOpenIssues();
@@ -134,6 +147,27 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  const executeIssue = async (target: string, func: string, args: unknown[]) => {
+    try {
+      await api.post('/user/admin/issues/execute', { target, func, args });
+      await getOpenIssues();
+      await getExecutedIssues(1, ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE);
+    } catch (error) {
+      await getOpenIssues();
+      throw error;
+    }
+  };
+
+  const withdrawVote = async (target: string, func: string, args: unknown[]) => {
+    try {
+      await api.post('/user/admin/vote/withdraw', { target, func, args });
+      await getOpenIssues();
+    } catch (error) {
+      await getOpenIssues();
+      throw error;
+    }
+  };
+
   const getOpenIssues = async () => {
     try {
       setOpenIssuesLoading(true);
@@ -141,6 +175,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
         const response = await api.get('/user/admin/issues');
         setOpenIssues(response?.data || {});
       } catch (error) {
+        // Keep the previous issue state if refresh fails.
       }
     } finally {
       setOpenIssuesLoading(false);
@@ -159,6 +194,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
         });
         setExecutedIssues(response?.data || {});
       } catch (error) {
+        // Keep the previous executed issue state if refresh fails.
       }
     } finally {
       setExecutedIssuesLoading(false);
@@ -172,6 +208,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
         const response = await api.get(`/user/admin/contract/search?search=${search}`);
         setContractSearchResults(response?.data || []);
       } catch (error) {
+        // Keep the previous search results if refresh fails.
       }
     } finally {
       setContractSearchResultsLoading(false);
@@ -185,6 +222,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
         const response = await api.get(`/user/admin/contract/details?address=${address}`);
         setContractDetailsResults(response?.data || {});
       } catch (error) {
+        // Keep the previous contract details if refresh fails.
       }
     } finally {
       setContractDetailsResultsLoading(false);
@@ -223,9 +261,9 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     const connected = account.isConnected && account.address;
     setConnectedWalletAddress(connected ? account.address : null);
     if (connected && walletClient) {
-      setWalletSigner(async (unsignedTx: any) => {
+      setWalletSigner(async (unsignedTx: UnsignedWalletTx) => {
         const d = unsignedTx.data;
-        return walletClient.signTypedData({
+        const typedData = {
           domain: {
             name: "STRATO",
             version: "1",
@@ -249,7 +287,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
             gasLimit: BigInt(d.gasLimit),
             network: d.network,
           },
-        });
+        } as const;
+        return walletClient.signTypedData(typedData as unknown as Parameters<typeof walletClient.signTypedData>[0]);
       });
     } else {
       setWalletSigner(null);
@@ -291,6 +330,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     getExecutedIssues,
     castVoteOnIssue,
     castVoteOnIssueById,
+    executeIssue,
+    withdrawVote,
     dismissIssue,
     addAdmin,
     removeAdmin,
@@ -304,7 +345,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     contractDetailsResultsLoading,
   }), [userAddress, effectiveLoggedIn, isAdmin, loading, userName,
     openIssues, openIssuesLoading, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues,
-    castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian,
+    castVoteOnIssue, castVoteOnIssueById, executeIssue, withdrawVote, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian,
     contractSearch, contractSearchResults, contractSearchResultsLoading,
     getContractDetails, contractDetailsResults, contractDetailsResultsLoading,
   ]);

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -33,6 +33,8 @@ interface UserContextType {
   dismissIssue: (issueId: string) => Promise<void>;
   addAdmin: (userAddress: string) => Promise<void>;
   removeAdmin: (userAddress: string) => Promise<void>;
+  addGuardian: (userAddress: string) => Promise<void>;
+  removeGuardian: (userAddress: string) => Promise<void>;
 }
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
@@ -199,6 +201,16 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     await getOpenIssues();
   };
 
+  const addGuardian = async (userAddress: string) => {
+    await api.post('/user/admin/guardian', { userAddress });
+    await getOpenIssues();
+  };
+
+  const removeGuardian = async (userAddress: string) => {
+    await api.delete('/user/admin/guardian', { data: { userAddress } });
+    await getOpenIssues();
+  };
+
   const dismissIssue = async (issueId: string) => {
     await api.post('/user/admin/dismiss', { issueId });
     await getOpenIssues();
@@ -282,6 +294,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     dismissIssue,
     addAdmin,
     removeAdmin,
+    addGuardian,
+    removeGuardian,
     contractSearch,
     contractSearchResults,
     contractSearchResultsLoading,
@@ -290,7 +304,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     contractDetailsResultsLoading,
   }), [userAddress, effectiveLoggedIn, isAdmin, loading, userName,
     openIssues, openIssuesLoading, getOpenIssues, executedIssues, executedIssuesLoading, getExecutedIssues,
-    castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin,
+    castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin, addGuardian, removeGuardian,
     contractSearch, contractSearchResults, contractSearchResultsLoading,
     getContractDetails, contractDetailsResults, contractDetailsResultsLoading,
   ]);


### PR DESCRIPTION
- Added queued governance: threshold now queues issues instead of immediately executing them.
- Added timelock state: `Timelock { queuedAt, executableAt, expiresAt }`.
- Added `executeIssue(...)`, which executes only after delay, before expiry, and after quorum recheck.
- Added `withdrawVote(...)`; queued issue is unqueued if votes fall below threshold.
- Prevented voting on already queued issues.
- Changed quorum counting to only count current admins.
- Added instant-function support for approved admin/guardian fast paths.
- Added guardian role + guardian allowlist.
- Added queue/withdraw/guardian/instant-function events.
- Refactored issue cleanup into `_clearIssue`, `_clearTimelock`, `_removeVote`.
- Tightened governance whitelist exclusions to block new internal/admin functions.
- Current constants are short dev values: `MINIMUM_DELAY` = 24 min, `GRACE_PERIOD` = 14 days, `MIN_ADMIN_COUNT` = 3.
