### PR TITLE
Fix wallet-only rewards and borrow refresh

### DIFF
--- a/mercata/backend/src/api/controllers/rewards.controller.ts
+++ b/mercata/backend/src/api/controllers/rewards.controller.ts
@@ -50,18 +50,17 @@ class RewardsController {
   /**
    * Get all activities with user-specific data for the specified user
    */
-  static async getUserActivities(
+  static async getMyActivities(
     req: Request,
     res: Response,
     next: NextFunction
   ): Promise<void> {
     try {
-      const { accessToken } = req;
-      const { userAddress } = req.params;
+      const { accessToken, address: userAddress } = req;
       const forceRefresh = req.query.refresh === "true";
 
       if (!userAddress) {
-        res.status(RestStatus.BAD_REQUEST).json({ error: "User address is required" });
+        res.status(RestStatus.UNAUTHORIZED).json({ error: "User address is required" });
         return;
       }
 

--- a/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
@@ -8,6 +8,7 @@ import { constants } from "../../../config/constants";
 let contractStateCache: { address: string; state: any; timestamp: number } | null = null;
 let pendingRequest: Promise<any> | null = null;
 const CACHE_TTL = 5000; // 5 seconds cache
+const normalizeUserAddress = (address: string): string => address.replace(/^0x/i, "").toLowerCase();
 
 /**
  * Clear the contract state cache
@@ -239,7 +240,8 @@ export const fetchUserInfo = async (
   forceRefresh: boolean = false
 ): Promise<Map<number, { stake: string; userIndex: string }>> => {
   const state = await fetchContractState(accessToken, rewardsAddress, forceRefresh);
-  const userInfo = state?.userInfo?.[userAddress.toLowerCase()] || {};
+  const normalizedUserAddress = normalizeUserAddress(userAddress);
+  const userInfo = state?.userInfo?.[normalizedUserAddress] || {};
   
   const userInfoMap = new Map<number, { stake: string; userIndex: string }>();
   
@@ -266,7 +268,7 @@ export const fetchUnclaimedRewards = async (
   const state = await fetchContractState(accessToken, rewardsAddress, forceRefresh);
   const unclaimedRewards = state?.unclaimedRewards || {};
   
-  return unclaimedRewards[userAddress.toLowerCase()] || "0";
+  return unclaimedRewards[normalizeUserAddress(userAddress)] || "0";
 };
 
 /**
@@ -316,11 +318,12 @@ export const fetchBonusRewards = async (
   userAddress: string
 ): Promise<{ total: bigint; byActivity: Map<string, bigint> }> => {
   try {
+    const normalizedUserAddress = normalizeUserAddress(userAddress);
     const { data: events = [] } = await cirrus.get(accessToken, "/event", {
       params: {
         address: `eq.${rewardsAddress}`,
         event_name: `eq.DirectPayoutApplied`,
-        "attributes->>user": `eq.${userAddress}`,
+        "attributes->>user": `eq.${normalizedUserAddress}`,
         select: "attributes",
       },
     });

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -4,6 +4,7 @@ import RewardsController from "../controllers/rewards.controller";
 
 const router = Router();
 const walletAuth = authHandler.authorizeRequest({ allowWalletAuth: true });
+const userRewardsAuth = authHandler.authorizeRequest({ allowWalletAuth: true, allowAnonAccess: false });
 
 // ═════════════════════════════════════════════════════════════════════════
 // REWARDS CONTRACT ENDPOINTS
@@ -85,18 +86,10 @@ router.get("/activities", authHandler.authorizeRequest(true), RewardsController.
 
 /**
  * @openapi
- * /rewards/activities/{userAddress}:
+ * /rewards/activities/me:
  *   get:
- *     summary: Get all activities with user-specific data for the specified user
+ *     summary: Get all activities with user-specific data for the authenticated user
  *     tags: [Rewards]
- *     parameters:
- *       - in: path
- *         name: userAddress
- *         required: true
- *         schema:
- *           type: string
- *         description: The user address to fetch activities for
- *         example: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
  *     responses:
  *       200:
  *         description: Activities with user-specific data and rewards breakdown
@@ -148,7 +141,7 @@ router.get("/activities", authHandler.authorizeRequest(true), RewardsController.
  *       401:
  *         description: Unauthorized
  */
-router.get("/activities/:userAddress", authHandler.authorizeRequest(), RewardsController.getUserActivities);
+router.get("/activities/me", userRewardsAuth, RewardsController.getMyActivities);
 
 /**
  * @openapi

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -42,6 +42,7 @@ type StakeSemanticsConfig = {
 };
 
 const normalizeAddr = (a: string): string => a.toLowerCase();
+const normalizeUserAddress = (a: string): string => a.replace(/^0x/i, "").toLowerCase();
 
 const STAKE_SEMANTICS: StakeSemanticsConfig = stakeSemanticsConfig as StakeSemanticsConfig;
 
@@ -397,6 +398,7 @@ export const fetchUserActivities = async (
   forceRefresh: boolean = false
 ): Promise<UserActivitiesResponse> => {
   const rewardsAddress = getRewardsAddress();
+  const normalizedUserAddress = normalizeUserAddress(userAddress);
 
   try {
     // Fetch all activities
@@ -405,11 +407,11 @@ export const fetchUserActivities = async (
 
     if (activities.length === 0) {
       const [unclaimedRewards, claimedRewardsMap, bonusResult] = await Promise.all([
-        fetchUnclaimedRewards(accessToken, rewardsAddress, userAddress, forceRefresh),
+        fetchUnclaimedRewards(accessToken, rewardsAddress, normalizedUserAddress, forceRefresh),
         fetchClaimedRewards(accessToken, rewardsAddress),
-        fetchBonusRewards(accessToken, rewardsAddress, userAddress)
+        fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress)
       ]);
-      const claimedRewards = claimedRewardsMap.get(userAddress.toLowerCase()) || 0n;
+      const claimedRewards = claimedRewardsMap.get(normalizedUserAddress) || 0n;
       return {
         unclaimedRewards,
         claimedRewards: claimedRewards.toString(),
@@ -423,10 +425,10 @@ export const fetchUserActivities = async (
 
     const [activityStatesMap, userInfoMap, unclaimedRewards, claimedRewardsMap, bonusResult] = await Promise.all([
       fetchActivityStates(accessToken, rewardsAddress, forceRefresh),
-      fetchUserInfo(accessToken, rewardsAddress, userAddress, activityIds, forceRefresh),
-      fetchUnclaimedRewards(accessToken, rewardsAddress, userAddress, forceRefresh),
+      fetchUserInfo(accessToken, rewardsAddress, normalizedUserAddress, activityIds, forceRefresh),
+      fetchUnclaimedRewards(accessToken, rewardsAddress, normalizedUserAddress, forceRefresh),
       fetchClaimedRewards(accessToken, rewardsAddress),
-      fetchBonusRewards(accessToken, rewardsAddress, userAddress)
+      fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress)
     ]);
 
     // Build shared pricing context once (used for LP/share-token TVL conversions)
@@ -488,7 +490,7 @@ export const fetchUserActivities = async (
       };
     }));
 
-    const claimedRewards = claimedRewardsMap.get(userAddress.toLowerCase()) || 0n;
+    const claimedRewards = claimedRewardsMap.get(normalizedUserAddress) || 0n;
 
     const bonusSources: BonusSource[] = [];
     for (const [actId, amount] of bonusResult.byActivity) {

--- a/mercata/ui/src/components/cdp/v2/components/Mint/Mint.tsx
+++ b/mercata/ui/src/components/cdp/v2/components/Mint/Mint.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -59,7 +58,6 @@ const Mint: React.FC<MintProps> = ({ onSuccess, refreshTrigger, guestMode = fals
   // Context Hooks
   // ============================================================================
 
-  const navigate = useNavigate();
   const { fetchAllPrices } = useOracleContext();
   const { tokenApys } = useEarnContext();
   const { vaultState } = useVaultContext();
@@ -957,7 +955,7 @@ const Mint: React.FC<MintProps> = ({ onSuccess, refreshTrigger, guestMode = fals
           
           if (shouldRefreshOnClose) {
             setShouldRefreshOnClose(false);
-            navigate(0);
+            onSuccess?.();
           }
         }}
       />

--- a/mercata/ui/src/components/rewards/LeaderboardTable.tsx
+++ b/mercata/ui/src/components/rewards/LeaderboardTable.tsx
@@ -3,7 +3,7 @@ import { Table } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Trophy, Medal, Award, User } from "lucide-react";
-import { LeaderboardEntry, formatRoundedWithCommas, roundByMagnitude } from "@/services/rewardsService";
+import { LeaderboardEntry, formatRoundedWithCommas, normalizeRewardsAddress, roundByMagnitude } from "@/services/rewardsService";
 import { formatBalance } from "@/utils/numberUtils";
 import CopyButton from "@/components/ui/copy";
 import { Badge } from "@/components/ui/badge";
@@ -41,6 +41,7 @@ export const LeaderboardTable = ({
 }: LeaderboardTableProps) => {
   const { userAddress } = useUser();
   const isMobile = useIsMobile();
+  const normalizedUserAddress = normalizeRewardsAddress(userAddress);
   
   const columns: ColumnsType<LeaderboardEntry> = useMemo(() => [
     {
@@ -62,7 +63,7 @@ export const LeaderboardTable = ({
       key: "address",
       dataIndex: "address",
       render: (address: string) => {
-        const isCurrentUser = userAddress && address.toLowerCase() === userAddress.toLowerCase();
+        const isCurrentUser = normalizedUserAddress && normalizeRewardsAddress(address) === normalizedUserAddress;
         return (
           <div className="flex items-center gap-2 font-mono text-sm">
             <span>{address.slice(0, 6)}...{address.slice(-4)}</span>
@@ -83,7 +84,7 @@ export const LeaderboardTable = ({
       dataIndex: "totalRewardsEarned",
       render: formatPoints,
     },
-  ], [userAddress]);
+  ], [normalizedUserAddress]);
 
 
   if (loading) {
@@ -142,7 +143,7 @@ export const LeaderboardTable = ({
               }}
               className="[&_.ant-table-thead>tr>th]:font-semibold"
               rowClassName={(record: LeaderboardEntry) => 
-                userAddress && record.address.toLowerCase() === userAddress.toLowerCase() 
+                normalizedUserAddress && normalizeRewardsAddress(record.address) === normalizedUserAddress
                   ? "highlight-row" 
                   : ""
               }

--- a/mercata/ui/src/hooks/useRewardsUserInfo.ts
+++ b/mercata/ui/src/hooks/useRewardsUserInfo.ts
@@ -17,7 +17,7 @@ export const useRewardsUserInfo = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const data = await fetchUserRewards(userAddress);
+        const data = await fetchUserRewards();
         setUserRewards(data);
         setError(null);
       } catch (err) {
@@ -36,7 +36,7 @@ export const useRewardsUserInfo = () => {
     }
     try {
       setLoading(true);
-      const data = await fetchUserRewards(userAddress, true); // Force refresh to bypass cache
+      const data = await fetchUserRewards(true); // Force refresh to bypass cache
       setUserRewards(data);
       setError(null);
     } catch (err) {

--- a/mercata/ui/src/hooks/useUserLeaderboardRank.ts
+++ b/mercata/ui/src/hooks/useUserLeaderboardRank.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { fetchLeaderboard } from "@/services/rewardsService";
+import { fetchLeaderboard, normalizeRewardsAddress } from "@/services/rewardsService";
 import { useUser } from "@/context/UserContext";
 
 export const useUserLeaderboardRank = () => {
@@ -24,6 +24,7 @@ export const useUserLeaderboardRank = () => {
       let found = false;
       let userRank: number | null = null;
       let userTotalEarned: string | null = null;
+      const normalizedUserAddress = normalizeRewardsAddress(userAddress);
 
       while (!found) {
         const response = await fetchLeaderboard(forceRefresh, limit, offset);
@@ -33,7 +34,7 @@ export const useUserLeaderboardRank = () => {
         }
 
         const userEntry = response.entries.find(
-          (entry) => entry.address.toLowerCase() === userAddress.toLowerCase()
+          (entry) => normalizeRewardsAddress(entry.address) === normalizedUserAddress
         );
 
         if (userEntry) {

--- a/mercata/ui/src/services/rewardsService.ts
+++ b/mercata/ui/src/services/rewardsService.ts
@@ -67,6 +67,9 @@ export interface LeaderboardResponse {
   limit: number;
 }
 
+export const normalizeRewardsAddress = (address: string | null | undefined): string =>
+  (address || "").toLowerCase().replace(/^0x/, "");
+
 
 /**
  * Fetch global Rewards contract state
@@ -135,9 +138,9 @@ export const fetchActivity = async (activityId: number): Promise<Activity> => {
  * Fetch user's rewards data
  * @param forceRefresh - If true, bypasses cache and fetches fresh data from blockchain
  */
-export const fetchUserRewards = async (userAddress: string, forceRefresh: boolean = false): Promise<UserRewardsData> => {
+export const fetchUserRewards = async (forceRefresh: boolean = false): Promise<UserRewardsData> => {
   const params = forceRefresh ? { refresh: "true" } : {};
-  const response = await api.get(`/rewards/activities/${userAddress}`, { params });
+  const response = await api.get(`/rewards/activities/me`, { params });
   const data = response.data;
   
   const unclaimedRewards = data.unclaimedRewards || "0";


### PR DESCRIPTION
Route rewards user data through authenticated wallet context and replace the CDP borrow page reload with targeted refreshes so MetaMask-only sessions keep their wallet state.