### PR TITLE
Fix MetaMask wallet-only address and signing flows

### DIFF
--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -64,6 +64,8 @@ const { Pool: PoolTable, PoolFactory, PoolSwap, StablePool: StablePoolTable, swa
 // READ OPERATIONS
 // ============================================================================
 
+const normalizeAddress = (address: string): string => address.toLowerCase().replace(/^0x/, "");
+
 // --- Pool Queries ---
 
 export const getPools = async (
@@ -382,12 +384,13 @@ export const getSwapHistory = async (
   senderAddress?: string
 ): Promise<SwapHistoryResponse> => {
   const offset = (page - 1) * limit;
+  const normalizedSenderAddress = senderAddress ? normalizeAddress(senderAddress) : undefined;
 
   const [swapEventsResponse, countResponse] = await Promise.all([
     cirrus.get(accessToken, `/${PoolSwap}`, {
       params: {
         address: `eq.${poolAddress}`,
-        ...(senderAddress ? { sender: `eq.${senderAddress}` } : {}),
+        ...(normalizedSenderAddress ? { sender: `eq.${normalizedSenderAddress}` } : {}),
         select: swapHistorySelectFields.join(','),
         order: 'block_timestamp.desc',
         limit: limit.toString(),
@@ -397,7 +400,7 @@ export const getSwapHistory = async (
     cirrus.get(accessToken, `/${PoolSwap}`, {
       params: {
         address: `eq.${poolAddress}`,
-        ...(senderAddress ? { sender: `eq.${senderAddress}` } : {}),
+        ...(normalizedSenderAddress ? { sender: `eq.${normalizedSenderAddress}` } : {}),
         select: "count()",
       }
     })

--- a/mercata/ui/src/components/BulkTransferModal.tsx
+++ b/mercata/ui/src/components/BulkTransferModal.tsx
@@ -32,6 +32,8 @@ interface ParsedTransfer {
   lineNumber: number; // CSV line number (1-indexed, including header if present)
 }
 
+const normalizeAddress = (addr?: string | null): string => (addr || "").toLowerCase().replace(/^0x/, "");
+
 interface ProcessingTransfer {
   tokenAddress: string;
   to: string;
@@ -115,7 +117,7 @@ const BulkTransferModal = ({
       errors.push("Missing recipient address");
     } else if (!isValidAddress(normalizedTo)) {
       errors.push("Invalid recipient address format");
-    } else if (userAddress && normalizedTo === userAddress.toLowerCase()) {
+    } else if (userAddress && normalizeAddress(normalizedTo) === normalizeAddress(userAddress)) {
       errors.push("Cannot transfer to self");
     }
 

--- a/mercata/ui/src/components/dashboard/activityTypes.tsx
+++ b/mercata/ui/src/components/dashboard/activityTypes.tsx
@@ -75,8 +75,10 @@ const getFullAmount = (val: string | number): string => {
 /**
  * Check if an address belongs to the user
  */
+const normalizeAddress = (addr?: string | null): string => (addr || "").toLowerCase().replace(/^0x/, "");
+
 const isUserAddress = (addr: string, userAddress?: string | null): boolean => {
-  return !!(userAddress && addr && addr.toLowerCase() === userAddress.toLowerCase());
+  return !!(userAddress && addr && normalizeAddress(addr) === normalizeAddress(userAddress));
 };
 
 /**

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -6,7 +6,6 @@ import { useAccount, useDisconnect, useWalletClient } from "wagmi";
 import { api, setAppAuthenticated, setConnectedWalletAddress, setWalletSigner } from "@/lib/axios";
 import { isAuthenticated, logout as authLogout } from "@/lib/auth";
 import { ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE } from "@/lib/constants";
-import { ensureStratoChainInWallet } from "@/lib/stratoChain";
 
 interface UserContextType {
   userAddress: string | null;
@@ -227,8 +226,6 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     const connected = account.isConnected && account.address;
     if (connected && walletClient) {
       setWalletSigner(async (unsignedTx: any) => {
-        await ensureStratoChainInWallet(walletClient);
-
         const d = unsignedTx.data;
         return walletClient.signTypedData({
           domain: {

--- a/mercata/ui/src/hooks/useLendingMetrics.tsx
+++ b/mercata/ui/src/hooks/useLendingMetrics.tsx
@@ -4,6 +4,8 @@ import { useLendingContext } from "@/context/LendingContext";
 import { useUser } from "@/context/UserContext";
 import { usdstAddress } from "@/lib/constants";
 
+const normalizeAddress = (addr?: string | null): string => (addr || "").toLowerCase().replace(/^0x/, "");
+
 export const useLendingMetrics = () => {
   const [loanList, setLoanList] = useState([]);
   
@@ -18,6 +20,7 @@ export const useLendingMetrics = () => {
   const fetchLoans = useCallback(async () => {
     if (!userAddress) return;
     try {
+      const normalizedUserAddress = normalizeAddress(userAddress);
       const userLoans = Object.entries(loans || {})
         .map(([loanId, loan]) => ({loanId,
           ...(loan as unknown as {
@@ -34,7 +37,7 @@ export const useLendingMetrics = () => {
             assetSymbol?: string;
             [key: string]: unknown;
           }),}))
-        .filter((loan) => loan?.loan?.user === userAddress && loan?.loan?.active === true);
+        .filter((loan) => normalizeAddress(loan?.loan?.user) === normalizedUserAddress && loan?.loan?.active === true);
 
       const enrichedLoans = await Promise.all(
         userLoans.map(async (loan) => {
@@ -54,7 +57,7 @@ export const useLendingMetrics = () => {
     } catch (e) {
       console.error("Error fetching loans:", e);
     }
-  }, [loans]);
+  }, [loans, userAddress]);
 
   useEffect(() => {
     if (Object.keys(loans || {}).length > 0 && userAddress) {

--- a/mercata/ui/src/utils/transferValidation.ts
+++ b/mercata/ui/src/utils/transferValidation.ts
@@ -8,6 +8,7 @@ import {
   safeParseUnits,
 } from "@/utils/numberUtils";
 
+const normalizeAddress = (addr?: string): string => (addr || "").toLowerCase().replace(/^0x/, "");
 
 export const validateRecipientAddress = (
   value: string,
@@ -16,7 +17,7 @@ export const validateRecipientAddress = (
   const addr = value.trim();
   if (!addr) return "";
   if (!isAddress(addr)) return "Invalid address";
-  if (userAddress && addr.toLowerCase() === userAddress.toLowerCase()) {
+  if (userAddress && normalizeAddress(addr) === normalizeAddress(userAddress)) {
     return "You cannot transfer to your own address.";
   }
   return "";


### PR DESCRIPTION
Normalize wallet addresses before comparing or filtering user-specific UI data, including swap history, activity highlights, lending metrics, and transfer self-checks. Remove the forced STRATO network switch from the global backend typed-data signer so CDP borrow does not interrupt MetaMask-only users mid-processing.

Fix "Show My Swaps" toggle on swap page for MM users