### PR TITLE
Fix external wallet RPC reads through backend proxy

### DIFF
--- a/mercata/backend/src/api/controllers/rpc.controller.ts
+++ b/mercata/backend/src/api/controllers/rpc.controller.ts
@@ -4,6 +4,32 @@ import { eth, bloc } from "../../utils/mercataApiHelper";
 import { StratoPaths } from "../../config/constants";
 
 class RpcController {
+  private static readonly READ_ONLY_RPC_METHODS = new Set([
+    "eth_call",
+    "eth_getBalance",
+    "eth_blockNumber",
+    "eth_chainId",
+    "eth_getCode",
+    "eth_getTransactionCount",
+    "eth_getTransactionReceipt",
+    "eth_getBlockByNumber",
+    "eth_getBlockByHash",
+    "eth_getLogs",
+    "net_version",
+  ]);
+
+  private static isReadOnlyRpcPayload(payload: unknown): boolean {
+    const requests = Array.isArray(payload) ? payload : [payload];
+    return requests.every(
+      (request) =>
+        request &&
+        typeof request === "object" &&
+        "method" in request &&
+        typeof request.method === "string" &&
+        RpcController.READ_ONLY_RPC_METHODS.has(request.method),
+    );
+  }
+
   static async submitSignedTx(
     req: Request,
     res: Response,
@@ -38,6 +64,11 @@ class RpcController {
     const chainId = req.params.chainId;
     const {upstream, fallback} = getRpcUpstream(chainId);
 
+    if (!RpcController.isReadOnlyRpcPayload(req.body)) {
+      res.status(403).json({ error: "RPC method not allowed" });
+      return;
+    }
+
     if (!upstream || !fallback) {
       res.status(400).json({ error: "Unsupported chainId" });
       return;
@@ -55,7 +86,7 @@ class RpcController {
       try {
         const upstreamRes = await fetch(upstream, {...requestPayload, signal: AbortSignal.timeout(5000)});
         response = await upstreamRes.json();
-        if (!upstreamRes.ok || !response.result) throw new Error(); //fallback
+        if (!upstreamRes.ok || (!Array.isArray(response) && response.error)) throw new Error(); //fallback
         res.status(upstreamRes.status).json(response);
         return;
       }

--- a/mercata/backend/src/api/routes/rpc.routes.ts
+++ b/mercata/backend/src/api/routes/rpc.routes.ts
@@ -23,6 +23,6 @@ const router = Router();
  */
 router.post("/submit", authHandler.authorizeRequest({ allowWalletAuth: true }), RpcController.submitSignedTx);
 router.post("/results", authHandler.authorizeRequest({ allowWalletAuth: true }), RpcController.txResults);
-router.post("/:chainId", authHandler.authorizeRequest(false), RpcController.proxy);
+router.post("/:chainId", RpcController.proxy);
 
 export default router;

--- a/mercata/backend/src/config/rpc.config.ts
+++ b/mercata/backend/src/config/rpc.config.ts
@@ -22,7 +22,7 @@ const rpcUpstreams: RpcMapping = {
   [baseChainId]: process.env.RPC_URL_BASE || fallbackRpcUpstreams[baseChainId],
   [baseSepoliaChainId]: process.env.RPC_URL_BASE_SEPOLIA || fallbackRpcUpstreams[baseSepoliaChainId],
   [lineaChainId]: process.env.RPC_URL_LINEA || fallbackRpcUpstreams[lineaChainId],
-  [lineaSepoliaChainId]: process.env.RPC_URL_LINEA_SEPOLIA || fallbackRpcUpstreams[lineaChainId],
+  [lineaSepoliaChainId]: process.env.RPC_URL_LINEA_SEPOLIA || fallbackRpcUpstreams[lineaSepoliaChainId],
 };
 
 export function getRpcUpstream(chainId: string): { upstream: string | undefined; fallback: string | undefined } {

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -4,7 +4,7 @@ import UsdstBalanceBox from "@/components/layouts/UsdstBalanceBox";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Transport, WagmiProvider } from "wagmi";
-import { mainnet, polygon, sepolia, base, baseSepolia } from "wagmi/chains";
+import { mainnet, polygon, sepolia, base, baseSepolia, linea, lineaSepolia } from "wagmi/chains";
 import {
   connectorsForWallets,
   RainbowKitProvider,
@@ -78,7 +78,8 @@ import { getNodeHealth, shouldShowNodeHealth, type NodeHealth } from "./lib/node
 
 
 const queryClient = new QueryClient();
-const baseChains = [mainnet, polygon, sepolia, base, baseSepolia] as const;
+const proxiedChainIds = new Set([mainnet.id, sepolia.id, base.id, baseSepolia.id, linea.id, lineaSepolia.id]);
+const baseChains = [mainnet, polygon, sepolia, base, baseSepolia, linea, lineaSepolia] as const;
 
 const App = () => {
   const [projectId, setProjectId] = useState("PROJECT_ID_UNSET");
@@ -153,7 +154,10 @@ const App = () => {
       const stratoChain = getStratoChain();
       const chains = stratoChain ? [...baseChains, stratoChain] : baseChains;
       const transports: Record<number, Transport> = Object.fromEntries(
-        chains.map((chain) => [chain.id, chain === stratoChain ? http(`/rpc`) : http()])
+        chains.map((chain) => [
+          chain.id,
+          chain === stratoChain ? http(`/rpc`) : proxiedChainIds.has(chain.id) ? http(`/api/rpc/${chain.id}`) : http(),
+        ])
       );
 
       const connectors = connectorsForWallets(

--- a/mercata/ui/src/lib/bridge/contractService.ts
+++ b/mercata/ui/src/lib/bridge/contractService.ts
@@ -17,9 +17,10 @@ import {
   Permit2Types
 } from './types';
 
+const PROXIED_CHAIN_IDS = new Set(["1", "11155111", "8453", "84532", "59144", "59141"]);
 
 async function getClient(chainId: string) {
-  const transport = http();
+  const transport = PROXIED_CHAIN_IDS.has(chainId) ? http(`/api/rpc/${chainId}`) : http();
 
   return createPublicClient({
     chain: await resolveViemChain(chainId),


### PR DESCRIPTION
Fix external RPC reads through backend proxy

Route browser-side external chain reads through the backend RPC proxy to avoid public RPC CORS failures. Keep the public proxy restricted with an explicit read-only JSON-RPC method allowlist, so adding new RPC methods requires updating the allowlist intentionally.