### PR TITLE
Allow read-only RPC proxy through nginx auth

### DIFF
--- a/mercata/backend/src/api/controllers/rpc.controller.ts
+++ b/mercata/backend/src/api/controllers/rpc.controller.ts
@@ -11,6 +11,7 @@ class RpcController {
     "eth_chainId",
     "eth_getCode",
     "eth_getTransactionCount",
+    "eth_getTransactionByHash",
     "eth_getTransactionReceipt",
     "eth_getBlockByNumber",
     "eth_getBlockByHash",
@@ -111,4 +112,3 @@ class RpcController {
 }
 
 export default RpcController;
-

--- a/nginx-packager/csrf.lua
+++ b/nginx-packager/csrf.lua
@@ -244,6 +244,12 @@ local wallet_auth_methods = {
     PUT = true
 }
 
+-- Backend only proxies allow-listed read-only JSON-RPC methods on these routes.
+function _M.allow_rpc_proxy_request()
+    local uri = ngx.var.uri or ""
+    return ngx.var.request_method == "POST" and uri:match("^/api/rpc/%d+$") ~= nil
+end
+
 function _M.is_valid_wallet_address(addr)
     if type(addr) ~= "string" then
         return false
@@ -297,6 +303,10 @@ function _M.protect_api()
     end
 
     if method == "POST" or method == "PUT" or method == "DELETE" or method == "PATCH" then
+        if _M.allow_rpc_proxy_request() then
+            return
+        end
+
         if _M.allow_wallet_auth_request() then
             return
         end

--- a/nginx-packager/openid.tpl.lua
+++ b/nginx-packager/openid.tpl.lua
@@ -78,6 +78,11 @@ local wallet_auth_methods = {
   PUT = true
 }
 
+-- Backend only proxies allow-listed read-only JSON-RPC methods on these routes.
+local function allow_rpc_proxy_request()
+  return ngx.req.get_method() == "POST" and (ngx.var.uri or ""):match("^/api/rpc/%d+$") ~= nil
+end
+
 local function is_valid_wallet_address(addr)
   if type(addr) ~= "string" then
     return false
@@ -129,7 +134,9 @@ else
   local authenticate_res, authenticate_err, authenticate_session
   -- Allow anonymous access only for safe/read-only methods on endpoints that explicitly allow it
   local method = ngx.req.get_method()
-  local allow_anonymous_request = ngx.var.allow_optional_anon_access == "true" and (method == "GET" or method == "HEAD" or method == "OPTIONS")
+  local allow_anonymous_request =
+    (ngx.var.allow_optional_anon_access == "true" and (method == "GET" or method == "HEAD" or method == "OPTIONS"))
+    or allow_rpc_proxy_request()
   local allow_wallet_request = allow_wallet_auth_request()
   -- if requested_uri is the UI page (like SMD), else the API call
   if ngx.var.is_ui == "true" then


### PR DESCRIPTION
## Summary

- Allow nginx auth to pass `POST /api/rpc/<numeric-chain-id>` requests through to the Mercata backend RPC proxy.
- Skip CSRF validation for that same numeric-chain RPC proxy route.
- Add `eth_getTransactionByHash` to the backend read-only JSON-RPC allow-list.
- Keep `/api/rpc/submit`, `/api/rpc/results`, and non-numeric RPC paths on the existing auth/CSRF behavior.

## Why

The Fund/deposits page uses JSON-RPC `POST`s for read-only EVM balance, contract, and receipt/transaction polling. The backend proxy already enforces a read-only method allow-list, but nginx was blocking browser requests before they reached the backend:

- `403 Security validation failed` from CSRF
- `401` from OIDC auth

After nginx was fixed, receipt polling could still false-fail because viem may call `eth_getTransactionByHash`, which the backend proxy was rejecting with `403 RPC method not allowed`.

## Validation

- `git diff --check`
- Built from the PR branch on the affected node:
  - `mercata-backend:17.0-fd1a9dd-26f58aaebf6c`
  - `nginx:17.0-fd1a9dd-cad38248c780`
- Verified on the affected node:
  - `POST /api/rpc/1` through nginx returns `200`
  - `eth_getBalance` returns the expected JSON-RPC balance response
  - `eth_getTransactionByHash` returns `200` from the backend proxy instead of `403 RPC method not allowed`
