### PR TITLE
exposed rpc endpoint on nginx locally that redirects to the upstram node

### DIFF
--- a/mercata/README.md
+++ b/mercata/README.md
@@ -21,7 +21,7 @@ The app consists of multiple parts:
 
 ### Prerequisites
 
-- Node.js v22.12+ (not tested with 23+) (with nvm and npm) — see https://nodejs.org/en/download
+- Node.js v22.12+ (not tested with 23+) (with nvm and npm) — see [https://nodejs.org/en/download](https://nodejs.org/en/download)
 
 ### Run Backend:
 
@@ -54,27 +54,29 @@ npm run dev
 
 - Make sure the port 80 is not used on your machine: `lsof -i :80` (should return empty output)
 - Then run:
-
   ```
   cd ../nginx
   OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration \
     OAUTH_CLIENT_ID=localhost \
     OAUTH_CLIENT_SECRET=client-secret-here \
+    NODE_URL=https://node5.mercata-testnet.blockapps.net \
     docker compose -f docker-compose.nginx-standalone.yml up -d --build
   ```
-
-- BEWARE! Disable any VPN on your host machine. It can interfere with Docker networking and cause a hang on http://localhost.
+- `NODE_URL` must match the backend's `NODE_URL` — nginx proxies `/rpc` to `NODE_URL/rpc` 
+- BEWARE! Disable any VPN on your host machine. It can interfere with Docker networking and cause a hang on [http://localhost](http://localhost).
 - If `http://localhost` does not open, try a browser incognito mode (the permanent redirect 301 to https could be cached in browser for the localhost domain, after running other software).
-- In most Linux scenarios 'host.docker.internal' will work just fine and there is no need to pass an explicit `HOST_IP` parameter into Docker Compose. If there are network issues then you can drop back to a hardcoded IP address - usually `HOST_IP=172.17.0.1 \` (the gateway IP of the default Docker bridge interface), or any static local IP of your host machine. More details here: https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
+- In most Linux scenarios 'host.docker.internal' will work just fine and there is no need to pass an explicit `HOST_IP` parameter into Docker Compose. If there are network issues then you can drop back to a hardcoded IP address - usually `HOST_IP=172.17.0.1 \` (the gateway IP of the default Docker bridge interface), or any static local IP of your host machine. More details here: [https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844](https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844)
 - You may also need to explicitly open ports in your Linux host's firewall configuration to allow Docker to communicate with the node processes running on your host. See iptables example below.
 - Nginx also supports the live updates of the Next.js app during development, when it is deployed with `npm run dev`.
 
 iptables example for Docker network bridge port setup:
 
-    0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:8080
-    0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:8080
-    0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:3001
-    0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:3001
+```
+0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:8080
+0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:8080
+0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:3001
+0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:3001
+```
 
 ---
 

--- a/mercata/nginx/docker-compose.nginx-standalone.yml
+++ b/mercata/nginx/docker-compose.nginx-standalone.yml
@@ -5,6 +5,7 @@ services:
     - OAUTH_DISCOVERY_URL=${OAUTH_DISCOVERY_URL}
     - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
     - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+    - NODE_URL=${NODE_URL}
     - ssl=${ssl:-false}
     - DOCKERIZED_APP=false
     - HOST_IP=${HOST_IP:-host.docker.internal}

--- a/mercata/nginx/docker-run.sh
+++ b/mercata/nginx/docker-run.sh
@@ -5,6 +5,7 @@ set -e
 OAUTH_DISCOVERY_URL=${OAUTH_DISCOVERY_URL:-NULL}
 OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID:-NULL}
 OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET:-NULL}
+NODE_URL=${NODE_URL:-NULL}
 HOST_IP=${HOST_IP:-host.docker.internal}
 DOCKERIZED_APP=${DOCKERIZED_APP:-true}
 
@@ -15,6 +16,10 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
   ########
   if [[ ${OAUTH_DISCOVERY_URL} = NULL || ${OAUTH_CLIENT_ID} = NULL || ${OAUTH_CLIENT_SECRET} = NULL ]] ; then
     echo 'OAUTH_DISCOVERY_URL, OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET are required for OAuth. Exit'
+    exit 4
+  fi
+  if [[ ${NODE_URL} = NULL ]] ; then
+    echo 'NODE_URL is required to proxy /rpc to the upstream STRATO node. Exit'
     exit 4
   fi
 
@@ -38,6 +43,10 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
     sed -i "s|__BACKEND_HOST__|$HOST_IP|g" /tmp/nginx.conf
     sed -i "s|__UI_HOST__|$HOST_IP|g" /tmp/nginx.conf
   fi
+
+  # Strip trailing slash from NODE_URL so `__NODE_URL__/rpc` is well-formed
+  NODE_URL_STRIPPED="${NODE_URL%/}"
+  sed -i "s|__NODE_URL__|$NODE_URL_STRIPPED|g" /tmp/nginx.conf
 
   ########
   ### Generate .lua scripts from templates according to configuration provided

--- a/mercata/nginx/nginx.tpl.conf
+++ b/mercata/nginx/nginx.tpl.conf
@@ -202,5 +202,14 @@ http {
         client_max_body_size 1m;
       }
 
+      # Proxy JSON-RPC calls to the upstream STRATO node's /rpc endpoint.
+      location /rpc {
+        proxy_set_header Accept-Encoding "";
+        proxy_set_header Cookie "";
+        proxy_hide_header Set-Cookie;
+        proxy_ssl_server_name on;
+        proxy_pass __NODE_URL__/rpc;
+      }
+
     }
 }


### PR DESCRIPTION
## Summary

- Add `/rpc` location to the standalone Mercata nginx that proxies to `NODE_URL/rpc`, mirroring the platform `nginx-packager` block. Local dev now matches prod 1:1 for the JSON-RPC path.
- Unblocks the STRATO Wallet connector, MetaMask-as-STRATO-signer (`ensureStratoChainInWallet`), and the Transfer page non-vault flow locally — all three were 404ing on `/rpc` and silently failing chain init / nonce fetch.
- New `NODE_URL` env var required when starting the standalone nginx; wired through `docker-compose.nginx-standalone.yml` and `docker-run.sh`, README updated.

## Test plan

- [x] `docker compose -f mercata/nginx/docker-compose.nginx-standalone.yml up -d --build` with `NODE_URL` set; container reports healthy.
- [x] `curl -X POST http://localhost/rpc -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'` returns the same chain ID prod returns.
- [x] Open app on `http://localhost`, click Connect Wallet — STRATO Wallet appears in the modal.
- [x] As a vault user: send a transfer via STRATO Wallet — signs and submits.
- [x] As an external-wallet user: send a STRATO transfer via MetaMask — chain-switch prompt appears and tx signs.
- [x] `/api/config`, `/api/...`, `/login`, `/auth/...`, and UI loading on port 80 all still work (regression).
- [ ] Starting nginx without `NODE_URL` exits with the expected error message.