### PR TITLE
Reduce API response times via caching and query optimization

### DIFF
--- a/mercata/backend/src/api/controllers/lending.controller.ts
+++ b/mercata/backend/src/api/controllers/lending.controller.ts
@@ -25,6 +25,7 @@ import {
   pauseLendingPool,
   unpauseLendingPool,
   getLendingInterestAccrued,
+  clearLiquidationCache,
 } from "../services/lending.service";
 import {
   validateDepositLiquidityArgs,
@@ -292,6 +293,7 @@ class LendingController {
       validateLiquidationArgs({id, ...req.body});
 
       const result = await executeLiquidationService(accessToken, userAddress as string, id, req.body || {});
+      clearLiquidationCache();
       res.status(RestStatus.OK).json(result);
       return next();
     } catch (error) {

--- a/mercata/backend/src/api/helpers/oracle.helper.ts
+++ b/mercata/backend/src/api/helpers/oracle.helper.ts
@@ -139,6 +139,9 @@ const addSaveUsdstTokenPrice = async (
   priceMap.set(vault.address, pricePerShare.toString());
 };
 
+// Cached vault→asset mapping populated by addYieldVaultTokenPrices, consumed by getCarryVaultUsdPriceMap
+let _yieldVaultAssetMap = new Map<string, string>();
+
 /** NAV per carry-vault share (underlying base units per share, WAD) for portfolio price × balance math. */
 const addYieldVaultTokenPrices = async (
   accessToken: string,
@@ -149,7 +152,9 @@ const addYieldVaultTokenPrices = async (
   );
   if (!vaultAddrs.length) return;
 
-  for (const vaultAddress of vaultAddrs) {
+  const assetMap = new Map<string, string>();
+
+  await Promise.all(vaultAddrs.map(async (vaultAddress) => {
     const { data: rows } = await cirrus.get(accessToken, `/${YieldVault}`, {
       params: {
         address: `eq.${vaultAddress}`,
@@ -157,7 +162,7 @@ const addYieldVaultTokenPrices = async (
       },
     });
     const v = rows?.[0];
-    if (!v?._asset || !v.address) continue;
+    if (!v?._asset || !v.address) return;
 
     const { data: balRows } = await cirrus.get(accessToken, `/${Token}-_balances`, {
       params: {
@@ -173,61 +178,31 @@ const addYieldVaultTokenPrices = async (
     const totalShares = BigInt(v._totalSupply || "0");
     const pricePerShare = totalShares === 0n ? DECIMALS : (totalAssets * DECIMALS) / totalShares;
     priceMap.set(v.address, pricePerShare.toString());
-  }
+    assetMap.set(String(v.address).toLowerCase(), String(v._asset).toLowerCase());
+  }));
+
+  _yieldVaultAssetMap = assetMap;
 };
 
 /**
  * USD-denominated per-share price for each carry vault (1e18 WAD).
- * Composes the vault's underlying-per-share NAV (idle + deployed) / totalShares with the
- * asset's USD oracle price. Keyed by vault address (lowercased, no 0x prefix).
- *
- * Rationale: `priceMap` already stores the underlying-denominated price (ETH per share for
- * the ETH carry vault) for portfolio math; consumers that need the USD value of a stake
- * denominated in carry-vault shares must apply the asset's USD oracle on top.
+ * Reuses the underlying NAV already stored in priceMap by addYieldVaultTokenPrices
+ * and multiplies by the asset's USD oracle price. No additional Cirrus calls.
  */
-export const getCarryVaultUsdPriceMap = async (
-  accessToken: string,
+export const getCarryVaultUsdPriceMap = (
   priceMap: OraclePriceMap
-): Promise<Map<string, string>> => {
+): Map<string, string> => {
   const out = new Map<string, string>();
-  const vaultAddrs = [config.ethCarryVault, config.wbtcCarryVault, config.usdcYieldVault].filter(
-    (a): a is string => typeof a === "string" && a.replace(/^0x/i, "").length > 0
-  );
-  if (!vaultAddrs.length) return out;
+  for (const [vaultAddr, assetAddr] of _yieldVaultAssetMap) {
+    const navStr = priceMap.get(vaultAddr) || priceMap.get(vaultAddr.toLowerCase()) || "0";
+    const nav = BigInt(navStr);
+    if (nav === 0n) continue;
 
-  for (const vaultAddress of vaultAddrs) {
-    const { data: rows } = await cirrus.get(accessToken, `/${YieldVault}`, {
-      params: {
-        address: `eq.${vaultAddress}`,
-        select: "address,_asset,deployedAssets::text,_totalSupply::text",
-      },
-    });
-    const v = rows?.[0];
-    if (!v?._asset || !v.address) continue;
+    const assetUsdStr = priceMap.get(assetAddr) || priceMap.get(assetAddr.toLowerCase()) || "0";
+    const assetUsd = BigInt(assetUsdStr);
+    if (assetUsd === 0n) continue;
 
-    const { data: balRows } = await cirrus.get(accessToken, `/${Token}-_balances`, {
-      params: {
-        address: `eq.${v._asset}`,
-        key: `eq.${vaultAddress}`,
-        select: "value::text",
-      },
-    });
-
-    const idle = BigInt(balRows?.[0]?.value || "0");
-    const deployed = BigInt(v.deployedAssets || "0");
-    const totalAssets = idle + deployed;
-    const totalShares = BigInt(v._totalSupply || "0");
-    if (totalShares === 0n) continue;
-
-    const pricePerShareUnderlying = (totalAssets * DECIMALS) / totalShares;
-
-    const assetKey = String(v._asset).toLowerCase();
-    const assetUsdPriceStr = priceMap.get(assetKey) || priceMap.get(v._asset) || "0";
-    const assetUsdPriceWad = BigInt(assetUsdPriceStr);
-    if (assetUsdPriceWad === 0n) continue;
-
-    const pricePerShareUsdWad = (pricePerShareUnderlying * assetUsdPriceWad) / DECIMALS;
-    out.set(String(v.address).toLowerCase(), pricePerShareUsdWad.toString());
+    out.set(vaultAddr, ((nav * assetUsd) / DECIMALS).toString());
   }
   return out;
 };

--- a/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
@@ -7,7 +7,7 @@ import { constants } from "../../../config/constants";
  */
 let contractStateCache: { address: string; state: any; timestamp: number } | null = null;
 let pendingRequest: Promise<any> | null = null;
-const CACHE_TTL = 5000; // 5 seconds cache
+const CACHE_TTL = 30_000; // 30 seconds cache
 const normalizeUserAddress = (address: string): string => address.replace(/^0x/i, "").toLowerCase();
 
 /**

--- a/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewards.helpers.ts
@@ -272,12 +272,21 @@ export const fetchUnclaimedRewards = async (
 };
 
 /**
- * Fetch total claimed rewards per user from RewardsClaimed events
+ * Fetch total claimed rewards per user from RewardsClaimed events.
+ * Cached 30 s — claims are append-only so brief staleness is safe.
  */
+let _claimedRewardsCache: { data: Map<string, bigint>; address: string; expiry: number } | null = null;
+const CLAIMED_REWARDS_TTL = 30_000;
+
 export const fetchClaimedRewards = async (
   accessToken: string,
   rewardsAddress: string
 ): Promise<Map<string, bigint>> => {
+  if (_claimedRewardsCache && _claimedRewardsCache.address === rewardsAddress
+      && Date.now() < _claimedRewardsCache.expiry) {
+    return _claimedRewardsCache.data;
+  }
+
   try {
     const { data: events = [] } = await cirrus.get(accessToken, "/event", {
       params: {
@@ -287,7 +296,7 @@ export const fetchClaimedRewards = async (
       },
     });
 
- return events.reduce((map: Map<string, bigint>, event: any) => {
+    const result = events.reduce((map: Map<string, bigint>, event: any) => {
       try {
         const attrs = typeof event.attributes === 'string' 
           ? JSON.parse(event.attributes) 
@@ -302,6 +311,9 @@ export const fetchClaimedRewards = async (
       }
       return map;
     }, new Map<string, bigint>());
+
+    _claimedRewardsCache = { data: result, address: rewardsAddress, expiry: Date.now() + CLAIMED_REWARDS_TTL };
+    return result;
   } catch (error) {
     console.error("Failed to fetch claimed rewards:", error);
     return new Map<string, bigint>();
@@ -311,14 +323,25 @@ export const fetchClaimedRewards = async (
 /**
  * Fetch bonus rewards for a specific user from DirectPayoutApplied events,
  * broken down by activityId so the caller can resolve activity names.
+ * Cached 30 s per user — bonus payouts are append-only.
  */
+type BonusRewardsResult = { total: bigint; byActivity: Map<string, bigint> };
+const _bonusRewardsCache = new Map<string, { data: BonusRewardsResult; expiry: number }>();
+const BONUS_REWARDS_TTL = 30_000;
+
 export const fetchBonusRewards = async (
   accessToken: string,
   rewardsAddress: string,
   userAddress: string
-): Promise<{ total: bigint; byActivity: Map<string, bigint> }> => {
+): Promise<BonusRewardsResult> => {
+  const normalizedUserAddress = normalizeUserAddress(userAddress);
+  const cacheKey = `${rewardsAddress}:${normalizedUserAddress}`;
+  const cached = _bonusRewardsCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data;
+  }
+
   try {
-    const normalizedUserAddress = normalizeUserAddress(userAddress);
     const { data: events = [] } = await cirrus.get(accessToken, "/event", {
       params: {
         address: `eq.${rewardsAddress}`,
@@ -342,7 +365,10 @@ export const fetchBonusRewards = async (
         byActivity.set(actId, (byActivity.get(actId) || 0n) + amount);
       } catch { /* skip */ }
     }
-    return { total, byActivity };
+
+    const result = { total, byActivity };
+    _bonusRewardsCache.set(cacheKey, { data: result, expiry: Date.now() + BONUS_REWARDS_TTL });
+    return result;
   } catch (error) {
     console.error("Failed to fetch bonus rewards:", error);
     return { total: 0n, byActivity: new Map() };

--- a/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
+++ b/mercata/backend/src/api/helpers/vaultPerformance.helper.ts
@@ -182,21 +182,20 @@ export const computeVaultPerformanceMetrics = async (
     const startDateObj = new Date(startDate + "T00:00:00Z");
     const actualDays = Math.max((now.getTime() - startDateObj.getTime()) / (24 * 60 * 60 * 1000), 1);
 
-    const { data: histStorage } = await cirrus.get(accessToken, "/history@storage", {
-      params: {
-        address: `eq.${shareTokenAddress}`,
-        valid_from: `lte.${startDate}`,
-        valid_to: `gte.${startDate}`,
-        select: "data",
-      },
-    });
-    const histTotalSupply = safeBigInt(histStorage?.[0]?.data?._totalSupply);
-    if (histTotalSupply <= 0n) return noData;
-
-    const [histBalances, histPrices] = await Promise.all([
+    const [{ data: histStorage }, histBalances, histPrices] = await Promise.all([
+      cirrus.get(accessToken, "/history@storage", {
+        params: {
+          address: `eq.${shareTokenAddress}`,
+          valid_from: `lte.${startDate}`,
+          valid_to: `gte.${startDate}`,
+          select: "data",
+        },
+      }),
       getHistoricalTokenBalances(accessToken, supportedAssets, botExecutor, startDate),
       getHistoricalAssetPrices(accessToken, priceOracleAddress, supportedAssets, startDate),
     ]);
+    const histTotalSupply = safeBigInt(histStorage?.[0]?.data?._totalSupply);
+    if (histTotalSupply <= 0n) return noData;
 
     let histEquity = 0n;
     let hodlEquity = 0n;

--- a/mercata/backend/src/api/services/earn.service.ts
+++ b/mercata/backend/src/api/services/earn.service.ts
@@ -47,9 +47,7 @@ export const getTokenApys = async (accessToken: string): Promise<TokenApyEntry[]
   const ctx = parsePhase1(phase1, vaultAddr, rewAddr, saveUsdstVault);
   const phase1b = await fetchPhase1b(accessToken, ctx, saveUsdstVault);
 
-  const carryVaultUsdPriceMap = await getCarryVaultUsdPriceMap(accessToken, ctx.prices).catch(
-    () => new Map<string, string>(),
-  );
+  const carryVaultUsdPriceMap = getCarryVaultUsdPriceMap(ctx.prices);
   const rewardActivities = buildRewardActivitiesFromMappings(
     ctx.rewardActivityCfgById, ctx.rewardActivityStateById, {
       priceMap: ctx.prices,

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -1421,6 +1421,10 @@ export interface LiquidationEntry {
 let _liquidationCache: { data: { registry: any; tokenInfoMap: Map<string, any> }; expiry: number } | null = null;
 const LIQUIDATION_CACHE_TTL = 30_000;
 
+export const clearLiquidationCache = (): void => {
+  _liquidationCache = null;
+};
+
 export const listLoansForLiquidation = async (
   accessToken: string,
   margin?: number

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -537,9 +537,16 @@ export const collateralAndBalance = async (
     });
 };
 
+let _publicCollateralCache: { data: any; expiry: number } | null = null;
+const PUBLIC_COLLATERAL_TTL = 30_000;
+
 export const getPublicCollateralInfo = async (
   accessToken: string,
 ) => {
+  if (_publicCollateralCache && Date.now() < _publicCollateralCache.expiry) {
+    return _publicCollateralCache.data;
+  }
+
   const registry = await getPool(accessToken, {
     select:
       `lendingPool:lendingPool_fkey(` +
@@ -558,14 +565,15 @@ export const getPublicCollateralInfo = async (
   const isPaused = registry.lendingPool._paused;
   const assets = registry.lendingPool.assetConfigs?.map((a: any) => a.asset).filter((asset: string) => asset !== registry.lendingPool.borrowableAsset) || [];
   
-  // Fetch token metadata only (no user balances)
   let tokenMap = new Map();
   if (assets.length > 0) {
-    const tokens = await getTokens(accessToken, {
-      address: `in.(${assets.join(",")})`,
-      select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,images:${Token}-images(value)`
+    const { data: tokenRows } = await cirrus.get(accessToken, `/${Token}`, {
+      params: {
+        address: `in.(${assets.join(",")})`,
+        select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,images:${Token}-images(value)`,
+      },
     });
-    tokenMap = new Map(tokens.map((t: any) => [t.address, { address: t.address, balance: "0", token: t }]));
+    tokenMap = new Map((tokenRows || []).map((t: any) => [t.address, { address: t.address, balance: "0", token: t }]));
   }
 
   // Create maps for asset configs and prices
@@ -626,6 +634,7 @@ export const getPublicCollateralInfo = async (
       };
     });
 
+  _publicCollateralCache = { data: result, expiry: Date.now() + PUBLIC_COLLATERAL_TTL };
   return result;
 };
 
@@ -815,9 +824,16 @@ export const liquidityAndBalance = async (
   };
 };
 
+let _publicLiquidityCache: { data: any; expiry: number } | null = null;
+const PUBLIC_LIQUIDITY_TTL = 30_000;
+
 export const getPublicLiquidityInfo = async (
   accessToken: string,
 ) => {
+  if (_publicLiquidityCache && Date.now() < _publicLiquidityCache.expiry) {
+    return _publicLiquidityCache.data;
+  }
+
   // Build query - no userLoan filter for public data
   const queryParams: Record<string, string> = {
     select:
@@ -846,16 +862,33 @@ export const getPublicLiquidityInfo = async (
     throw new Error("Lending pool, borrowable asset, or mToken not found");
   }
 
-  // Fetch token metadata - only pool balances (no user balances)
-  const tokenData = await getTokens(accessToken, {
-    address: `in.(${borrowableAsset},${mToken})`,
-    select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,balances:${Token}-_balances(user:key,balance:value::text)`,
-    "balances.key": `eq.${registry.liquidityPool?.address || ''}`
+  // Fetch token metadata + exchange rate in parallel (lightweight — no getTokens overhead)
+  const [{ data: tokenRows }, exchangeRate] = await Promise.all([
+    cirrus.get(accessToken, `/${Token}`, {
+      params: {
+        address: `in.(${borrowableAsset},${mToken})`,
+        select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,balances:${Token}-_balances(user:key,balance:value::text)`,
+        "balances.key": `eq.${registry.liquidityPool?.address || ''}`,
+      },
+    }),
+    getExchangeRateFromCirrus(accessToken),
+  ]);
+
+  // Build price map from oracle prices already in registry
+  const priceMap = new Map<string, string>();
+  (registry.oracle?.prices || []).forEach((p: any) => {
+    priceMap.set(p.asset, p.price);
   });
 
+  // Add price to token objects (same shape getTokens would produce)
+  const tokenData = (tokenRows || []).map((t: any) => ({
+    ...t,
+    price: priceMap.get(t.address) || "0",
+  }));
+
   // Extract token data
-  const borrowableToken = tokenData.find(token => token.address === borrowableAsset);
-  const mTokenInfo = tokenData.find(token => token.address === mToken);
+  const borrowableToken = tokenData.find((token: any) => token.address === borrowableAsset);
+  const mTokenInfo = tokenData.find((token: any) => token.address === mToken);
 
   // User balances are always "0" for guests
   const borrowableBalance = "0";
@@ -867,18 +900,6 @@ export const getPublicLiquidityInfo = async (
 
   // Asset config for borrowable asset
   const borrowableAssetConfig = assetConfigs?.find((c: any) => c.asset === borrowableAsset)?.AssetConfig || {};
-
-  // Build price map (USD 1e18)
-  const priceMap = new Map<string, string>();
-  (registry.oracle?.prices || []).forEach((p: any) => {
-    priceMap.set(p.asset, p.price);
-  });
-  if (!priceMap.has(borrowableAsset)) {
-    priceMap.set(borrowableAsset, borrowableToken?.price?.toString() || "0");
-  }
-  if (!priceMap.has(mToken)) {
-    priceMap.set(mToken, mTokenInfo?.price?.toString() || "0");
-  }
 
   // Index/scaled-debt state from Cirrus
   const borrowIndexStr     = registry.lendingPool?.borrowIndex     || "0";
@@ -900,9 +921,6 @@ export const getPublicLiquidityInfo = async (
 
   // System totals and exchange rate
   const systemTotalDebt = totalDebtFromScaled(totalScaledDebtStr.toString(), borrowIndexStr.toString());
-
-  // Get exchange rate from Cirrus events instead of calculating manually
-  const exchangeRate = await getExchangeRateFromCirrus(accessToken);
 
   const totalUSDSTSupplied = (BigInt(availableLiquidity) + BigInt(systemTotalDebt)).toString();
 
@@ -935,7 +953,7 @@ export const getPublicLiquidityInfo = async (
   // Back-compat field
   const totalBorrowPrincipal = systemTotalDebt;
 
-  return {
+  const result = {
     supplyable: {
       ...borrowableTokenClean,
       userBalance: borrowableBalance, // "0" for guests
@@ -956,17 +974,16 @@ export const getPublicLiquidityInfo = async (
     maxSupplyAPY: Math.floor(apyData.supplyAPY * 100) / 100,
     borrowAPY: Math.floor(apyData.borrowAPY * 100) / 100,
     exchangeRate,
-    // Additional pool metrics
     borrowIndex: borrowIndexStr.toString(),
     reservesAccrued: reservesAccruedStr.toString(),
-    // New index-based fields for UI (always "0" for guests):
     totalAmountOwed: totalAmountOwedClamped,
     totalAmountOwedPreview: totalAmountOwedPreviewClamped,
-    // Compat:
     totalBorrowPrincipal,
-    // Pause status
     isPaused,
   };
+
+  _publicLiquidityCache = { data: result, expiry: Date.now() + PUBLIC_LIQUIDITY_TTL };
+  return result;
 };
 
 export const getLoan = async (

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -76,6 +76,9 @@ const parseBigIntLike = (value: unknown): bigint => {
   }
 };
 
+const _userFlowCache = new Map<string, { data: { totalDepositedUsd: bigint; totalWithdrawnUsd: bigint }; expiry: number }>();
+const USER_FLOW_CACHE_TTL = 60_000;
+
 const getLendingUserFlowTotals = async (
   accessToken: string,
   lendingPoolAddress: string,
@@ -89,6 +92,12 @@ const getLendingUserFlowTotals = async (
 
   if (!lendingPoolAddress || !normalizedUser) {
     return { totalDepositedUsd, totalWithdrawnUsd };
+  }
+
+  const cacheKey = `${lendingPoolAddress}:${normalizedUser}`;
+  const cached = _userFlowCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data;
   }
 
   try {
@@ -134,7 +143,9 @@ const getLendingUserFlowTotals = async (
     console.warn("Failed to compute lending flow totals:", error);
   }
 
-  return { totalDepositedUsd, totalWithdrawnUsd };
+  const result = { totalDepositedUsd, totalWithdrawnUsd };
+  _userFlowCache.set(cacheKey, { data: result, expiry: Date.now() + USER_FLOW_CACHE_TTL });
+  return result;
 };
 
 
@@ -669,16 +680,22 @@ export const liquidityAndBalance = async (
     throw new Error("Lending pool, borrowable asset, or mToken not found");
   }
 
-  // Fetch token metadata with balances included
-  const tokenData = await getTokens(accessToken, {
-    address: `in.(${borrowableAsset},${mToken})`,
-    select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,balances:${Token}-_balances(user:key,balance:value::text)`,
-    "balances.key": `in.(${userAddress},${registry.liquidityPool?.address || ''})`
-  });
+  // Parallel: token metadata + exchange rate + user flow totals
+  const [{ data: tokenRows }, exchangeRate, flowTotals] = await Promise.all([
+    cirrus.get(accessToken, `/${Token}`, {
+      params: {
+        address: `in.(${borrowableAsset},${mToken})`,
+        select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,balances:${Token}-_balances(user:key,balance:value::text)`,
+        "balances.key": `in.(${userAddress},${registry.liquidityPool?.address || ''})`,
+      },
+    }),
+    getExchangeRateFromCirrus(accessToken),
+    getLendingUserFlowTotals(accessToken, registry.lendingPool?.address || "", userAddress),
+  ]);
 
-  // Extract token data and user balances
-  const borrowableToken = tokenData.find(token => token.address === borrowableAsset);
-  const mTokenInfo = tokenData.find(token => token.address === mToken);
+  const tokenData = tokenRows || [];
+  const borrowableToken = tokenData.find((token: any) => token.address === borrowableAsset);
+  const mTokenInfo = tokenData.find((token: any) => token.address === mToken);
 
   const borrowableBalance = borrowableToken?.balances?.find((b: any) => b.user === userAddress)?.balance || "0";
   const mTokenBalance = mTokenInfo?.balances?.find((b: any) => b.user === userAddress)?.balance || "0";
@@ -695,12 +712,6 @@ export const liquidityAndBalance = async (
   (registry.oracle?.prices || []).forEach((p: any) => {
     priceMap.set(p.asset, p.price);
   });
-  if (!priceMap.has(borrowableAsset)) {
-    priceMap.set(borrowableAsset, borrowableToken?.price?.toString() || "0");
-  }
-  if (!priceMap.has(mToken)) {
-    priceMap.set(mToken, mTokenInfo?.price?.toString() || "0");
-  }
 
   // Index/scaled-debt state from Cirrus
   const borrowIndexStr     = registry.lendingPool?.borrowIndex     || "0";
@@ -730,11 +741,8 @@ export const liquidityAndBalance = async (
   const totalAmountOwedClamped = (() => { try { return (BigInt(totalAmountOwed) <= 1n) ? "0" : totalAmountOwed; } catch { return totalAmountOwed; } })();
   const totalAmountOwedPreviewClamped = (() => { try { return (BigInt(totalAmountOwedPreview) <= 1n) ? "0" : totalAmountOwedPreview; } catch { return totalAmountOwedPreview; } })();
 
-  // System totals and exchange rate
+  // System totals
   const systemTotalDebt = totalDebtFromScaled(totalScaledDebtStr.toString(), borrowIndexStr.toString());
-
-  // Get exchange rate from Cirrus events instead of calculating manually
-  const exchangeRate = await getExchangeRateFromCirrus(accessToken);
 
   const totalUSDSTSupplied = (BigInt(availableLiquidity) + BigInt(systemTotalDebt)).toString();
 
@@ -771,11 +779,7 @@ export const liquidityAndBalance = async (
     ? ((userMTokenBalanceTotal * BigInt(exchangeRate)) / WAD)
     : 0n;
 
-  const { totalDepositedUsd, totalWithdrawnUsd } = await getLendingUserFlowTotals(
-    accessToken,
-    registry.lendingPool?.address || "",
-    userAddress
-  );
+  const { totalDepositedUsd, totalWithdrawnUsd } = flowTotals;
   const userNetInvestedUsd = totalDepositedUsd - totalWithdrawnUsd;
   const userAllTimeEarningsUsd = userUSDSTValueTotal - userNetInvestedUsd;
 
@@ -1414,27 +1418,56 @@ export interface LiquidationEntry {
   maxRepay?: string;
 }
 
+let _liquidationCache: { data: { registry: any; tokenInfoMap: Map<string, any> }; expiry: number } | null = null;
+const LIQUIDATION_CACHE_TTL = 30_000;
+
 export const listLoansForLiquidation = async (
   accessToken: string,
   margin?: number
 ): Promise<LiquidationEntry[]> => {
-  const select =
-    `lendingPool:lendingPool_fkey(` +
-      `address,` +
-      `borrowableAsset,` +
-      `borrowIndex::text,` +
-      `_paused,` +
-      `assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value),` +
-      `loans:${LendingPool}-userLoan(user:key,LoanInfo:value)` +
-    `),` +
-    `collateralVault:collateralVault_fkey(` +
-      `userCollaterals:${CollateralVault}-userCollaterals(user:key,asset:key2,amount:value::text)` +
-    `),` +
-    `oracle:priceOracle_fkey(` +
-      `prices:${PriceOracle}-prices(asset:key,price:value::text)` +
-    `)`;
+  let registry: any;
+  let tokenInfoMap: Map<string, any>;
 
-  const registry = await getPool(accessToken, { select });
+  if (_liquidationCache && Date.now() < _liquidationCache.expiry) {
+    registry = _liquidationCache.data.registry;
+    tokenInfoMap = _liquidationCache.data.tokenInfoMap;
+  } else {
+    const select =
+      `lendingPool:lendingPool_fkey(` +
+        `address,` +
+        `borrowableAsset,` +
+        `borrowIndex::text,` +
+        `_paused,` +
+        `assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value),` +
+        `loans:${LendingPool}-userLoan(user:key,LoanInfo:value)` +
+      `),` +
+      `collateralVault:collateralVault_fkey(` +
+        `userCollaterals:${CollateralVault}-userCollaterals(user:key,asset:key2,amount:value::text)` +
+      `),` +
+      `oracle:priceOracle_fkey(` +
+        `prices:${PriceOracle}-prices(asset:key,price:value::text)` +
+      `)`;
+
+    registry = await getPool(accessToken, { select });
+
+    const borrowable: string = registry.lendingPool?.borrowableAsset;
+    const collateralsArr = registry.collateralVault?.userCollaterals || [];
+    const tokenSet = new Set<string>([borrowable]);
+    collateralsArr.forEach((c: any) => tokenSet.add(c.asset));
+
+    tokenInfoMap = new Map<string, any>();
+    try {
+      const { data: tokenRows } = await cirrus.get(accessToken, `/${Token}`, {
+        params: {
+          address: `in.(${Array.from(tokenSet).join(',')})`,
+          select: "address,_symbol,_name",
+        },
+      });
+      tokenInfoMap = new Map<string, any>((tokenRows || []).map((t: any) => [t.address, t]));
+    } catch {}
+
+    _liquidationCache = { data: { registry, tokenInfoMap }, expiry: Date.now() + LIQUIDATION_CACHE_TTL };
+  }
 
   const borrowableAsset: string = registry.lendingPool?.borrowableAsset;
   const borrowIndexStr = registry.lendingPool?.borrowIndex || "0";
@@ -1455,17 +1488,6 @@ export const listLoansForLiquidation = async (
     list.push({ asset: c.asset, amount: c.amount });
     collMap.set(c.user, list);
   }
-
-  const tokenSet = new Set<string>([borrowableAsset]);
-  collateralsArr.forEach((c: any) => tokenSet.add(c.asset));
-  let tokenInfoMap = new Map<string, any>();
-  try {
-    const tokenRows = await getTokens(accessToken, {
-      address: `in.(${Array.from(tokenSet).join(',')})`,
-      select: "address,_symbol,_name"
-    });
-    tokenInfoMap = new Map<string, any>(tokenRows.map((t: any) => [t.address, t]));
-  } catch {}
 
   const results: LiquidationEntry[] = [];
 

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -221,6 +221,46 @@ const inferStakeUsdInfo = (
   return empty;
 };
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// PRICING CONTEXT CACHE — 30 s TTL, shared across all rewards endpoints
+// ═══════════════════════════════════════════════════════════════════════════════
+
+type PricingCtx = {
+  priceMap: Map<string, string>;
+  mTokenAddress: string | null;
+  sTokenAddress: string | null;
+  vaultShareTokenAddress: string | null;
+  carryVaultUsdPriceMap: Map<string, string>;
+};
+
+let _pricingCtxCache: { ctx: PricingCtx; expiry: number } | null = null;
+const PRICING_CTX_TTL = 30_000;
+
+const buildPricingCtx = async (accessToken: string, forceRefresh: boolean = false): Promise<PricingCtx> => {
+  if (!forceRefresh && _pricingCtxCache && Date.now() < _pricingCtxCache.expiry) {
+    return _pricingCtxCache.ctx;
+  }
+
+  const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
+    getCompletePriceMap(accessToken),
+    getMTokenAddress(accessToken),
+    getVaultShareTokenAddress(accessToken).catch(() => ""),
+  ]);
+  const carryVaultUsdPriceMap = getCarryVaultUsdPriceMap(priceMap);
+  const { sToken } = getSafetyModuleConfig();
+
+  const ctx: PricingCtx = {
+    priceMap,
+    mTokenAddress,
+    sTokenAddress: sToken.address || null,
+    vaultShareTokenAddress: vaultShareTokenAddress || null,
+    carryVaultUsdPriceMap,
+  };
+
+  _pricingCtxCache = { ctx, expiry: Date.now() + PRICING_CTX_TTL };
+  return ctx;
+};
+
 /**
  * Get rewards contract address or throw error
  */
@@ -423,29 +463,14 @@ export const fetchUserActivities = async (
 
     const activityIds = activities.map((a: any) => a.activityId);
 
-    const [activityStatesMap, userInfoMap, unclaimedRewards, claimedRewardsMap, bonusResult] = await Promise.all([
+    const [activityStatesMap, userInfoMap, unclaimedRewards, claimedRewardsMap, bonusResult, pricingCtx] = await Promise.all([
       fetchActivityStates(accessToken, rewardsAddress, forceRefresh),
       fetchUserInfo(accessToken, rewardsAddress, normalizedUserAddress, activityIds, forceRefresh),
       fetchUnclaimedRewards(accessToken, rewardsAddress, normalizedUserAddress, forceRefresh),
       fetchClaimedRewards(accessToken, rewardsAddress),
-      fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress)
+      fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress),
+      buildPricingCtx(accessToken, forceRefresh),
     ]);
-
-    // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
-      getCompletePriceMap(accessToken),
-      getMTokenAddress(accessToken),
-      getVaultShareTokenAddress(accessToken).catch(() => ""),
-    ]);
-    const carryVaultUsdPriceMap = await getCarryVaultUsdPriceMap(accessToken, priceMap);
-    const { sToken } = getSafetyModuleConfig();
-    const pricingCtx = {
-      priceMap,
-      mTokenAddress,
-      sTokenAddress: sToken.address || null,
-      vaultShareTokenAddress: vaultShareTokenAddress || null,
-      carryVaultUsdPriceMap,
-    };
 
     // Combine all data
     const userActivities = await Promise.all(activities.map(async (activity: any) => {
@@ -536,21 +561,7 @@ export const fetchAllActivities = async (
       return [];
     }
 
-    // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
-      getCompletePriceMap(accessToken),
-      getMTokenAddress(accessToken),
-      getVaultShareTokenAddress(accessToken).catch(() => ""),
-    ]);
-    const carryVaultUsdPriceMap = await getCarryVaultUsdPriceMap(accessToken, priceMap);
-    const { sToken } = getSafetyModuleConfig();
-    const pricingCtx = {
-      priceMap,
-      mTokenAddress,
-      sTokenAddress: sToken.address || null,
-      vaultShareTokenAddress: vaultShareTokenAddress || null,
-      carryVaultUsdPriceMap,
-    };
+    const pricingCtx = await buildPricingCtx(accessToken, forceRefresh);
 
     // Combine activities with their states
     const enriched = await Promise.all(activities.map(async (activity: any) => {

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -333,7 +333,7 @@ export interface RewardsOverview {
 }
 
 let _rewardTokenSymbolCache: { symbol: string | null; tokenAddress: string; expiry: number } | null = null;
-const REWARD_TOKEN_SYMBOL_TTL = 60_000;
+const REWARD_TOKEN_SYMBOL_TTL = 30_000;
 
 const getRewardTokenSymbol = async (accessToken: string, rewardToken: string): Promise<string | null> => {
   if (_rewardTokenSymbolCache && _rewardTokenSymbolCache.tokenAddress === rewardToken

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -332,21 +332,49 @@ export interface RewardsOverview {
   currentSeason: number;
 }
 
+let _rewardTokenSymbolCache: { symbol: string | null; tokenAddress: string; expiry: number } | null = null;
+const REWARD_TOKEN_SYMBOL_TTL = 60_000;
+
+const getRewardTokenSymbol = async (accessToken: string, rewardToken: string): Promise<string | null> => {
+  if (_rewardTokenSymbolCache && _rewardTokenSymbolCache.tokenAddress === rewardToken
+      && Date.now() < _rewardTokenSymbolCache.expiry) {
+    return _rewardTokenSymbolCache.symbol;
+  }
+  let symbol: string | null = null;
+  try {
+    if (rewardToken) {
+      const { data } = await cirrus.get(accessToken, `/${Token}`, {
+        params: { address: "eq." + rewardToken, select: "_symbol" },
+      });
+      symbol = data?.[0]?._symbol || null;
+    }
+  } catch (error) {
+    console.error(`Error fetching token symbol for ${rewardToken}:`, error);
+  }
+  _rewardTokenSymbolCache = { symbol, tokenAddress: rewardToken, expiry: Date.now() + REWARD_TOKEN_SYMBOL_TTL };
+  return symbol;
+};
+
 /**
  * Get global Rewards contract overview data
  * @param accessToken - Access token for authentication
  * @param forceRefresh - If true, bypasses cache and fetches fresh data from blockchain
  * @returns Rewards overview data
  */
+let _overviewCache: { data: RewardsOverview; expiry: number } | null = null;
+const OVERVIEW_CACHE_TTL = 30_000;
+
 export const fetchRewardsOverview = async (
   accessToken: string,
   forceRefresh: boolean = false
 ): Promise<RewardsOverview> => {
+  if (!forceRefresh && _overviewCache && Date.now() < _overviewCache.expiry) {
+    return _overviewCache.data;
+  }
+
   const rewardsAddress = getRewardsAddress();
 
   try {
-    // All these functions now use the same cached contract state, so they're fast
-    // fetchAllUsersLeaderboard also uses cached contract state + cached claimed rewards
     const [contractData, activitiesMap, activityStatesMap, allUsersLeaderboard] = await Promise.all([
       fetchRewardsContractData(accessToken, rewardsAddress, forceRefresh),
       fetchActivities(accessToken, rewardsAddress, forceRefresh),
@@ -354,46 +382,24 @@ export const fetchRewardsOverview = async (
       fetchAllUsersLeaderboard(accessToken, rewardsAddress, forceRefresh)
     ]);
 
-    // Count only actively-emitting activities (matches UI visibility filter)
     const activeActivityCount = Array.from(activitiesMap.values())
       .filter((a) => BigInt(a.emissionRate || "0") > 0n).length;
 
-    // Hardcoded season info for now
     const currentSeason = 2;
 
-
-    // Sum up total stake across all activities
     let totalStake = BigInt(0);
     activityStatesMap.forEach((state: any) => {
-      const stake = BigInt(state?.totalStake || "0");
-      totalStake += stake;
+      totalStake += BigInt(state?.totalStake || "0");
     });
 
-    // Sum up total distributed (all users' unclaimed + pending + claimed rewards)
     let totalDistributed = BigInt(0);
     allUsersLeaderboard.forEach((user) => {
       totalDistributed += BigInt(user.totalRewardsEarned);
     });
 
-    // Fetch token symbol
-    let rewardTokenSymbol: string | null = null;
-    try {
-      if (contractData.rewardToken) {
-        const { data } = await cirrus.get(accessToken, `/${Token}`, {
-          params: {
-            address: "eq." + contractData.rewardToken,
-            select: "_symbol",
-          }
-        });
-        const token = data?.[0];
-        rewardTokenSymbol = token?._symbol || null;
-      }
-    } catch (error) {
-      console.error(`Error fetching token symbol for ${contractData.rewardToken}:`, error);
-      // Continue without symbol, will be null
-    }
+    const rewardTokenSymbol = await getRewardTokenSymbol(accessToken, contractData.rewardToken);
 
-    return {
+    const result: RewardsOverview = {
       rewardToken: contractData.rewardToken,
       rewardTokenSymbol,
       totalRewardsEmission: contractData.totalRewardsEmission,
@@ -403,6 +409,9 @@ export const fetchRewardsOverview = async (
       totalDistributed: totalDistributed.toString(),
       currentSeason
     };
+
+    _overviewCache = { data: result, expiry: Date.now() + OVERVIEW_CACHE_TTL };
+    return result;
   } catch (error) {
     console.error("Failed to fetch Rewards overview:", error);
     throw error;

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -55,6 +55,9 @@ const getSafetyExchangeRate = (totalAssets: bigint, totalShares: bigint): bigint
   return (totalAssets * WAD) / totalShares;
 };
 
+let _safetyApyCache: { apy: string; expiry: number } | null = null;
+const SAFETY_APY_TTL = 60_000;
+
 const getSafetyApy = async (
   accessToken: string,
   safetyModuleAddress: string,
@@ -62,6 +65,9 @@ const getSafetyApy = async (
   totalSharesNow: bigint
 ): Promise<string> => {
   if (!safetyModuleAddress) return "-";
+  if (_safetyApyCache && Date.now() < _safetyApyCache.expiry) {
+    return _safetyApyCache.apy;
+  }
 
   const nowMs = Date.now();
   const thirtyDaysAgoMs = nowMs - THIRTY_DAYS_MS;
@@ -140,8 +146,13 @@ const getSafetyApy = async (
   const apy = (Math.pow(1 + periodReturn, 365 / lookbackDays) - 1) * 100;
   if (!Number.isFinite(apy)) return "-";
 
-  return apy.toFixed(2);
+  const result = apy.toFixed(2);
+  _safetyApyCache = { apy: result, expiry: Date.now() + SAFETY_APY_TTL };
+  return result;
 };
+
+const _safetyFlowCache = new Map<string, { data: { totalDepositedUsd: bigint; totalWithdrawnUsd: bigint }; expiry: number }>();
+const SAFETY_FLOW_TTL = 60_000;
 
 const getSafetyUserFlowTotals = async (
   accessToken: string,
@@ -156,6 +167,12 @@ const getSafetyUserFlowTotals = async (
 
   if (!safetyModuleAddress || !normalizedUser) {
     return { totalDepositedUsd, totalWithdrawnUsd };
+  }
+
+  const cacheKey = `${safetyModuleAddress}:${normalizedUser}`;
+  const cached = _safetyFlowCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data;
   }
 
   try {
@@ -200,7 +217,9 @@ const getSafetyUserFlowTotals = async (
     console.warn("Failed to compute safety flow totals:", error);
   }
 
-  return { totalDepositedUsd, totalWithdrawnUsd };
+  const result = { totalDepositedUsd, totalWithdrawnUsd };
+  _safetyFlowCache.set(cacheKey, { data: result, expiry: Date.now() + SAFETY_FLOW_TTL });
+  return result;
 };
 
 interface SafetyModuleInfo {
@@ -362,6 +381,9 @@ export const getPublicSafetyModuleInfo = async (
   }
 };
 
+let _safetyPoolCache: { safetyModuleData: any[]; sTokenTotalSupply: any[]; expiry: number } | null = null;
+const SAFETY_POOL_TTL = 30_000;
+
 export const getSafetyModuleInfo = async (
   accessToken: string,
   userAddress: string
@@ -371,88 +393,37 @@ export const getSafetyModuleInfo = async (
   const sTokenAddress = safetyModuleConfig.sToken.address;
 
   try {
-    // Note: We need to query multiple sources for complete SafetyModule data:
-    // 1. SafetyModule contract config and _managedAssets (COOLDOWN_SECONDS, UNSTAKE_WINDOW, _managedAssets, etc.)
-    // 2. sToken totalSupply (this is totalShares)
-    // 3. User's sToken balance
-    // 4. User's cooldown start time
-    
-    let safetyModuleData: any[] = [];
-    let sTokenTotalSupply: any[] = [];
-    let userTokenBalance: any[] = [];
-    let cooldownData: any[] = [];
+    let safetyModuleData: any[];
+    let sTokenTotalSupply: any[];
 
-    try {
-      // Query SafetyModule contract configuration and _managedAssets
-      const response1 = await cirrus.get(
-        accessToken,
-        `/BlockApps-SafetyModule`,
-        {
-          params: {
-            address: `eq.${safetyModuleAddress}`,
-            select: "*,_managedAssets::text"
-          }
-        }
-      );
-      safetyModuleData = response1.data || [];
-    } catch (error) {
-      console.warn("SafetyModule contract not found or not deployed:", error);
+    if (_safetyPoolCache && Date.now() < _safetyPoolCache.expiry) {
+      safetyModuleData = _safetyPoolCache.safetyModuleData;
+      sTokenTotalSupply = _safetyPoolCache.sTokenTotalSupply;
+    } else {
+      [safetyModuleData, sTokenTotalSupply] = await Promise.all([
+        cirrus.get(accessToken, `/BlockApps-SafetyModule`, {
+          params: { address: `eq.${safetyModuleAddress}`, select: "*,_managedAssets::text" },
+        }).then(r => r.data || []).catch(() => []),
+        cirrus.get(accessToken, `/BlockApps-Token`, {
+          params: { address: `eq.${sTokenAddress}`, select: "_totalSupply::text" },
+        }).then(r => r.data || []).catch(() => []),
+      ]);
+      _safetyPoolCache = { safetyModuleData, sTokenTotalSupply, expiry: Date.now() + SAFETY_POOL_TTL };
     }
 
-    try {
-      // Query sToken total supply (this represents totalShares)
-      const response2 = await cirrus.get(
-        accessToken,
-        `/BlockApps-Token`,
-        {
-          params: {
-            address: `eq.${sTokenAddress}`,
-            select: "_totalSupply::text"
-          }
-        }
-      );
-      sTokenTotalSupply = response2.data || [];
-    } catch (error) {
-      console.warn("sToken total supply query failed:", error);
-    }
+    const [userTokenBalance, cooldownData] = await Promise.all([
+      cirrus.get(accessToken, `/BlockApps-Token`, {
+        params: {
+          address: `eq.${sTokenAddress}`,
+          select: `address,balances:BlockApps-Token-_balances(user:key,balance:value::text)`,
+          "balances.key": `eq.${userAddress.toLowerCase()}`,
+        },
+      }).then(r => r.data?.[0]?.balances || []).catch(() => []),
+      cirrus.get(accessToken, `/BlockApps-SafetyModule-cooldownStart`, {
+        params: { key: `eq.${userAddress.toLowerCase()}`, select: "value::text" },
+      }).then(r => r.data || []).catch(() => []),
+    ]);
 
-    try {
-      // Query user's sUSDST token balance using nested relationship pattern
-      const response3 = await cirrus.get(
-        accessToken,
-        `/BlockApps-Token`,
-        {
-          params: {
-            address: `eq.${sTokenAddress}`,
-            select: `address,balances:BlockApps-Token-_balances(user:key,balance:value::text)`,
-            "balances.key": `eq.${userAddress.toLowerCase()}`
-          }
-        }
-      );
-      const tokenData = response3.data || [];
-      userTokenBalance = tokenData?.[0]?.balances || [];
-    } catch (error) {
-      console.warn("sUSDST token balance query failed:", error);
-    }
-
-    try {
-      // Query user's cooldown start from SafetyModule
-      const response4 = await cirrus.get(
-        accessToken,
-        `/BlockApps-SafetyModule-cooldownStart`,
-        {
-          params: {
-            key: `eq.${userAddress.toLowerCase()}`,
-            select: "value::text"
-          }
-        }
-      );
-      cooldownData = response4.data || [];
-    } catch (error) {
-      console.warn("SafetyModule cooldown data query failed:", error);
-    }
-
-    // Extract data from responses
     const safetyModule = safetyModuleData?.[0] || {};
     
     // Get totalAssets from SafetyModule's _managedAssets state variable

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -55,9 +55,6 @@ const getSafetyExchangeRate = (totalAssets: bigint, totalShares: bigint): bigint
   return (totalAssets * WAD) / totalShares;
 };
 
-let _safetyApyCache: { apy: string; expiry: number } | null = null;
-const SAFETY_APY_TTL = 60_000;
-
 const getSafetyApy = async (
   accessToken: string,
   safetyModuleAddress: string,
@@ -65,9 +62,6 @@ const getSafetyApy = async (
   totalSharesNow: bigint
 ): Promise<string> => {
   if (!safetyModuleAddress) return "-";
-  if (_safetyApyCache && Date.now() < _safetyApyCache.expiry) {
-    return _safetyApyCache.apy;
-  }
 
   const nowMs = Date.now();
   const thirtyDaysAgoMs = nowMs - THIRTY_DAYS_MS;
@@ -146,13 +140,8 @@ const getSafetyApy = async (
   const apy = (Math.pow(1 + periodReturn, 365 / lookbackDays) - 1) * 100;
   if (!Number.isFinite(apy)) return "-";
 
-  const result = apy.toFixed(2);
-  _safetyApyCache = { apy: result, expiry: Date.now() + SAFETY_APY_TTL };
-  return result;
+  return apy.toFixed(2);
 };
-
-const _safetyFlowCache = new Map<string, { data: { totalDepositedUsd: bigint; totalWithdrawnUsd: bigint }; expiry: number }>();
-const SAFETY_FLOW_TTL = 60_000;
 
 const getSafetyUserFlowTotals = async (
   accessToken: string,
@@ -167,12 +156,6 @@ const getSafetyUserFlowTotals = async (
 
   if (!safetyModuleAddress || !normalizedUser) {
     return { totalDepositedUsd, totalWithdrawnUsd };
-  }
-
-  const cacheKey = `${safetyModuleAddress}:${normalizedUser}`;
-  const cached = _safetyFlowCache.get(cacheKey);
-  if (cached && Date.now() < cached.expiry) {
-    return cached.data;
   }
 
   try {
@@ -217,9 +200,7 @@ const getSafetyUserFlowTotals = async (
     console.warn("Failed to compute safety flow totals:", error);
   }
 
-  const result = { totalDepositedUsd, totalWithdrawnUsd };
-  _safetyFlowCache.set(cacheKey, { data: result, expiry: Date.now() + SAFETY_FLOW_TTL });
-  return result;
+  return { totalDepositedUsd, totalWithdrawnUsd };
 };
 
 interface SafetyModuleInfo {
@@ -381,9 +362,6 @@ export const getPublicSafetyModuleInfo = async (
   }
 };
 
-let _safetyPoolCache: { safetyModuleData: any[]; sTokenTotalSupply: any[]; expiry: number } | null = null;
-const SAFETY_POOL_TTL = 30_000;
-
 export const getSafetyModuleInfo = async (
   accessToken: string,
   userAddress: string
@@ -393,37 +371,88 @@ export const getSafetyModuleInfo = async (
   const sTokenAddress = safetyModuleConfig.sToken.address;
 
   try {
-    let safetyModuleData: any[];
-    let sTokenTotalSupply: any[];
+    // Note: We need to query multiple sources for complete SafetyModule data:
+    // 1. SafetyModule contract config and _managedAssets (COOLDOWN_SECONDS, UNSTAKE_WINDOW, _managedAssets, etc.)
+    // 2. sToken totalSupply (this is totalShares)
+    // 3. User's sToken balance
+    // 4. User's cooldown start time
+    
+    let safetyModuleData: any[] = [];
+    let sTokenTotalSupply: any[] = [];
+    let userTokenBalance: any[] = [];
+    let cooldownData: any[] = [];
 
-    if (_safetyPoolCache && Date.now() < _safetyPoolCache.expiry) {
-      safetyModuleData = _safetyPoolCache.safetyModuleData;
-      sTokenTotalSupply = _safetyPoolCache.sTokenTotalSupply;
-    } else {
-      [safetyModuleData, sTokenTotalSupply] = await Promise.all([
-        cirrus.get(accessToken, `/BlockApps-SafetyModule`, {
-          params: { address: `eq.${safetyModuleAddress}`, select: "*,_managedAssets::text" },
-        }).then(r => r.data || []).catch(() => []),
-        cirrus.get(accessToken, `/BlockApps-Token`, {
-          params: { address: `eq.${sTokenAddress}`, select: "_totalSupply::text" },
-        }).then(r => r.data || []).catch(() => []),
-      ]);
-      _safetyPoolCache = { safetyModuleData, sTokenTotalSupply, expiry: Date.now() + SAFETY_POOL_TTL };
+    try {
+      // Query SafetyModule contract configuration and _managedAssets
+      const response1 = await cirrus.get(
+        accessToken,
+        `/BlockApps-SafetyModule`,
+        {
+          params: {
+            address: `eq.${safetyModuleAddress}`,
+            select: "*,_managedAssets::text"
+          }
+        }
+      );
+      safetyModuleData = response1.data || [];
+    } catch (error) {
+      console.warn("SafetyModule contract not found or not deployed:", error);
     }
 
-    const [userTokenBalance, cooldownData] = await Promise.all([
-      cirrus.get(accessToken, `/BlockApps-Token`, {
-        params: {
-          address: `eq.${sTokenAddress}`,
-          select: `address,balances:BlockApps-Token-_balances(user:key,balance:value::text)`,
-          "balances.key": `eq.${userAddress.toLowerCase()}`,
-        },
-      }).then(r => r.data?.[0]?.balances || []).catch(() => []),
-      cirrus.get(accessToken, `/BlockApps-SafetyModule-cooldownStart`, {
-        params: { key: `eq.${userAddress.toLowerCase()}`, select: "value::text" },
-      }).then(r => r.data || []).catch(() => []),
-    ]);
+    try {
+      // Query sToken total supply (this represents totalShares)
+      const response2 = await cirrus.get(
+        accessToken,
+        `/BlockApps-Token`,
+        {
+          params: {
+            address: `eq.${sTokenAddress}`,
+            select: "_totalSupply::text"
+          }
+        }
+      );
+      sTokenTotalSupply = response2.data || [];
+    } catch (error) {
+      console.warn("sToken total supply query failed:", error);
+    }
 
+    try {
+      // Query user's sUSDST token balance using nested relationship pattern
+      const response3 = await cirrus.get(
+        accessToken,
+        `/BlockApps-Token`,
+        {
+          params: {
+            address: `eq.${sTokenAddress}`,
+            select: `address,balances:BlockApps-Token-_balances(user:key,balance:value::text)`,
+            "balances.key": `eq.${userAddress.toLowerCase()}`
+          }
+        }
+      );
+      const tokenData = response3.data || [];
+      userTokenBalance = tokenData?.[0]?.balances || [];
+    } catch (error) {
+      console.warn("sUSDST token balance query failed:", error);
+    }
+
+    try {
+      // Query user's cooldown start from SafetyModule
+      const response4 = await cirrus.get(
+        accessToken,
+        `/BlockApps-SafetyModule-cooldownStart`,
+        {
+          params: {
+            key: `eq.${userAddress.toLowerCase()}`,
+            select: "value::text"
+          }
+        }
+      );
+      cooldownData = response4.data || [];
+    } catch (error) {
+      console.warn("SafetyModule cooldown data query failed:", error);
+    }
+
+    // Extract data from responses
     const safetyModule = safetyModuleData?.[0] || {};
     
     // Get totalAssets from SafetyModule's _managedAssets state variable

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -9,6 +9,7 @@ import { postAndWaitForTx } from "../../utils/txHelper";
 import { extractContractName } from "../../utils/utils";
 import { StratoPaths, constants } from "../../config/constants";
 import * as config from "../../config/config";
+import { computeVaultPerformanceMetrics } from "../helpers/vaultPerformance.helper";
 
 const {
   Vault,
@@ -337,206 +338,6 @@ const getBatchPrices = async (
   return result;
 };
 
-/**
- * Get historical token balance for an address at a specific date
- */
-const getHistoricalTokenBalance = async (
-  accessToken: string,
-  tokenAddress: string,
-  holderAddress: string,
-  date: string // Format: YYYY-MM-DD
-): Promise<string> => {
-  try {
-    const { data } = await cirrus.get(accessToken, "/history@mapping", {
-      params: {
-        select: "value::text",
-        address: `eq.${tokenAddress}`,
-        collection_name: "eq._balances",
-        "key->>key": `eq.${holderAddress}`,
-        valid_from: `lte.${date}`,
-        valid_to: `gte.${date}`,
-      },
-    });
-
-    const value = data?.[0]?.value;
-    // Ensure we always return a valid number string, never empty
-    if (!value || value === "") return "0";
-    return value;
-  } catch (error) {
-    console.error(`Error fetching historical balance for ${tokenAddress}:`, error);
-    return "0";
-  }
-};
-
-/**
- * Get historical price for an asset at a specific date
- */
-const getHistoricalAssetPrice = async (
-  accessToken: string,
-  oracleAddress: string,
-  assetAddress: string,
-  date: string // Format: YYYY-MM-DD
-): Promise<string> => {
-  try {
-    const { data } = await cirrus.get(accessToken, "/history@mapping", {
-      params: {
-        select: "value::text",
-        address: `eq.${oracleAddress}`,
-        collection_name: "eq.prices",
-        "key->>key": `eq.${assetAddress}`,
-        valid_from: `lte.${date}`,
-        valid_to: `gte.${date}`,
-      },
-    });
-
-    const value = data?.[0]?.value;
-    // Ensure we always return a valid number string, never empty
-    if (!value || value === "") return "0";
-    return value;
-  } catch (error) {
-    console.error(`Error fetching historical price for ${assetAddress}:`, error);
-    return "0";
-  }
-};
-
-/**
- * Get the first deposit timestamp for the vault
- */
-const getFirstDepositDate = async (
-  accessToken: string,
-  vaultAddress: string
-): Promise<{ date: string; timestamp: Date } | null> => {
-  try {
-    const { data: depositEvents } = await cirrus.get(accessToken, `/${Vault}-Deposited`, {
-      params: {
-        select: "block_timestamp",
-        address: `eq.${vaultAddress}`,
-        order: "block_timestamp.asc",
-        limit: "1",
-      },
-    });
-
-    if (!depositEvents?.length || !depositEvents[0]?.block_timestamp) {
-      return null;
-    }
-
-    const timestamp = new Date(depositEvents[0].block_timestamp);
-    const date = timestamp.toISOString().split("T")[0]; // YYYY-MM-DD
-    return { date, timestamp };
-  } catch (error) {
-    console.error("Error fetching first deposit date:", error);
-    return null;
-  }
-};
-
-/**
- * Get vault performance metrics using time-weighted return (TWR) via NAV/share.
- * Returns both the vault APY and the alpha (outperformance vs HODL benchmark).
- * Alpha = vaultAPY - hodlAPY, where HODL reprices historical balances at current prices.
- */
-const getPerformanceMetrics = async (
-  accessToken: string,
-  vaultAddress: string,
-  currentEquity: bigint,
-  currentTotalShares: bigint,
-  shareTokenAddress: string,
-  botExecutor: string,
-  priceOracleAddress: string,
-  supportedAssets: string[],
-  currentPrices: Map<string, string>
-): Promise<{ apy: string; alpha: string }> => {
-  const noData = { apy: "-", alpha: "-" };
-  try {
-    if (currentTotalShares <= 0n || currentEquity <= 0n) return noData;
-
-    const currentNAV = (currentEquity * WAD) / currentTotalShares;
-
-    const firstDeposit = await getFirstDepositDate(accessToken, vaultAddress);
-    if (!firstDeposit) return noData;
-
-    const now = new Date();
-    const dayAfterFirstDeposit = new Date(firstDeposit.timestamp.getTime() + 24 * 60 * 60 * 1000);
-    const earliestStartDate = dayAfterFirstDeposit.toISOString().split("T")[0];
-    const todayStr = now.toISOString().split("T")[0];
-
-    if (earliestStartDate >= todayStr) return noData;
-
-    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-    const startDate = thirtyDaysAgo >= dayAfterFirstDeposit
-      ? thirtyDaysAgo.toISOString().split("T")[0]
-      : earliestStartDate;
-
-    const startDateObj = new Date(startDate + "T00:00:00Z");
-    const actualDays = Math.max((now.getTime() - startDateObj.getTime()) / (24 * 60 * 60 * 1000), 1);
-
-    // Historical total supply
-    const { data: histStorage } = await cirrus.get(accessToken, "/history@storage", {
-      params: {
-        address: `eq.${shareTokenAddress}`,
-        valid_from: `lte.${startDate}`,
-        valid_to: `gte.${startDate}`,
-        select: "data",
-      },
-    });
-    const histTotalSupply = safeBigInt(histStorage?.[0]?.data?._totalSupply);
-    if (histTotalSupply <= 0n) return noData;
-
-    // Fetch all historical balances and prices in parallel
-    const [histBalances, histPrices] = await Promise.all([
-      Promise.all(supportedAssets.map(addr =>
-        getHistoricalTokenBalance(accessToken, addr, botExecutor, startDate)
-      )),
-      Promise.all(supportedAssets.map(addr =>
-        getHistoricalAssetPrice(accessToken, priceOracleAddress, addr, startDate)
-      )),
-    ]);
-
-    let histEquity = 0n;
-    let hodlEquity = 0n;
-
-    for (let i = 0; i < supportedAssets.length; i++) {
-      const histBalanceBN = safeBigInt(histBalances[i]);
-      const histPriceBN = safeBigInt(histPrices[i]);
-
-      if (histPriceBN > 0n) {
-        histEquity += (histBalanceBN * histPriceBN) / WAD;
-      }
-
-      const currentPriceBN = safeBigInt(currentPrices.get(supportedAssets[i]));
-      if (currentPriceBN > 0n) {
-        hodlEquity += (histBalanceBN * currentPriceBN) / WAD;
-      }
-    }
-
-    if (histEquity <= 0n) return noData;
-
-    // Vault APY (NAV-based TWR)
-    const histNAV = (histEquity * WAD) / histTotalSupply;
-    if (histNAV <= 0n) return noData;
-
-    const vaultReturn = Number(((currentNAV - histNAV) * WAD) / histNAV) / 1e18;
-    if (vaultReturn <= -1) return noData;
-
-    const vaultApy = Math.pow(1 + vaultReturn, 365 / actualDays) - 1;
-
-    // HODL APY (passive benchmark)
-    const hodlReturn = Number(((hodlEquity - histEquity) * WAD) / histEquity) / 1e18;
-    const hodlApy = hodlReturn <= -1 ? -1 : Math.pow(1 + hodlReturn, 365 / actualDays) - 1;
-
-    // Alpha = vault outperformance vs HODL
-    const alpha = vaultApy - hodlApy;
-
-    return {
-      apy: (vaultApy * 100).toFixed(2),
-      alpha: (alpha * 100).toFixed(2),
-    };
-  } catch (error) {
-    console.error("Error calculating performance metrics:", error);
-    return noData;
-  }
-};
-
-
 // ═══════════════════════════════════════════════════════════════════════════════
 // PUBLIC SERVICE FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -786,8 +587,7 @@ export const getVaultInfo = async (accessToken: string): Promise<VaultInfo> => {
     navPerShare = ((totalEquity * WAD) / totalSharesBN).toString();
   }
 
-  // Calculate APY and alpha vs HODL
-  const { apy, alpha } = await getPerformanceMetrics(
+  const { apy, alpha } = await computeVaultPerformanceMetrics(
     accessToken,
     vaultAddress,
     totalEquity,

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -706,9 +706,11 @@ export const deposit = async (
 
   const builtTx = await buildFunctionTx(tx, userAddress, accessToken);
   
-  return await postAndWaitForTx(accessToken, () =>
+  const result = await postAndWaitForTx(accessToken, () =>
     strato.post(accessToken, StratoPaths.transactionParallel, builtTx)
   );
+  _vaultInfoCache = null;
+  return result;
 };
 
 export interface WithdrawBasketItem {
@@ -858,9 +860,11 @@ export const withdraw = async (
     args: { amountUSD: amountUsd },
   }, userAddress, accessToken);
 
-  return await postAndWaitForTx(accessToken, () =>
+  const result = await postAndWaitForTx(accessToken, () =>
     strato.post(accessToken, StratoPaths.transactionParallel, builtTx)
   );
+  _vaultInfoCache = null;
+  return result;
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -482,10 +482,15 @@ export const getUserBalances = async (
   return { balances };
 };
 
+let _vaultInfoCache: { data: VaultInfo; ts: number } | null = null;
+const VAULT_INFO_TTL = 30_000;
+
 /**
  * Get comprehensive vault info (global state)
  */
 export const getVaultInfo = async (accessToken: string): Promise<VaultInfo> => {
+  if (_vaultInfoCache && Date.now() - _vaultInfoCache.ts < VAULT_INFO_TTL) return _vaultInfoCache.data;
+
   const vaultAddress = getVaultAddress();
   
   if (!vaultAddress) {
@@ -599,7 +604,7 @@ export const getVaultInfo = async (accessToken: string): Promise<VaultInfo> => {
     currentPrices
   );
 
-  return {
+  const result: VaultInfo = {
     totalEquity: totalEquity.toString(),
     withdrawableEquity: withdrawableEquity.toString(),
     totalShares,
@@ -613,6 +618,8 @@ export const getVaultInfo = async (accessToken: string): Promise<VaultInfo> => {
     shareTokenAddress: shareToken,
     botExecutor,
   };
+  _vaultInfoCache = { data: result, ts: Date.now() };
+  return result;
 };
 
 /**


### PR DESCRIPTION
**1. GET /api/vault/info**
Removed ~200 lines of inefficient local history functions from vault.service.ts and replaced with batched computeVaultPerformanceMetrics from vaultPerformance.helper.ts. Parallelized the history@storage call with getHistoricalTokenBalances and getHistoricalAssetPrices using Promise.all. Added 30s TTL cache (_vaultInfoCache) on the entire getVaultInfo response so repeated calls return instantly from memory.

**2. GET /api/rewards/activities**
Parallelized the addYieldVaultTokenPrices for-loop (was sequential await per vault, now Promise.all). Made getCarryVaultUsdPriceMap synchronous by reusing NAV data from the price map instead of making its own Cirrus calls. Introduced a 30s TTL cached buildPricingCtx so the expensive pricing context (priceMap + mTokenAddress + vaultShareTokenAddress + carryVaultUsdPriceMap) is computed once and reused.

**3. GET /api/rewards/activities/me**
Added 30s TTL caches on fetchClaimedRewards and fetchBonusRewards (append-only event data, safe to cache). Hoisted buildPricingCtx into the main Promise. So it runs in parallel with user-scoped fetches instead of sequentially after them.

**4. GET /api/lending/liquidity/public**
Added 30s TTL response cache for the entire endpoint (public, no user inputs). Replaced the getTokens wrapper with a direct Cirrus. Get query for just the needed token fields, eliminating the duplicate getPool (with huge userCollaterals payload) and getCompletePriceMap (~20 Cirrus calls) that getTokens was triggering unnecessarily.

**5. GET /api/lending/collateral/public**
Added 30s TTL response cache (same pattern as liquidity/public). Replaced getTokens with direct Cirrus. get for token metadata, eliminating the same duplicate getPool + getCompletePriceMap overhead.****

**6. GET /api/rewards/overview**
Cached the reward token symbol Cirrus query with 30s TTL — previously fetched on every request with no cache. Added 30s TTL cache on the entire overview response — public data that changes at most once per block. forceRefresh=true query param bypasses cache, preserving existing behavior.

**7. GET /api/lending/liquidity**
Replaced getTokens call (which internally triggered a duplicate getPool + getCompletePriceMap ~20 Cirrus calls) with a direct cirrus.get for only the needed token fields. Parallelized token query, getExchangeRateFromCirrus, and getLendingUserFlowTotals with Promise.all — previously all three ran sequentially. Added 60s per-user TTL cache on getLendingUserFlowTotals (paginated event walk) — events are append-only so brief staleness is safe.

**8. GET /api/lend/liquidate**
Replaced getTokens call (which triggered duplicate getPool + getCompletePriceMap) with a direct cirrus.get for just address, _symbol, _name. Added 30s TTL cache on registry snapshot + tokenInfoMap — shared by both /liquidate and /liquidate/near-unhealthy, while the margin filter runs fresh from cached data on each request.

