### PR TITLE
WIP added caching and reduced api response time

### DIFF
--- a/mercata/backend/src/api/helpers/oracle.helper.ts
+++ b/mercata/backend/src/api/helpers/oracle.helper.ts
@@ -207,9 +207,15 @@ export const getCarryVaultUsdPriceMap = (
   return out;
 };
 
+let _completePriceMapCache: { data: Map<string, string>; expiry: number } | null = null;
+const COMPLETE_PRICE_MAP_TTL = 30_000;
+
 export const getCompletePriceMap = async (
   accessToken: string
 ): Promise<Map<string, string>> => {
+  if (_completePriceMapCache && Date.now() < _completePriceMapCache.expiry) {
+    return _completePriceMapCache.data;
+  }
   const priceMap = await getOraclePrices(accessToken);
   await Promise.all([
     addMTokenPrice(accessToken, priceMap),
@@ -219,5 +225,6 @@ export const getCompletePriceMap = async (
     addSaveUsdstTokenPrice(accessToken, priceMap),
     addYieldVaultTokenPrices(accessToken, priceMap),
   ]);
+  _completePriceMapCache = { data: priceMap, expiry: Date.now() + COMPLETE_PRICE_MAP_TTL };
   return priceMap;
 };

--- a/mercata/backend/src/api/services/saveUsdst.service.ts
+++ b/mercata/backend/src/api/services/saveUsdst.service.ts
@@ -333,11 +333,17 @@ const getVaultState = async (accessToken: string): Promise<Record<string, any> |
   return data?.[0] || null;
 };
 
+const _userFlowCache = new Map<string, { data: { totalDepositedAssets: bigint; totalWithdrawnAssets: bigint }; ts: number }>();
+const USER_FLOW_TTL = 60_000;
+
 const getUserFlowTotals = async (
   accessToken: string,
   vaultAddress: string,
   userAddress: string
 ): Promise<{ totalDepositedAssets: bigint; totalWithdrawnAssets: bigint }> => {
+  const cacheKey = `${vaultAddress}:${userAddress}`;
+  const cached = _userFlowCache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < USER_FLOW_TTL) return cached.data;
   const normalizedUser = normalizeAddress(userAddress);
   if (!vaultAddress || !normalizedUser) {
     return { totalDepositedAssets: 0n, totalWithdrawnAssets: 0n };
@@ -390,10 +396,17 @@ const getUserFlowTotals = async (
     console.warn("Failed to compute saveUSDST flow totals:", error);
   }
 
-  return { totalDepositedAssets, totalWithdrawnAssets };
+  const result = { totalDepositedAssets, totalWithdrawnAssets };
+  _userFlowCache.set(cacheKey, { data: result, ts: Date.now() });
+  return result;
 };
 
+let _saveInfoCache: { data: SaveUsdstInfo; ts: number } | null = null;
+const SAVE_INFO_TTL = 30_000;
+
 export const getSaveUsdstInfo = async (accessToken: string): Promise<SaveUsdstInfo> => {
+  if (_saveInfoCache && Date.now() - _saveInfoCache.ts < SAVE_INFO_TTL) return _saveInfoCache.data;
+
   const fallback = emptyInfo();
   const vaultState = await getVaultState(accessToken);
 
@@ -434,7 +447,7 @@ export const getSaveUsdstInfo = async (accessToken: string): Promise<SaveUsdstIn
     totalShares
   );
 
-  return {
+  const result: SaveUsdstInfo = {
     configured: true,
     deployed: true,
     vaultAddress,
@@ -450,6 +463,8 @@ export const getSaveUsdstInfo = async (accessToken: string): Promise<SaveUsdstIn
     apy,
     paused: Boolean(vaultState._paused),
   };
+  _saveInfoCache = { data: result, ts: Date.now() };
+  return result;
 };
 
 export const getSaveUsdstUserInfo = async (

--- a/mercata/backend/src/api/services/tokens.v2.service.ts
+++ b/mercata/backend/src/api/services/tokens.v2.service.ts
@@ -681,11 +681,19 @@ export const getBalanceHistory = async (
   return balanceHistory.map(({timestamp, data}) => ({timestamp, balance: data.balance}));
 };
 
+const _netBalanceHistoryCache = new Map<string, { data: BalanceSnapshot[]; expiry: number }>();
+const NET_BALANCE_HISTORY_TTL = 60_000;
+
 export const getNetBalanceHistory = async (
   accessToken: string,
   userAddress: string,
   historyParams: HistoryParams,
 ): Promise<BalanceSnapshot[]> => {
+  const cacheKey = `${userAddress}:${historyParams.numTicks}:${historyParams.interval}`;
+  const cached = _netBalanceHistoryCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data;
+  }
 
   // Pre-fetch vault config and carry vault active request IDs in parallel
   const carryVaultAddrs = listVaultDefs().filter(v => v.address).map(v => v.address);
@@ -751,7 +759,9 @@ export const getNetBalanceHistory = async (
     updatePortfolioInfoMapping,
     processBalanceSnapshot
   );
-  return balanceHistory.map(({timestamp, data}) => ({timestamp, balance: data.netBalance}));
+  const result = balanceHistory.map(({timestamp, data}) => ({timestamp, balance: data.netBalance}));
+  _netBalanceHistoryCache.set(cacheKey, { data: result, expiry: Date.now() + NET_BALANCE_HISTORY_TTL });
+  return result;
 };
 
 export const getBorrowingHistory = async (

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -367,19 +367,27 @@ export const getVaultShareTokenAddress = async (
  * Get vault config for history tracking.
  * Returns shareToken, botExecutor, and supportedAssets needed for portfolio history.
  */
+let _vaultHistoryConfigCache: { data: { shareToken: string; botExecutor: string; supportedAssets: string[] } | null; expiry: number } | null = null;
+const VAULT_HISTORY_CONFIG_TTL = 30_000;
+
 export const getVaultHistoryConfig = async (
   accessToken: string
 ): Promise<{ shareToken: string; botExecutor: string; supportedAssets: string[] } | null> => {
+  if (_vaultHistoryConfigCache && Date.now() < _vaultHistoryConfigCache.expiry) {
+    return _vaultHistoryConfigCache.data;
+  }
   const vaultAddress = getVaultAddress();
   if (!vaultAddress) return null;
   const vaultData = await getVaultData(accessToken, vaultAddress);
   if (!vaultData) return null;
-  return {
+  const result = {
     shareToken: vaultData.shareToken || "",
     botExecutor: vaultData.botExecutor || "",
     supportedAssets: (vaultData.supportedAssets || [])
       .filter((addr: string) => addr && addr !== "0000000000000000000000000000000000000000"),
   };
+  _vaultHistoryConfigCache = { data: result, expiry: Date.now() + VAULT_HISTORY_CONFIG_TTL };
+  return result;
 };
 
 /**

--- a/mercata/backend/src/api/services/yieldVault.service.ts
+++ b/mercata/backend/src/api/services/yieldVault.service.ts
@@ -1321,10 +1321,16 @@ const computeApy = async (
   }
 };
 
+const _vaultInfoCache = new Map<string, { data: YieldVaultInfo; ts: number }>();
+const VAULT_INFO_TTL = 30_000;
+
 export const getYieldVaultInfo = async (
   _accessToken: string,
   key: string
 ): Promise<YieldVaultInfo> => {
+  const cached = _vaultInfoCache.get(key);
+  if (cached && Date.now() - cached.ts < VAULT_INFO_TTL) return cached.data;
+
   const def = resolveVaultDef(key);
   const fallback = emptyInfo(def, key);
   if (!def?.address) return fallback;
@@ -1409,7 +1415,7 @@ export const getYieldVaultInfo = async (
   const tvlUsd = underlyingUsdWad(idleAssets + deployedAssets, assetPrice, decimals);
   const apy = await computeApy(serviceToken, def.address, assetAddress, totalAssets, totalShares);
 
-  return {
+  const result: YieldVaultInfo = {
     key,
     configured: true,
     deployed: true,
@@ -1436,6 +1442,8 @@ export const getYieldVaultInfo = async (
     minIdleRequirement: minIdleRequirement.toString(),
     deployBlockedReason,
   };
+  _vaultInfoCache.set(key, { data: result, ts: Date.now() });
+  return result;
 };
 
 export const getYieldVaultUserInfo = async (


### PR DESCRIPTION
**1. /api/tokens/v2/net-balance-history?duration=1d** 
Added 60s TTL cache on the entire getNetBalanceHistory response per (userAddress, numTicks, interval). Also added 30s TTL cache on getVaultHistoryConfig. On warm cache, the expensive dual /history@storage + /history@mapping queries and per-tick reducers are skipped entirely.

**2. /api/tokens/v2?status=neq.2** 
Added 30s TTL global cache on getCompletePriceMap in oracle.helper.ts. This eliminates the repeated fan-out of oracle prices + LP prices + share token + sUSDST exchange on every request. Benefits ~10 other endpoints that also call getCompletePriceMap.

**3. /api/lend/liquidate/near-unhealthy?margin=0.2** 
Added 30s TTL cache (_liquidationCache) on the registry data (loans, collaterals, configs, prices) and tokenInfoMap, shared by both /liquidate and /near-unhealthy. Replaced the heavyweight getTokens wrapper with a direct cirrus.get for only address, _symbol, _name.

**4. /api/tokens/balance?address=eq.… 1010**
 Indirectly optimized via the global getCompletePriceMap 30s cache (fix #2). getBalance calls getCompletePriceMap internally — with the cache warm, the price map lookup is instant instead of a full Cirrus fan-out.

**5. /api/earn/yield-vault/wbtc-carry/user**
 Added 30s TTL cache on getYieldVaultInfo per vault key in yieldVault.service.ts. The heavy vault-level computation (~15-30 Cirrus calls: vault state, oracle prices, strategy holdings, CDP positions, APY history) is cached globally. User-specific reads (wallet balance, shares, claimable) remain always fresh.

**6. /api/earn/yield-vault/wbtc-carry/info**
 Same fix as #5 — calls the same getYieldVaultInfo("wbtc-carry") function which is now cached with 30s TTL. No additional changes needed.

**7. /api/earn/yield-vault/eth-carry/user** 
Same fix as #5 — getYieldVaultInfo("eth-carry") is cached per vault key. User-specific reads remain fresh.

**8. /api/earn/yield-vault/eth-carry/info** 
Same fix as #5 — shares the getYieldVaultInfo cache keyed by "eth-carry".

**9. /api/earn/yield-vault/usdc-yield/info** 
Same fix as #5 — shares the getYieldVaultInfo cache keyed by "usdc-yield".

**10. /api/earn/yield-vault/usdc-yield/user**
 Same fix as #5 — getYieldVaultInfo("usdc-yield") cached, user-specific reads remain fresh.

**11. /api/earn/save-usdst/info** 
Added 30s TTL cache on getSaveUsdstInfo in saveUsdst.service.ts. The vault state read, token symbol, asset balance, oracle price, and APY computation (which itself has no TTL cache on this path) are all skipped on warm cache. Benefits all 8 callers including user info, deposit/redeem, metrics, and earning assets.

**12. /api/earn/save-usdst/user** 
Added 60s per-user TTL cache on getUserFlowTotals in saveUsdst.service.ts. This eliminates the paginated event walk (Deposit + Withdraw events from genesis) that runs on every request. Combined with the getSaveUsdstInfo 30s cache from fix #11, the endpoint reduces to two small parallel Cirrus balance reads on warm cache.