### PR TITLE
Optimize /api/swap-pools

### DIFF
--- a/mercata/backend/src/api/cache/swappingCache.ts
+++ b/mercata/backend/src/api/cache/swappingCache.ts
@@ -1,0 +1,201 @@
+import { RawGetPool, RawToken } from "@mercata/shared-types";
+
+export const LIVE_POOL_SELECT_FIELDS = "address,tokenABalance::text,tokenBBalance::text,aToBRatio::text,bToARatio::text,lpToken:lpToken_fkey(_totalSupply::text)";
+
+const POOL_FETCH_CACHE_TTL_MS = 3_600_000;
+const TRADING_VOLUME_CACHE_TTL_MS = 3_600_000;
+const STABLE_POOL_FEE_CACHE_TTL_MS = 3_600_000;
+const MULTI_TOKEN_STABLE_POOL_CACHE_TTL_MS = 3_600_000;
+const MULTI_TOKEN_TOKEN_METADATA_CACHE_TTL_MS = 3_600_000;
+
+type CachedMultiTokenStablePool = {
+  address: string;
+  lpToken: string;
+  fee: string;
+  coins: { coinIndex: number; tokenAddress: string }[];
+};
+
+let poolFetchCache: {
+  key: string;
+  expiresAt: number;
+  poolData: Partial<RawGetPool>[];
+  factoryData: unknown;
+} | undefined;
+
+let tradingVolumeCache: {
+  key: string;
+  expiresAt: number;
+  volumeMap: Map<string, string>;
+} | undefined;
+
+let stablePoolFeeCache: {
+  key: string;
+  expiresAt: number;
+  feeMap: Map<string, number>;
+} | undefined;
+
+let multiTokenStablePoolCache: {
+  expiresAt: number;
+  stablePools: CachedMultiTokenStablePool[];
+} | undefined;
+
+let multiTokenTokenMetadataCache: {
+  key: string;
+  expiresAt: number;
+  tokenMetadataMap: Map<string, RawToken>;
+} | undefined;
+
+const getAddressSetCacheKey = (addresses: string[]): string =>
+  addresses.map(address => address.toLowerCase()).sort().join(",");
+
+export const getPoolFetchCacheKey = (params: Record<string, string>): string =>
+  JSON.stringify(Object.entries(params).sort(([a], [b]) => a.localeCompare(b)));
+
+const stripTokenBalances = <T extends { balances?: unknown[] } | undefined>(token: T): T =>
+  token
+    ? { ...token, balances: [] } as T
+    : token;
+
+const stripLPTokenLiveFields = <T extends { balances?: unknown[]; _totalSupply?: string } | undefined>(token: T): T =>
+  token
+    ? { ...token, balances: [], _totalSupply: "0" } as T
+    : token;
+
+const stripLivePoolFields = (pools: RawGetPool[]): Partial<RawGetPool>[] =>
+  pools.map(({ tokenABalance, tokenBBalance, aToBRatio, bToARatio, ...pool }) => ({
+    ...pool,
+    tokenA: stripTokenBalances(pool.tokenA),
+    tokenB: stripTokenBalances(pool.tokenB),
+    lpToken: stripLPTokenLiveFields(pool.lpToken),
+  }));
+
+export const applyLivePoolFields = (cachedPools: Partial<RawGetPool>[], livePools: RawGetPool[]): RawGetPool[] => {
+  const livePoolByAddress = new Map(livePools.map(pool => [pool.address.toLowerCase(), pool]));
+  return cachedPools.map((pool) => {
+    const livePool = livePoolByAddress.get((pool.address || "").toLowerCase());
+    return {
+      ...pool,
+      lpToken: pool.lpToken
+        ? { ...pool.lpToken, _totalSupply: livePool?.lpToken?._totalSupply || "0" }
+        : pool.lpToken,
+      tokenABalance: livePool?.tokenABalance || "0",
+      tokenBBalance: livePool?.tokenBBalance || "0",
+      aToBRatio: livePool?.aToBRatio || "0",
+      bToARatio: livePool?.bToARatio || "0",
+    } as RawGetPool;
+  });
+};
+
+export const getCachedPoolFetch = (key: string) =>
+  poolFetchCache?.key === key && poolFetchCache.expiresAt > Date.now()
+    ? poolFetchCache
+    : undefined;
+
+export const setCachedPoolFetch = (
+  key: string,
+  poolData: RawGetPool[],
+  factoryData: unknown
+) => {
+  poolFetchCache = {
+    key,
+    expiresAt: Date.now() + POOL_FETCH_CACHE_TTL_MS,
+    poolData: stripLivePoolFields(poolData),
+    factoryData,
+  };
+};
+
+export const getCachedTradingVolume = (poolAddresses: string[]): Map<string, string> | undefined => {
+  const key = getAddressSetCacheKey(poolAddresses);
+  return tradingVolumeCache?.key === key && tradingVolumeCache.expiresAt > Date.now()
+    ? new Map(tradingVolumeCache.volumeMap)
+    : undefined;
+};
+
+export const setCachedTradingVolume = (
+  poolAddresses: string[],
+  volumeMap: Map<string, string>
+) => {
+  tradingVolumeCache = {
+    key: getAddressSetCacheKey(poolAddresses),
+    expiresAt: Date.now() + TRADING_VOLUME_CACHE_TTL_MS,
+    volumeMap: new Map(volumeMap),
+  };
+};
+
+export const getCachedStablePoolFees = (addresses: string[]): Map<string, number> | undefined => {
+  const key = getAddressSetCacheKey(addresses);
+  return stablePoolFeeCache?.key === key && stablePoolFeeCache.expiresAt > Date.now()
+    ? new Map(stablePoolFeeCache.feeMap)
+    : undefined;
+};
+
+export const setCachedStablePoolFees = (
+  addresses: string[],
+  feeMap: Map<string, number>
+) => {
+  stablePoolFeeCache = {
+    key: getAddressSetCacheKey(addresses),
+    expiresAt: Date.now() + STABLE_POOL_FEE_CACHE_TTL_MS,
+    feeMap: new Map(feeMap),
+  };
+};
+
+export const getCachedMultiTokenStablePools = (): CachedMultiTokenStablePool[] | undefined =>
+  multiTokenStablePoolCache && multiTokenStablePoolCache.expiresAt > Date.now()
+    ? multiTokenStablePoolCache.stablePools.map(pool => ({
+      ...pool,
+      coins: pool.coins.map(coin => ({ ...coin })),
+    }))
+    : undefined;
+
+export const setCachedMultiTokenStablePools = (stablePools: CachedMultiTokenStablePool[]) => {
+  multiTokenStablePoolCache = {
+    expiresAt: Date.now() + MULTI_TOKEN_STABLE_POOL_CACHE_TTL_MS,
+    stablePools: stablePools.map(pool => ({
+      ...pool,
+      coins: pool.coins.map(coin => ({ ...coin })),
+    })),
+  };
+};
+
+const getLiveFieldAddressSet = (addresses: string[] = []): Set<string> =>
+  new Set(addresses.map(address => address.toLowerCase()));
+
+const stripCachedTokenMetadata = (
+  token: RawToken,
+  liveTotalSupplyAddresses: Set<string>
+): RawToken => ({
+  ...token,
+  balances: [],
+  ...(liveTotalSupplyAddresses.has(token.address.toLowerCase()) ? { _totalSupply: "0" } : {}),
+});
+
+export const getCachedMultiTokenTokenMetadata = (
+  tokenAddresses: string[],
+  liveTotalSupplyAddresses: string[] = []
+): Map<string, RawToken> | undefined => {
+  const key = getAddressSetCacheKey(tokenAddresses);
+  const liveTotalSupplyAddressSet = getLiveFieldAddressSet(liveTotalSupplyAddresses);
+  return multiTokenTokenMetadataCache?.key === key && multiTokenTokenMetadataCache.expiresAt > Date.now()
+    ? new Map([...multiTokenTokenMetadataCache.tokenMetadataMap].map(([address, token]) => [
+      address,
+      stripCachedTokenMetadata(token, liveTotalSupplyAddressSet),
+    ]))
+    : undefined;
+};
+
+export const setCachedMultiTokenTokenMetadata = (
+  tokenAddresses: string[],
+  tokenMetadataMap: Map<string, RawToken>,
+  liveTotalSupplyAddresses: string[] = []
+) => {
+  const liveTotalSupplyAddressSet = getLiveFieldAddressSet(liveTotalSupplyAddresses);
+  multiTokenTokenMetadataCache = {
+    key: getAddressSetCacheKey(tokenAddresses),
+    expiresAt: Date.now() + MULTI_TOKEN_TOKEN_METADATA_CACHE_TTL_MS,
+    tokenMetadataMap: new Map([...tokenMetadataMap].map(([address, token]) => [
+      address,
+      stripCachedTokenMetadata(token, liveTotalSupplyAddressSet),
+    ])),
+  };
+};

--- a/mercata/backend/src/api/helpers/swapping.helper.ts
+++ b/mercata/backend/src/api/helpers/swapping.helper.ts
@@ -4,11 +4,27 @@ import { SwapToken, LPToken, PoolCoin, RawGetPool, RawPoolFactory, RawToken, Raw
 import { safeBigInt, safeBigIntDivide } from "../../utils/bigIntUtils";
 import { toUTCTime } from "./cirrusHelpers";
 import { getOraclePrices } from "../services/oracle.service";
+import {
+  getCachedStablePoolFees,
+  getCachedTradingVolume,
+  getCachedMultiTokenStablePools,
+  setCachedStablePoolFees,
+  setCachedTradingVolume,
+  setCachedMultiTokenStablePools,
+} from "../cache/swappingCache";
 import JSONBig from "json-bigint";
 
 const { Pool, PoolSwap, StablePoolCoins, StablePoolTokenBalances, swapHistorySelectFields, swapTokenSelectFields, LendingRegistry } = constants;
 const WAD = 10n ** 18n;
 const JSONbigString = JSONBig({ storeAsString: true });
+const PRICE_ORACLE_CACHE_TTL_MS = 3_600_000;
+
+let cachedPriceOracle:
+  | {
+    address: string;
+    expiresAt: number;
+  }
+  | undefined;
 
 // ============================================================================
 // CALCULATION HELPERS
@@ -111,18 +127,10 @@ export const calculateLPTokenPrice = (
 // DATA PROCESSING HELPERS
 // ============================================================================
 
-export const buildPoolParams = (rawParams: Record<string, string | undefined>, userAddress?: string): Record<string, string> => ({
+export const buildPoolParams = (rawParams: Record<string, string | undefined>): Record<string, string> => ({
   poolFactory: "eq." + constants.poolFactory,
   ...Object.fromEntries(Object.entries(rawParams).filter(([_, v]) => v !== undefined)),
   select: rawParams.select || constants.swapSelectFields.join(","),
-  ...(rawParams.select || !userAddress ? {} : {
-    "lpToken.balances.value": "gt.0",
-    "lpToken.balances.key": `eq.${userAddress}`,
-    "tokenA.balances.value": "gt.0",
-    "tokenA.balances.key": `eq.${userAddress}`,
-    "tokenB.balances.value": "gt.0",
-    "tokenB.balances.key": `eq.${userAddress}`,
-  }),
 });
 
 export const extractTokenAddresses = <T extends { tokenA: { address: string }; tokenB: { address: string } }>(poolData: T[]): string[] => [
@@ -151,6 +159,10 @@ export const getTradingVolume24hForPools = async (
 ): Promise<Map<string, string>> => {
   if (poolAddresses.length === 0) {
     return new Map();
+  }
+  const cachedVolumeMap = getCachedTradingVolume(poolAddresses);
+  if (cachedVolumeMap) {
+    return cachedVolumeMap;
   }
 
   const { data: swapEvents } = await cirrus.get(accessToken, `/${PoolSwap}`, {
@@ -184,6 +196,8 @@ export const getTradingVolume24hForPools = async (
     const newVolume = safeBigInt(currentVolume) + tokenInVolume;
     volumeMap.set(poolAddress, newVolume.toString());
   });
+
+  setCachedTradingVolume(poolAddresses, volumeMap);
 
   return volumeMap;
 };
@@ -259,6 +273,28 @@ const extractEventActor = (event: { attributes?: unknown; transaction_sender?: u
   );
 };
 
+const getCachedPriceOracleAddress = async (accessToken: string): Promise<string | undefined> => {
+  if (cachedPriceOracle && cachedPriceOracle.expiresAt > Date.now()) {
+    return cachedPriceOracle.address;
+  }
+
+  const { data: lendingRegistryData } = await cirrus.get(accessToken, `/${LendingRegistry}`, {
+    params: {
+      address: `eq.${constants.lendingRegistry}`,
+      select: "priceOracle",
+      limit: "1",
+    },
+  });
+  const oracleAddress = lendingRegistryData?.[0]?.priceOracle;
+  if (oracleAddress) {
+    cachedPriceOracle = {
+      address: oracleAddress,
+      expiresAt: Date.now() + PRICE_ORACLE_CACHE_TTL_MS,
+    };
+  }
+  return oracleAddress;
+};
+
 const extractLiquidityTokenAmounts = (attributes: unknown): { tokenAAmount: bigint; tokenBAmount: bigint } => {
   const attrs = parseAttributes(attributes);
 
@@ -301,14 +337,7 @@ export const getUserPoolLiquidityFlowTotals = async (
 
   const poolAddresses = pools.map((pool) => pool.address);
 
-  const { data: lendingRegistryData } = await cirrus.get(accessToken, `/${LendingRegistry}`, {
-    params: {
-      address: `eq.${constants.lendingRegistry}`,
-      select: "priceOracle",
-      limit: "1",
-    },
-  });
-  const oracleAddress = lendingRegistryData?.[0]?.priceOracle;
+  const oracleAddress = await getCachedPriceOracleAddress(accessToken);
   if (!oracleAddress) return totals;
 
   const { data: events } = await cirrus.get(accessToken, "/event", {
@@ -316,6 +345,7 @@ export const getUserPoolLiquidityFlowTotals = async (
       address: `in.(${poolAddresses.join(",")})`,
       event_name: "in.(AddLiquidity,RemoveLiquidity)",
       select: "address,event_name,attributes,block_timestamp,transaction_sender",
+      or: `(attributes->>provider.eq.${normalizedUserAddress},attributes->>user.eq.${normalizedUserAddress},attributes->>sender.eq.${normalizedUserAddress},transaction_sender.eq.${normalizedUserAddress})`,
       order: "block_timestamp.asc",
       limit: "10000",
     },
@@ -645,6 +675,7 @@ export const fetchTokenMetadata = async (
   tokenAddresses: string[],
   userAddress?: string
 ): Promise<Map<string, RawToken>> => {
+  const startedAt = Date.now();
   const { data: tokens } = await cirrus.get(accessToken, `/${constants.Token}`, {
     params: {
       address: `in.(${tokenAddresses.join(",")})`,
@@ -652,6 +683,7 @@ export const fetchTokenMetadata = async (
       ...(userAddress ? { "balances.key": `eq.${userAddress}` } : {}),
     }
   });
+  console.log(`[getPools] multi-token token metadata (${tokenAddresses.length} tokens): ${Date.now() - startedAt}ms`);
 
   const tokenMap = new Map<string, RawToken>();
   (tokens as RawToken[]).forEach(t => {
@@ -782,6 +814,10 @@ export const fetchStablePoolFees = async (
 ): Promise<Map<string, number>> => {
   const map = new Map<string, number>();
   if (addresses.length === 0) return map;
+  const cachedFeeMap = getCachedStablePoolFees(addresses);
+  if (cachedFeeMap) {
+    return cachedFeeMap;
+  }
 
   const { data } = await cirrus.get(accessToken, "/BlockApps-StablePool", {
     params: {
@@ -794,6 +830,8 @@ export const fetchStablePoolFees = async (
     const fee = BigInt(row.fee || "0");
     if (fee > 0n) map.set(row.address, Number(fee / BigInt(STABLE_FEE_TO_BPS)));
   }
+
+  setCachedStablePoolFees(addresses, map);
 
   return map;
 };
@@ -823,12 +861,26 @@ export const applyStablePoolFees = async (
 export const fetchMultiTokenStablePools = async (
   accessToken: string,
 ): Promise<MultiTokenStablePool[]> => {
+  const cachedStablePools = getCachedMultiTokenStablePools();
+  if (cachedStablePools) {
+    const liveBalances = await Promise.all(
+      cachedStablePools.map(pool => fetchPoolTokenBalances(accessToken, pool.address))
+    );
+    console.log("[getPools] multi-token stable pools query: 0ms (cached)");
+    return cachedStablePools.map((pool, index) => ({
+      ...pool,
+      tokenBalances: liveBalances[index],
+    }));
+  }
+
+  const startedAt = Date.now();
   const { data: stablePools } = await cirrus.get(accessToken, "/BlockApps-StablePool", {
     params: {
       initialA: "gt.0",
       select: "address,lpToken,fee::text,BlockApps-StablePool-coins(key,value),BlockApps-StablePool-tokenBalances(key,value::text)",
     }
   });
+  console.log(`[getPools] multi-token stable pools query: ${Date.now() - startedAt}ms`);
 
   const results: MultiTokenStablePool[] = [];
   for (const pool of stablePools as any[]) {
@@ -848,6 +900,8 @@ export const fetchMultiTokenStablePools = async (
     results.push({ address: pool.address, lpToken: pool.lpToken, fee: pool.fee || "0", coins, tokenBalances });
   }
 
+  setCachedMultiTokenStablePools(results.map(({ tokenBalances, ...pool }) => pool));
+
   return results;
 };
 
@@ -863,22 +917,37 @@ export const buildMultiTokenPoolEntry = async (
   volumeMap: Map<string, string>,
   factoryData: { swapFeeRate: number; lpSharePercent: number },
   userAddress?: string,
+  preloadedTokenMetadataMap?: Map<string, RawToken>,
 ): Promise<any> => {
   const coinAddresses = stablePool.coins.map(c => c.tokenAddress);
 
-  const [tokenMetadataMap, lpTokenData] = await Promise.all([
-    fetchTokenMetadata(accessToken, coinAddresses, userAddress),
-    fetchTokenMetadata(accessToken, [stablePool.lpToken], userAddress),
-  ]);
+  let tokenMetadataMap: Map<string, RawToken>;
+  let lpTokenData: Map<string, RawToken>;
+  if (preloadedTokenMetadataMap) {
+    tokenMetadataMap = preloadedTokenMetadataMap;
+    lpTokenData = preloadedTokenMetadataMap;
+    console.log(`[getPools] multi-token ${stablePool.address} metadata queries: 0ms (batched)`);
+  } else {
+    const metadataStartedAt = Date.now();
+    [tokenMetadataMap, lpTokenData] = await Promise.all([
+      fetchTokenMetadata(accessToken, coinAddresses, userAddress),
+      fetchTokenMetadata(accessToken, [stablePool.lpToken], userAddress),
+    ]);
+    console.log(`[getPools] multi-token ${stablePool.address} metadata queries: ${Date.now() - metadataStartedAt}ms`);
+  }
 
   // Fetch prices for coins not yet in priceMap
   const missingPriceAddresses = coinAddresses.filter(addr => !priceMap.has(addr));
   if (missingPriceAddresses.length > 0) {
+    const pricesStartedAt = Date.now();
     const additionalPrices = await getOraclePrices(accessToken, {
       select: "asset:key,price:value::text",
       key: `in.(${missingPriceAddresses.join(',')})`
     });
+    console.log(`[getPools] multi-token ${stablePool.address} missing prices (${missingPriceAddresses.length} tokens): ${Date.now() - pricesStartedAt}ms`);
     additionalPrices.forEach((price, addr) => priceMap.set(addr, price));
+  } else {
+    console.log(`[getPools] multi-token ${stablePool.address} missing prices: 0ms`);
   }
 
   const coins = buildPoolCoins(stablePool.coins, tokenMetadataMap, stablePool.tokenBalances, priceMap, userAddress);

--- a/mercata/backend/src/api/services/oracle.service.ts
+++ b/mercata/backend/src/api/services/oracle.service.ts
@@ -18,6 +18,16 @@ const {
   StablePoolCoins,
 } = constants;
 
+const ORACLE_PRICE_CACHE_TTL_MS = 60_000;
+let oraclePriceCache: {
+  key: string;
+  expiresAt: number;
+  priceMap: OraclePriceMap;
+} | undefined;
+
+const getOraclePriceCacheKey = (params: Record<string, string>): string =>
+  JSON.stringify(Object.entries(params).sort(([a], [b]) => a.localeCompare(b)));
+
 /**
  * Check if an address is an LP token by querying the PoolFactory's allPools array
  * @param accessToken - User access token
@@ -65,15 +75,29 @@ const findPoolByLPToken = async (
 
 export const getOraclePrices = async (
   accessToken: string,
-  params: Record<string, string> = { select: "asset:key,price:value::text" }
+  params: Record<string, string> = { select: "asset:key,price:value::text" },
+  useCache = false
 ): Promise<OraclePriceMap> => {
+  const cacheKey = getOraclePriceCacheKey(params);
+  if (useCache && oraclePriceCache?.key === cacheKey && oraclePriceCache.expiresAt > Date.now()) {
+    return new Map(oraclePriceCache.priceMap);
+  }
+
   const { data: rawPrices } = await cirrus.get(accessToken, `/${PriceOracle}-prices`, { params });
 
   const prices = rawPrices as OraclePriceEntry[];
 
-  return new Map(
+  const priceMap = new Map(
     prices?.filter((p: OraclePriceEntry) => p.asset && p.price).map((p: OraclePriceEntry) => [p.asset, p.price]) || []
   );
+  if (useCache) {
+    oraclePriceCache = {
+      key: cacheKey,
+      expiresAt: Date.now() + ORACLE_PRICE_CACHE_TTL_MS,
+      priceMap: new Map(priceMap),
+    };
+  }
+  return priceMap;
 };
 
 export const getRebaseFactors = async (

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -30,6 +30,15 @@ import {
   applyStablePoolFees,
   getUserPoolLiquidityFlowTotals,
 } from "../helpers/swapping.helper";
+import {
+  LIVE_POOL_SELECT_FIELDS,
+  applyLivePoolFields,
+  getCachedPoolFetch,
+  getPoolFetchCacheKey,
+  setCachedPoolFetch,
+  getCachedMultiTokenTokenMetadata,
+  setCachedMultiTokenTokenMetadata,
+} from "../cache/swappingCache";
 import { getOraclePrices } from "./oracle.service";
 import {
   SwapHistoryEntry,
@@ -66,6 +75,40 @@ const { Pool: PoolTable, PoolFactory, PoolSwap, StablePool: StablePoolTable, swa
 
 const normalizeAddress = (address: string): string => address.toLowerCase().replace(/^0x/, "");
 
+const formatElapsedMs = (ms: number): string => `${Math.round(ms * 100) / 100}ms`;
+
+const getUserBalanceEntries = (
+  address: string,
+  userAddress: string,
+  balanceMap: Map<string, string>
+) => balanceMap.has(address)
+  ? [{ user: userAddress, balance: balanceMap.get(address) || "0" }]
+  : [];
+
+const applyUserBalancesToPools = (
+  pools: RawGetPool[],
+  userAddress: string | undefined,
+  balanceMap: Map<string, string>
+): RawGetPool[] => {
+  if (!userAddress) return pools;
+
+  return pools.map(pool => ({
+    ...pool,
+    tokenA: {
+      ...pool.tokenA,
+      balances: getUserBalanceEntries(pool.tokenA.address, userAddress, balanceMap),
+    },
+    tokenB: {
+      ...pool.tokenB,
+      balances: getUserBalanceEntries(pool.tokenB.address, userAddress, balanceMap),
+    },
+    lpToken: {
+      ...pool.lpToken,
+      balances: getUserBalanceEntries(pool.lpToken.address, userAddress, balanceMap),
+    },
+  }));
+};
+
 // --- Pool Queries ---
 
 export const getPools = async (
@@ -73,56 +116,203 @@ export const getPools = async (
   userAddress: string | undefined,
   rawParams: Record<string, string | undefined> = {}
 ): Promise<PoolList> => {
-  const params = buildPoolParams(rawParams, userAddress);
+  const startedAt = performance.now();
+  let sectionStartedAt = startedAt;
+  const trackSection = (section: string, details = "") => {
+    const now = performance.now();
+    console.log(`[getPools] ${section}${details ? ` ${details}` : ""}: ${formatElapsedMs(now - sectionStartedAt)}`);
+    sectionStartedAt = now;
+  };
+  const trackTotal = () => {
+    console.log(`[getPools] total: ${formatElapsedMs(performance.now() - startedAt)}`);
+  };
+  const params = buildPoolParams(rawParams);
+  trackSection("build params");
 
-  const [{data: poolData}, { data: factoryData }] = await Promise.all([
-    cirrus.get(accessToken, `/${PoolTable}`, { params }),
-    cirrus.get(accessToken, `/${PoolFactory}`, {
-      params: { address: "eq." + config.poolFactory, select: "swapFeeRate,lpSharePercent" }
-    })
-  ]);
+  const poolFetchCacheKey = getPoolFetchCacheKey(params);
+  const cachedPoolFetch = getCachedPoolFetch(poolFetchCacheKey);
+  trackSection("check pool fetch cache", cachedPoolFetch ? "(hit)" : "(miss)");
+
+  let poolData: RawGetPool[];
+  let factoryData: unknown;
+  if (cachedPoolFetch) {
+    const cachedPoolAddresses = cachedPoolFetch.poolData.map(pool => pool.address).filter(Boolean);
+    const { data: livePoolData } = await cirrus.get(accessToken, `/${PoolTable}`, {
+      params: {
+        poolFactory: params.poolFactory,
+        address: `in.(${cachedPoolAddresses.join(",")})`,
+        select: LIVE_POOL_SELECT_FIELDS,
+      }
+    });
+    poolData = applyLivePoolFields(cachedPoolFetch.poolData as Partial<RawGetPool>[], livePoolData as RawGetPool[]);
+    factoryData = cachedPoolFetch.factoryData;
+    trackSection("fetch live cached pool fields", `(${cachedPoolAddresses.length} pools)`);
+  } else {
+    const [{data: fetchedPoolData}, { data: fetchedFactoryData }] = await Promise.all([
+      cirrus.get(accessToken, `/${PoolTable}`, { params }),
+      cirrus.get(accessToken, `/${PoolFactory}`, {
+        params: { address: "eq." + config.poolFactory, select: "swapFeeRate,lpSharePercent" }
+      })
+    ]);
+    poolData = fetchedPoolData as RawGetPool[];
+    factoryData = fetchedFactoryData;
+    setCachedPoolFetch(poolFetchCacheKey, poolData, factoryData);
+    trackSection("fetch pools and factory", `(${poolData.length} pools)`);
+  }
 
   // Filter out hidden pools and pools with deactivated tokens (status !== 2 = ACTIVE)
   const ACTIVE_TOKEN_STATUS = "2";
-  const validatedPools = (poolData as RawGetPool[]).filter(
+  const validatedPools = poolData.filter(
     pool => !config.hiddenSwapPools.has(pool.address)
       && pool.tokenA.status === ACTIVE_TOKEN_STATUS
       && pool.tokenB.status === ACTIVE_TOKEN_STATUS
   );
-  const validatedFactory = factoryData[0] as RawPoolFactory;
+  const validatedFactory = (factoryData as RawPoolFactory[])[0];
   const tokenAddresses = extractTokenAddresses(validatedPools);
+  trackSection("validate pools");
+
+  let userBalanceMap = new Map<string, string>();
+  if (userAddress) {
+    const userBalanceAddresses = [
+      ...new Set(validatedPools.flatMap(pool => [
+        pool.tokenA.address,
+        pool.tokenB.address,
+        pool.lpToken.address,
+      ]))
+    ];
+    if (userBalanceAddresses.length) {
+      const { data: liveUserBalances } = await cirrus.get(accessToken, `/${constants.Token}-_balances`, {
+        params: {
+          key: `eq.${userAddress}`,
+          address: `in.(${userBalanceAddresses.join(",")})`,
+          select: "address,user:key,balance:value::text",
+        }
+      });
+      userBalanceMap = new Map(
+        (liveUserBalances as { address: string; balance: string }[]).map(balance => [balance.address, balance.balance])
+      );
+    }
+  }
+  const poolsWithUserBalances = applyUserBalancesToPools(validatedPools, userAddress, userBalanceMap);
+  trackSection("fetch normal pool user balances", userAddress ? `(${userBalanceMap.size} balances)` : "(skipped)");
+
   const priceMap = await getOraclePrices(accessToken, {
     select: "asset:key,price:value::text",
     key: `in.(${tokenAddresses.join(',')})`
-  });
+  }, true);
+  trackSection("fetch oracle prices");
+
   const volumeMap = await getTradingVolume24hForPools(accessToken, validatedPools.map(pool => pool.address), priceMap);
+  trackSection("fetch 24h volume");
 
   let userLiquidityFlowTotals: Map<string, { totalDepositedUsd: bigint; totalWithdrawnUsd: bigint }> | undefined;
   if (userAddress) {
     userLiquidityFlowTotals = await getUserPoolLiquidityFlowTotals(
       accessToken,
-      validatedPools,
+      poolsWithUserBalances,
       userAddress,
       priceMap
     );
   }
+  trackSection("fetch user liquidity flows");
 
   const poolList: any[] = buildPoolList(
-    validatedPools,
+    poolsWithUserBalances,
     priceMap,
     volumeMap,
     validatedFactory,
     userAddress
   );
+  trackSection("build pool list");
 
   // Replace or add multi-token stable pools. These pools also appear in the BlockApps-Pool table
   // (from Pool(pool).setFeeParameters()) but with invalid tokenA/tokenB. Replace those entries
   // with properly built multi-token pool entries.
+  console.log("[getPools] ------- build multi-token pools -------");
   const multiTokenStablePools = await fetchMultiTokenStablePools(accessToken);
+  trackSection("fetch multi-token stable pools", `(${multiTokenStablePools.length} pools)`);
+
+  const multiTokenLPTokenAddresses = [
+    ...new Set(multiTokenStablePools.map(stablePool => stablePool.lpToken))
+  ];
+  const multiTokenTokenAddresses = [
+    ...new Set(multiTokenStablePools.flatMap(stablePool => [
+      ...stablePool.coins.map(coin => coin.tokenAddress),
+      stablePool.lpToken,
+    ]))
+  ];
+  let multiTokenMetadataMap = multiTokenTokenAddresses.length
+    ? getCachedMultiTokenTokenMetadata(multiTokenTokenAddresses, multiTokenLPTokenAddresses)
+    : new Map<string, RawToken>();
+  trackSection("check multi-token metadata cache", multiTokenMetadataMap ? "(hit)" : "(miss)");
+
+  if (multiTokenTokenAddresses.length && !multiTokenMetadataMap) {
+    multiTokenMetadataMap = await fetchTokenMetadata(accessToken, multiTokenTokenAddresses);
+    setCachedMultiTokenTokenMetadata(multiTokenTokenAddresses, multiTokenMetadataMap, multiTokenLPTokenAddresses);
+    trackSection("fetch multi-token metadata", `(${multiTokenTokenAddresses.length} tokens)`);
+  }
+  multiTokenMetadataMap = multiTokenMetadataMap || new Map<string, RawToken>();
+  if (multiTokenLPTokenAddresses.length) {
+    const { data: liveLPTokens } = await cirrus.get(accessToken, `/${constants.Token}`, {
+      params: {
+        address: `in.(${multiTokenLPTokenAddresses.join(",")})`,
+        select: "address,_totalSupply::text",
+      }
+    });
+    (liveLPTokens as { address: string; _totalSupply: string }[]).forEach((token) => {
+      const cachedToken = multiTokenMetadataMap.get(token.address);
+      if (cachedToken) {
+        multiTokenMetadataMap.set(token.address, {
+          ...cachedToken,
+          _totalSupply: token._totalSupply,
+        });
+      }
+    });
+  }
+  trackSection("fetch multi-token LP live metadata", `(${multiTokenLPTokenAddresses.length} tokens)`);
+
+  if (userAddress && multiTokenTokenAddresses.length) {
+    const { data: liveUserBalances } = await cirrus.get(accessToken, `/${constants.Token}-_balances`, {
+      params: {
+        key: `eq.${userAddress}`,
+        address: `in.(${multiTokenTokenAddresses.join(",")})`,
+        select: "address,user:key,balance:value::text",
+      }
+    });
+    (liveUserBalances as { address: string; user: string; balance: string }[]).forEach((balance) => {
+      const address = balance.address;
+      const cachedToken = multiTokenMetadataMap.get(address);
+      if (cachedToken) {
+        multiTokenMetadataMap.set(address, {
+          ...cachedToken,
+          balances: [{ user: balance.user, balance: balance.balance }],
+        });
+      }
+    });
+  }
+  trackSection("fetch multi-token user balances", userAddress ? `(${multiTokenTokenAddresses.length} tokens)` : "(skipped)");
+
+  const missingMultiTokenPriceAddresses = [
+    ...new Set(multiTokenStablePools
+      .flatMap(stablePool => stablePool.coins.map(coin => coin.tokenAddress))
+      .filter(address => !priceMap.has(address)))
+  ];
+  if (missingMultiTokenPriceAddresses.length > 0) {
+    const additionalPrices = await getOraclePrices(accessToken, {
+      select: "asset:key,price:value::text",
+      key: `in.(${missingMultiTokenPriceAddresses.join(',')})`
+    }, true);
+    additionalPrices.forEach((price, addr) => priceMap.set(addr, price));
+    missingMultiTokenPriceAddresses.forEach((addr) => {
+      if (!priceMap.has(addr)) priceMap.set(addr, "0");
+    });
+  }
+  trackSection("fetch multi-token missing prices", `(${missingMultiTokenPriceAddresses.length} tokens)`);
+
   await Promise.all(multiTokenStablePools.map(async (stablePool) => {
     try {
       const poolEntry = await buildMultiTokenPoolEntry(
-        accessToken, stablePool, priceMap, volumeMap, validatedFactory, userAddress
+        accessToken, stablePool, priceMap, volumeMap, validatedFactory, userAddress, multiTokenMetadataMap
       );
       const existingIdx = poolList.findIndex((p: any) => p.address === stablePool.address);
       if (existingIdx !== -1) {
@@ -134,14 +324,18 @@ export const getPools = async (
       console.error(`Failed to build multi-token pool ${stablePool.address}:`, err);
     }
   }));
+  console.log("[getPools] ------- end build multi-token pools -------");
+  trackSection("build multi-token pools");
 
   const patchedPoolList = await applyStablePoolFees(accessToken, poolList);
+  trackSection("apply stable pool fees");
 
   if (!userAddress) {
+    trackTotal();
     return patchedPoolList;
   }
 
-  return patchedPoolList.map((pool) => {
+  const poolsWithUserTotals = patchedPoolList.map((pool) => {
     const flow = userLiquidityFlowTotals?.get(pool.address.toLowerCase()) || {
       totalDepositedUsd: 0n,
       totalWithdrawnUsd: 0n,
@@ -169,6 +363,10 @@ export const getPools = async (
       userAllTimeEarningsUsd: userAllTimeEarningsUsd.toString(),
     };
   });
+  trackSection("build user totals");
+  trackTotal();
+
+  return poolsWithUserTotals;
 };
 
 // --- Token Queries ---


### PR DESCRIPTION
# Summary

- /api/swap-pools does not cache final responses. It caches reusable shared source data, then rebuilds the response per request.
- Auth and no-auth share the same cached base data; auth only layers live per-user balances and liquidity totals afterward.
- Wallet connection only affects the endpoint when the frontend sends X-Wallet-Address; normal logged-in api.get('/swap-pools') should use the app user address.
- Multi-token LP live metadata was optimized to fetch only address,_totalSupply::text, avoiding full token metadata joins.
- User liquidity history was optimized by pushing user filtering into Cirrus and caching the priceOracle address.
- Regression check: before/after auth and no-auth snapshots had same pool counts and schemas; observed value diffs were live oracle/price/liquidity/user-balance changes only.

# Performance Comparison (median time within 300-600 runs)

<img width="695" height="270" alt="Screenshot 2026-05-21 at 7 39 00 PM" src="https://github.com/user-attachments/assets/bf154ffe-0106-4244-9332-7bdd6ccc9334" />



# Cache TTLs:

- **Pool/factory base fetch cache:** 1 hour
- **24h trading volume cache:** 1 hour
- **Stable pool fee cache:** 1 hour
- **Multi-token stable pool structure cache:** 1 hour
- **Multi-token token metadata cache:** 1 hour
- **Price oracle address cache:** 1 hour
- **Oracle prices cache (Optional — boolean gated):** 1 minute

# Caching Logic by Flow

## No Auth Flow
### Cached / cache-backed fields
**Top-level pool identity/config fields:**

- address
- poolName
- poolSymbol
- isStable
- isPaused
- isDisabled
- lpSharePercent
- swapFeeRate, from cached factory data or stable-pool fee cache
- multi-token-only coins[].coinIndex
- multi-token stable-pool structure: stable pool address, lpToken, fee, coins[].tokenAddress


**Token metadata fields under tokenA, tokenB, lpToken, and coins[]:**


- address
- _name
- _symbol
- customDecimals
- _totalSupply for non-LP tokens
- images


**24h/stable helper cache-backed fields:**

- tradingVolume24h
- apy, derived from cached tradingVolume24h, fee, and live liquidity
- stable pool swapFeeRate, via stable fee cache
- Never cached / fetched live or recomputed


**Live pool reserves and ratios:**

- top-level aToBRatio
- top-level bToARatio
- tokenA.poolBalance
- tokenB.poolBalance
- multi-token coins[].poolBalance


**LP live supply:**

lpToken._totalSupply


**Oracle/derived price fields:**

- tokenA.price
- tokenB.price
- lpToken.price
- coins[].price
- oracleAToBRatio
- oracleBToARatio
- totalLiquidityUSD


**No-auth user fields are present but always zero/default, not cached:**

- tokenA.balance
- tokenB.balance
- lpToken.balance
- lpToken.totalBalance
- coins[].balance


## Auth Flow
### Auth includes everything above, plus user-specific values.

### Cached / cache-backed fields
**Same shared fields as no-auth:**

- pool identity/config
- token metadata
- images
- non-live stable pool structure
- cached 24h trading volume
- cached stable pool fees
- cached multi-token token metadata with balances stripped
- Never cached / fetched live or computed per user
- 

**User token balances:**

- tokenA.balance
- tokenB.balance
- lpToken.balance
- lpToken.totalBalance
- multi-token coins[].balance


**User liquidity history totals:**

- userTotalDepositedUsd
- userTotalWithdrawnUsd
- userNetInvestedUsd
- userAllTimeEarningsUsd


**Still live/recomputed in auth too:**

- tokenA.poolBalance
- tokenB.poolBalance
- coins[].poolBalance
- lpToken._totalSupply
- aToBRatio
- bToARatio
- totalLiquidityUSD
- all price fields
- oracleAToBRatio
- oracleBToARatio
- apy