### PR TITLE
optimized /reward/activity  & /activity/me api

### DIFF
--- a/mercata/backend/src/api/helpers/oracle.helper.ts
+++ b/mercata/backend/src/api/helpers/oracle.helper.ts
@@ -149,7 +149,8 @@ const addYieldVaultTokenPrices = async (
   );
   if (!vaultAddrs.length) return;
 
-  for (const vaultAddress of vaultAddrs) {
+  // Parallel instead of sequential
+  await Promise.all(vaultAddrs.map(async (vaultAddress) => {
     const { data: rows } = await cirrus.get(accessToken, `/${YieldVault}`, {
       params: {
         address: `eq.${vaultAddress}`,
@@ -157,7 +158,7 @@ const addYieldVaultTokenPrices = async (
       },
     });
     const v = rows?.[0];
-    if (!v?._asset || !v.address) continue;
+    if (!v?._asset || !v.address) return;
 
     const { data: balRows } = await cirrus.get(accessToken, `/${Token}-_balances`, {
       params: {
@@ -173,7 +174,7 @@ const addYieldVaultTokenPrices = async (
     const totalShares = BigInt(v._totalSupply || "0");
     const pricePerShare = totalShares === 0n ? DECIMALS : (totalAssets * DECIMALS) / totalShares;
     priceMap.set(v.address, pricePerShare.toString());
-  }
+  }));
 };
 
 /**
@@ -195,7 +196,8 @@ export const getCarryVaultUsdPriceMap = async (
   );
   if (!vaultAddrs.length) return out;
 
-  for (const vaultAddress of vaultAddrs) {
+  // Parallel instead of sequential
+  await Promise.all(vaultAddrs.map(async (vaultAddress) => {
     const { data: rows } = await cirrus.get(accessToken, `/${YieldVault}`, {
       params: {
         address: `eq.${vaultAddress}`,
@@ -203,7 +205,7 @@ export const getCarryVaultUsdPriceMap = async (
       },
     });
     const v = rows?.[0];
-    if (!v?._asset || !v.address) continue;
+    if (!v?._asset || !v.address) return;
 
     const { data: balRows } = await cirrus.get(accessToken, `/${Token}-_balances`, {
       params: {
@@ -217,18 +219,18 @@ export const getCarryVaultUsdPriceMap = async (
     const deployed = BigInt(v.deployedAssets || "0");
     const totalAssets = idle + deployed;
     const totalShares = BigInt(v._totalSupply || "0");
-    if (totalShares === 0n) continue;
+    if (totalShares === 0n) return;
 
     const pricePerShareUnderlying = (totalAssets * DECIMALS) / totalShares;
 
     const assetKey = String(v._asset).toLowerCase();
     const assetUsdPriceStr = priceMap.get(assetKey) || priceMap.get(v._asset) || "0";
     const assetUsdPriceWad = BigInt(assetUsdPriceStr);
-    if (assetUsdPriceWad === 0n) continue;
+    if (assetUsdPriceWad === 0n) return;
 
     const pricePerShareUsdWad = (pricePerShareUnderlying * assetUsdPriceWad) / DECIMALS;
     out.set(String(v.address).toLowerCase(), pricePerShareUsdWad.toString());
-  }
+  }));
   return out;
 };
 

--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -91,7 +91,11 @@ const inferStakeSemantics = (activity: {
 
 
 
+// Static address — only changes on redeploy
+let _mTokenCache: { value: string | null; expiresAt: number } | null = null;
+
 const getMTokenAddress = async (accessToken: string): Promise<string | null> => {
+  if (_mTokenCache && Date.now() < _mTokenCache.expiresAt) return _mTokenCache.value;
   try {
     const { data } = await cirrus.get(accessToken, `/${LendingPool}`, {
       params: {
@@ -101,7 +105,9 @@ const getMTokenAddress = async (accessToken: string): Promise<string | null> => 
         limit: "1",
       }
     });
-    return data?.[0]?.mToken || null;
+    const value = data?.[0]?.mToken || null;
+    _mTokenCache = { value, expiresAt: Date.now() + 3_600_000 };
+    return value;
   } catch {
     return null;
   }
@@ -423,20 +429,19 @@ export const fetchUserActivities = async (
 
     const activityIds = activities.map((a: any) => a.activityId);
 
-    const [activityStatesMap, userInfoMap, unclaimedRewards, claimedRewardsMap, bonusResult] = await Promise.all([
+    // User data + pricing in one parallel batch
+    const [activityStatesMap, userInfoMap, unclaimedRewards, claimedRewardsMap, bonusResult, priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
       fetchActivityStates(accessToken, rewardsAddress, forceRefresh),
       fetchUserInfo(accessToken, rewardsAddress, normalizedUserAddress, activityIds, forceRefresh),
       fetchUnclaimedRewards(accessToken, rewardsAddress, normalizedUserAddress, forceRefresh),
       fetchClaimedRewards(accessToken, rewardsAddress),
-      fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress)
-    ]);
-
-    // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
+      fetchBonusRewards(accessToken, rewardsAddress, normalizedUserAddress),
       getCompletePriceMap(accessToken),
       getMTokenAddress(accessToken),
       getVaultShareTokenAddress(accessToken).catch(() => ""),
     ]);
+
+    // Carry vault prices depend on priceMap from above
     const carryVaultUsdPriceMap = await getCarryVaultUsdPriceMap(accessToken, priceMap);
     const { sToken } = getSafetyModuleConfig();
     const pricingCtx = {
@@ -524,10 +529,13 @@ export const fetchAllActivities = async (
   const rewardsAddress = getRewardsAddress();
 
   try {
-    // Fetch all activities and their states
-    const [activitiesMap, activityStatesMap] = await Promise.all([
+    // Phase 1: contract state + pricing addresses in parallel
+    const [activitiesMap, activityStatesMap, priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
       fetchActivities(accessToken, rewardsAddress, forceRefresh),
-      fetchActivityStates(accessToken, rewardsAddress, forceRefresh)
+      fetchActivityStates(accessToken, rewardsAddress, forceRefresh),
+      getCompletePriceMap(accessToken),
+      getMTokenAddress(accessToken),
+      getVaultShareTokenAddress(accessToken).catch(() => ""),
     ]);
 
     const activities = Array.from(activitiesMap.values());
@@ -536,12 +544,7 @@ export const fetchAllActivities = async (
       return [];
     }
 
-    // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
-      getCompletePriceMap(accessToken),
-      getMTokenAddress(accessToken),
-      getVaultShareTokenAddress(accessToken).catch(() => ""),
-    ]);
+    // Phase 2: carry vault prices (depends on priceMap from phase 1)
     const carryVaultUsdPriceMap = await getCarryVaultUsdPriceMap(accessToken, priceMap);
     const { sToken } = getSafetyModuleConfig();
     const pricingCtx = {

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -553,13 +553,19 @@ export interface UserTokenBalance {
 /**
  * Get the vault share token address.
  */
+// Static address — only changes on redeploy
+let _shareTokenAddrCache: { value: string; expiresAt: number } | null = null;
+
 export const getVaultShareTokenAddress = async (
   accessToken: string
 ): Promise<string> => {
+  if (_shareTokenAddrCache && Date.now() < _shareTokenAddrCache.expiresAt) return _shareTokenAddrCache.value;
   const vaultAddress = getVaultAddress();
   if (!vaultAddress) return "";
   const vaultData = await getVaultData(accessToken, vaultAddress);
-  return vaultData?.shareToken || "";
+  const value = vaultData?.shareToken || "";
+  _shareTokenAddrCache = { value, expiresAt: Date.now() + 3_600_000 };
+  return value;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Parallelized sequential vault loops in `addYieldVaultTokenPrices` and `getCarryVaultUsdPriceMap` (6 sequential Cirrus calls → 3 parallel pairs)
- Merged sequential fetch phases into single `Promise.all` in both `fetchAllActivities` and `fetchUserActivities` — contract state and pricing now overlap instead of running back-to-back
- Cached static contract addresses that never change after deployment:
  - `getMTokenAddress` — **1hr cache** (Lending Pool mToken address)
  - `getVaultShareTokenAddress` — **1hr cache** (Vault share token address)

## What stays live (no caching)

All prices, stakes, user data, rewards, and events are fetched fresh on every call.

## Testing Completed On: `/rewards/activities`

| Flow | Tested Functionality | localhost before response time | localhost after response time | workspace before response time | workspace after response time |
|------|:---:|---:|---:|---:|---:|
| Anonymous flow | ✅ | 5641.45ms | 2045ms | 1.59s | 637ms |
| STRATO OAuth flow | ✅ | 5905.64ms | 2640ms | 3.84s | 1.87s |
| MetaMask Wallet Connect flow | ✅ | 5485.53ms | 2681ms | 3.98s | 1.03s |
| Both flows | ✅ | - | - | - | - |

---

## Testing Completed On: `/rewards/activities/me`

| Flow | Tested Functionality | localhost before response time | localhost after response time | workspace before response time | workspace after response time |
|------|:---:|---:|---:|---:|---:|
| Anonymous flow | ✅ | - | - | - | - |
| STRATO OAuth flow | ✅ | 6019.64ms | 1817ms | 5.11s | 1.83s |
| MetaMask Wallet Connect flow | ✅ | 5776.16ms | 2036ms | 4.09s | 988ms |
| Both flows | ✅ | - | - | - | - |