### PR TITLE
Vault updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ all_develop: build_develop docker-compose
 
 build_develop: develop apex highway highway-nginx nginx postgrest prometheus smd vault-wrapper vault-nginx mercata-backend mercata-ui bridge bridge-nginx oracle
 
-.PHONY: all_develop build_buildbase build_common build_common_docker build_common_profiled build_develop docker docker-compose highway highway-nginx local oracle strato strato_docker vault-nginx vault-wrapper vault-wrapper_docker install-completions install-bash-completions install-zsh-completions apex-force nginx-force postgrest-force prometheus-force smd-force mercata-backend-force mercata-ui-force bridge-force bridge-nginx-force app
+.PHONY: all_develop build_buildbase build_common build_common_docker build_common_profiled build_develop docker docker-compose highway highway-nginx local oracle strato strato_docker vault-nginx vault-wrapper vault-wrapper_docker migrate-key install-completions install-bash-completions install-zsh-completions apex-force nginx-force postgrest-force prometheus-force smd-force mercata-backend-force mercata-ui-force bridge-force bridge-nginx-force app
 
 app: mercata-backend mercata-ui
 	@echo ""
@@ -362,6 +362,17 @@ vault-wrapper: build_common_docker
 	cp strato/vault/doit.sh ${VAULTDIR}
 	docker build --target vault-wrapper --tag ${REPO_URL}vault-wrapper:${VERSION} --file Dockerfile.multi ${FAKEROOT}
 	docker tag ${REPO_URL}vault-wrapper:${VERSION} ${REPO_AWS_ECR_URL}vault-wrapper:${VERSION}
+
+# Builds the migrate-key admin tool on the host and installs it to ~/.local/bin.
+# See strato/vault/vault-runner/README.md ("Migrating a single key between Vaults")
+# for the full operator workflow (docker cp into the vault-wrapper container, etc).
+migrate-key:
+	@echo Now building migrate-key...
+	cd strato && stack ${NIX_FLAG} build blockapps-vault-wrapper-server:exe:migrate-key
+	cd strato && stack ${NIX_FLAG} --local-bin-path ${HOME}/.local/bin install blockapps-vault-wrapper-server:exe:migrate-key
+	@echo
+	@echo "Installed: ${HOME}/.local/bin/migrate-key"
+	@echo "Next steps: see strato/vault/vault-runner/README.md - 'Migrating a single key between Vaults'"
 
 vault-nginx:
 	@echo Now building vault-nginx...

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ all_develop: build_develop docker-compose
 
 build_develop: develop apex highway highway-nginx nginx postgrest prometheus smd vault-wrapper vault-nginx mercata-backend mercata-ui bridge bridge-nginx oracle
 
-.PHONY: all_develop build_buildbase build_common build_common_docker build_common_profiled build_develop docker docker-compose highway highway-nginx local oracle strato strato_docker vault-nginx vault-wrapper vault-wrapper_docker migrate-key install-completions install-bash-completions install-zsh-completions apex-force nginx-force postgrest-force prometheus-force smd-force mercata-backend-force mercata-ui-force bridge-force bridge-nginx-force app
+.PHONY: all_develop build_buildbase build_common build_common_docker build_common_profiled build_develop docker docker-compose highway highway-nginx local oracle strato strato_docker vault-nginx vault-wrapper vault-wrapper_docker migrate-key change-vault-password install-completions install-bash-completions install-zsh-completions apex-force nginx-force postgrest-force prometheus-force smd-force mercata-backend-force mercata-ui-force bridge-force bridge-nginx-force app
 
 app: mercata-backend mercata-ui
 	@echo ""
@@ -373,6 +373,17 @@ migrate-key:
 	@echo
 	@echo "Installed: ${HOME}/.local/bin/migrate-key"
 	@echo "Next steps: see strato/vault/vault-runner/README.md - 'Migrating a single key between Vaults'"
+
+# Builds the change-vault-password admin tool on the host and installs it to ~/.local/bin.
+# See strato/vault/vault-runner/README.md ("Changing the existing Vault password")
+# for the full operator workflow (docker cp into the vault-wrapper container, etc).
+change-vault-password:
+	@echo Now building change-vault-password...
+	cd strato && stack ${NIX_FLAG} build blockapps-vault-wrapper-server:exe:change-vault-password
+	cd strato && stack ${NIX_FLAG} --local-bin-path ${HOME}/.local/bin install blockapps-vault-wrapper-server:exe:change-vault-password
+	@echo
+	@echo "Installed: ${HOME}/.local/bin/change-vault-password"
+	@echo "Next steps: see strato/vault/vault-runner/README.md - 'Changing the existing Vault password'"
 
 vault-nginx:
 	@echo Now building vault-nginx...

--- a/strato/vault/doit.sh
+++ b/strato/vault/doit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 minLogLevel=LevelInfo
 if [ "${VAULTWRAPPER_DEBUG:-false}" == true ]; then
@@ -12,7 +12,7 @@ vault-wrapper:
 --phsot=\$postgres_host="${postgres_host}"
 --pgport=\$postgres_port="${postgres_port}"
 --pguser=\$postgres_user="${postgres_user}"
---password=\$postgres_password="${postgres_password}"
+--password=\$postgres_password="***"
 --database=\$postgres_vault_wrapper_db="${postgres_vault_wrapper_db}"
 --minLogLevel="${minLogLevel}"
 --keyStoreCacheTimeout="${keyStoreCacheTimeout}"

--- a/strato/vault/server/app/Main.hs
+++ b/strato/vault/server/app/Main.hs
@@ -19,6 +19,7 @@ import Data.Cache
 import Data.IORef
 import Data.Pool
 import Data.String (fromString)
+import qualified GHC.Conc as Conc
 import Database.Persist.Sql (rawExecute)
 import Database.Persist.Postgresql (withPostgresqlConn)
 import Database.PostgreSQL.Simple
@@ -85,11 +86,15 @@ main = do
   void $ Strato23.runMigrations conn
   close conn
 
-  let poolConfig = defaultPoolConfig
-                    (connect dbConnectInfo)
-                    close
-                    3 -- timeout: 3 seconds
-                    20 -- max resources
+  stripes <- if flags_pgPoolStripes <= 0
+               then Conc.getNumCapabilities
+               else pure flags_pgPoolStripes
+  let poolConfig = setNumStripes (Just stripes)
+                 $ defaultPoolConfig
+                     (connect dbConnectInfo)
+                     close
+                     (realToFrac flags_pgPoolIdleTimeout)
+                     flags_pgPoolSize
   pool <- newPool poolConfig
   mgr <- newManager defaultManagerSettings
   password <- newIORef Nothing

--- a/strato/vault/server/app/MigrateKey.hs
+++ b/strato/vault/server/app/MigrateKey.hs
@@ -1,0 +1,448 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- migrate-key
+--
+-- Move a single user's key between two Vault instances (different DBs,
+-- different vault passwords) without ever writing the plaintext private
+-- key to disk.
+--
+-- Two modes, chosen by which of --out / --in is provided:
+--
+--   --out=<path>  EXPORT mode
+--     Reads the user's encrypted key from the configured Postgres DB
+--     (decrypting it with the current vault password), then re-encrypts
+--     it under a one-time transport password and writes the result to
+--     <path> as a JSON envelope.
+--
+--   --in=<path>   IMPORT mode
+--     Reads the JSON envelope, decrypts it with the transport password,
+--     re-encrypts under the destination vault password, and inserts a
+--     new user row in the configured destination Postgres DB.
+--
+-- Passwords are read from stdin (two lines, newline-separated). They are
+-- never accepted on the command line or via environment variables.
+--   EXPORT: line 1 = current vault password, line 2 = transport password
+--   IMPORT: line 1 = transport password,    line 2 = destination vault password
+--
+-- Exit codes:
+--   0 - success
+--   1 - failure (on import, the destination DB transaction is rolled back)
+
+import Control.Arrow
+import Control.Exception (SomeException, bracket, try)
+import Control.Monad (unless, when)
+import qualified Crypto.Saltine.Class as Saltine
+import qualified Crypto.Saltine.Core.SecretBox as SecretBox
+import Data.Aeson ((.:), (.=))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Lazy as BL
+import Data.Int (Int32)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Database.PostgreSQL.Simple hiding (Query)
+import Database.PostgreSQL.Simple.SqlQQ
+import Database.PostgreSQL.Simple.Transaction
+import HFlags
+import Opaleye hiding (Field, Table, max, min, not, null)
+import qualified Options
+import Strato.Strato23.Crypto
+import Strato.Strato23.Database.Queries (getMessageQuery, postUserKeyQuery')
+import Strato.Strato23.Database.Tables as TS
+import Strato.Strato23.Server.Password (getKeyFromPasswordAndSalt, superSecretVaultWrapperMessage)
+import Blockchain.Strato.Model.Address (formatAddressWithoutColor, fromPrivateKey, stringAddress)
+import Blockchain.Strato.Model.Secp256k1 (exportPrivateKey, importPrivateKey)
+import System.Environment (lookupEnv)
+import System.Exit (ExitCode (..), exitWith)
+import System.IO
+  ( BufferMode (..),
+    IOMode (..),
+    hClose,
+    hFlush,
+    hGetEcho,
+    hIsTerminalDevice,
+    hPutStr,
+    hPutStrLn,
+    hSetBuffering,
+    hSetEcho,
+    openFile,
+    stderr,
+    stdin,
+    stdout,
+  )
+
+defineFlag "out" ("" :: String) "Export mode: path to write the encrypted key envelope to"
+defineFlag "in" ("" :: String) "Import mode: path to read the encrypted key envelope from"
+defineFlag "x_user_unique_name" ("" :: String) "(export only) x_user_unique_name column value of the user to export"
+defineFlag "x_identity_provider_id" ("" :: String) "(export only) x_identity_provider_id column value of the user to export"
+defineFlag "force" False "(import only) overwrite an existing user row with the same (x_user_unique_name, x_identity_provider_id)"
+
+envelopeVersion :: Int
+envelopeVersion = 1
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
+  _ <- $initHFlags "migrate-key"
+
+  let outPath = flags_out
+      inPath = flags_in
+  case (null outPath, null inPath) of
+    (False, False) -> die_ "exactly one of --out or --in must be provided, not both"
+    (True, True) -> die_ "exactly one of --out or --in must be provided"
+    (False, True) -> runExport outPath
+    (True, False) -> runImport inPath flags_force
+
+-- | Resolve Postgres connection settings using the following precedence:
+--
+--   1. CLI flag, if the operator passed a value different from the built-in
+--      HFlags default (i.e. explicitly overrode it).
+--   2. Environment variable (same names the vault-wrapper daemon reads from
+--      docker-compose: @postgres_host@, @postgres_port@, @postgres_user@,
+--      @postgres_password@, @postgres_vault_wrapper_db@), if set and non-empty.
+--   3. The built-in HFlags default from 'Options'.
+--
+-- This matches the standard Unix CLI > env > default convention while still
+-- letting operators run the tool inside an existing vault-wrapper container
+-- without re-typing connection settings that are already in its environment.
+connectInfo :: IO ConnectInfo
+connectInfo = do
+  host <- resolve "postgres_host" Options.flags_pghost "postgres"
+  portStr <- resolve "postgres_port" Options.flags_pgport "5432"
+  user <- resolve "postgres_user" Options.flags_pguser "postgres"
+  pw <- resolve "postgres_password" Options.flags_password "api"
+  db <- resolve "postgres_vault_wrapper_db" Options.flags_database "oauth"
+  pure
+    ConnectInfo
+      { connectHost = host,
+        connectPort = read portStr,
+        connectUser = user,
+        connectPassword = pw,
+        connectDatabase = db
+      }
+  where
+    -- envName: env var name; flagVal: current HFlags value; flagDefault: the
+    -- value HFlags would have had if the operator did not pass the flag.
+    resolve :: String -> String -> String -> IO String
+    resolve envName flagVal flagDefault
+      | flagVal /= flagDefault = pure flagVal -- operator explicitly overrode via CLI
+      | otherwise = do
+          mEnv <- lookupEnv envName
+          pure $ case mEnv of
+            Just s | not (null s) -> s
+            _ -> flagDefault
+
+-- ----------------------------------------------------------------------------
+-- Export mode
+-- ----------------------------------------------------------------------------
+
+runExport :: String -> IO ()
+runExport outPath = do
+  when (null flags_x_user_unique_name) $
+    die_ "--x_user_unique_name is required in export mode"
+  when (null flags_x_identity_provider_id) $
+    die_ "--x_identity_provider_id is required in export mode"
+
+  vaultPwBs <- readPasswordLine "Current source vault password: "
+  transportPwBs <- readPasswordLine "Transport password (used to protect the export file): "
+  when (BS.null vaultPwBs) $ die_ "vault password is empty"
+  when (BS.null transportPwBs) $ die_ "transport password is empty"
+  when (vaultPwBs == transportPwBs) $
+    die_ "vault password and transport password must differ"
+
+  let vaultPw = Password vaultPwBs
+      transportPw = Password transportPwBs
+      uName = T.pack flags_x_user_unique_name
+      uProv = T.pack flags_x_identity_provider_id
+
+  ci <- connectInfo
+  bracket (connect ci) close $ \conn -> do
+    _ <- (query_ conn [sql| SELECT 1 |] :: IO [Only Int])
+    putStrLn "DB connection OK."
+
+    (msgSalt, msgNonce, encMsg) <- loadMessage conn
+    let vaultKey = getKeyFromPasswordAndSalt vaultPw msgSalt
+    case decrypt vaultKey msgNonce encMsg of
+      Just m | m == superSecretVaultWrapperMessage -> pure ()
+      _ -> die_ "source vault password does not match the vault's stored message; aborting."
+    putStrLn "Source vault password validated."
+
+    -- Look up exactly one row matching (x_user_unique_name, x_identity_provider_id).
+    rows <- runSelect conn $ proc () -> do
+      (uid, uname, uprov, _salt, nonce, encSk, addrBs) <- selectTable TS.usersTable -< ()
+      restrict -< uname .== toFields uName .&& uprov .== toFields uProv
+      returnA -< (uid, nonce, encSk, addrBs)
+    (uid :: Int32, userNonce :: SecretBox.Nonce, encSecPrvKey :: BS.ByteString, addrBs :: BS.ByteString) <-
+      case rows of
+        [r] -> pure r
+        [] -> die_ "no user matches the given (x_user_unique_name, x_identity_provider_id)"
+        _ -> die_ "more than one user matches; refusing to proceed (the UNIQUE constraint should prevent this)"
+    putStrLn $ "Found user id=" <> show uid
+
+    plain <- case decrypt vaultKey userNonce encSecPrvKey of
+      Just p -> pure p
+      Nothing -> die_ "could not decrypt the user's key with the source vault password"
+
+    -- Sanity-check: the recovered private key must produce the stored address.
+    privKey <- case importPrivateKey plain of
+      Just k -> pure k
+      Nothing -> die_ "decrypted bytes are not a valid private key"
+    let derivedAddr = fromPrivateKey privKey
+        derivedAddrBs = C8.pack (formatAddressWithoutColor derivedAddr)
+    when (derivedAddrBs /= addrBs) $
+      die_ "address mismatch between decrypted key and DB row; aborting."
+    putStrLn "Address self-check passed."
+
+    -- Wrap under the transport password.
+    (transportSalt, transportNonce) <- newSaltAndNonce
+    let transportKey = getKeyFromPasswordAndSalt transportPw transportSalt
+        transportCiphertext = encrypt transportKey transportNonce plain
+
+    let env =
+          Envelope
+            { envVersion = envelopeVersion,
+              envXUserUniqueName = uName,
+              envXIdentityProviderId = uProv,
+              envAddressHex = T.decodeUtf8 addrBs,
+              envTransportSalt = transportSalt,
+              envTransportNonce = Saltine.encode transportNonce,
+              envTransportCiphertext = transportCiphertext
+            }
+    writeEnvelope outPath env
+    putStrLn $ "OK: wrote encrypted envelope to " <> outPath
+
+-- ----------------------------------------------------------------------------
+-- Import mode
+-- ----------------------------------------------------------------------------
+
+runImport :: String -> Bool -> IO ()
+runImport inPath force = do
+  transportPwBs <- readPasswordLine "Transport password (the one used during export): "
+  vaultPwBs <- readPasswordLine "Destination vault password: "
+  when (BS.null transportPwBs) $ die_ "transport password is empty"
+  when (BS.null vaultPwBs) $ die_ "destination vault password is empty"
+
+  let transportPw = Password transportPwBs
+      vaultPw = Password vaultPwBs
+
+  env <- readEnvelope inPath
+  unless (envVersion env == envelopeVersion) $
+    die_ $ "unsupported envelope version: " <> show (envVersion env)
+
+  -- Decrypt the envelope under the transport password.
+  transportNonce <- case Saltine.decode (envTransportNonce env) of
+    Just n -> pure n
+    Nothing -> die_ "envelope transport_nonce is not a valid SecretBox nonce"
+  let transportKey = getKeyFromPasswordAndSalt transportPw (envTransportSalt env)
+  plain <- case decrypt transportKey transportNonce (envTransportCiphertext env) of
+    Just p -> pure p
+    Nothing -> die_ "could not decrypt envelope (wrong transport password, or file is corrupted)"
+
+  privKey <- case importPrivateKey plain of
+    Just k -> pure k
+    Nothing -> die_ "decrypted envelope bytes are not a valid private key"
+
+  -- Address sanity check against the envelope.
+  let derivedAddr = fromPrivateKey privKey
+      derivedAddrBs = C8.pack (formatAddressWithoutColor derivedAddr)
+      claimedAddrBs = T.encodeUtf8 (envAddressHex env)
+  when (derivedAddrBs /= claimedAddrBs) $
+    die_ "address mismatch between envelope's recorded address and the decrypted key"
+  -- Also verify it parses as an Address.
+  case stringAddress (T.unpack (envAddressHex env)) of
+    Just _ -> pure ()
+    Nothing -> die_ "envelope address_hex is not a valid Ethereum address"
+
+  ci <- connectInfo
+  bracket (connect ci) close $ \conn -> do
+    _ <- (query_ conn [sql| SELECT 1 |] :: IO [Only Int])
+    putStrLn "Destination DB connection OK."
+
+    (msgSalt, msgNonce, encMsg) <- loadMessage conn
+    let vaultKey = getKeyFromPasswordAndSalt vaultPw msgSalt
+    case decrypt vaultKey msgNonce encMsg of
+      Just m | m == superSecretVaultWrapperMessage -> pure ()
+      _ -> die_ "destination vault password does not match the destination vault's stored message; aborting."
+    putStrLn "Destination vault password validated."
+
+    -- Check for an existing user row with the same (name, provider).
+    existing <-
+      runSelect conn $ proc () -> do
+        (uid, uname, uprov, _, _, _, _) <- selectTable TS.usersTable -< ()
+        restrict -<
+          uname .== toFields (envXUserUniqueName env)
+            .&& uprov .== toFields (envXIdentityProviderId env)
+        returnA -< uid
+    case existing :: [Int32] of
+      [] -> pure ()
+      (_ : _) ->
+        unless force $
+          die_ "a user with this (x_user_unique_name, x_identity_provider_id) already exists in the destination DB; re-run with --force to overwrite"
+
+    -- Re-encrypt the plaintext private key under the destination vault key
+    -- with a fresh nonce, then write inside a serializable transaction.
+    userNonce <- SecretBox.newNonce
+    let encSecPrvKey = encrypt vaultKey userNonce (exportPrivateKey privKey)
+
+    eRes <- try $
+      withTransactionSerializable conn $ do
+        case existing :: [Int32] of
+          [] -> do
+            -- Insert via the existing helper (uses the per-user salt = msgSalt convention
+            -- by reusing the message salt, matching post-MigrateSalt behavior).
+            let keystore =
+                  KeyStore
+                    { keystoreSalt = msgSalt,
+                      keystoreAcctNonce = userNonce,
+                      keystoreAcctEncSecKey = encSecPrvKey,
+                      keystoreAcctAddress = derivedAddr
+                    }
+            ok <-
+              postUserKeyQuery'
+                (envXUserUniqueName env)
+                (envXIdentityProviderId env)
+                keystore
+                conn
+            unless ok $ fail "insert returned False (user already present?)"
+            pure ("inserted" :: String)
+          _ -> do
+            -- --force overwrite path.
+            n <-
+              execute
+                conn
+                [sql|
+                  UPDATE users
+                  SET salt = ?, nonce = ?, enc_sec_prv_key = ?, address = ?
+                  WHERE x_user_unique_name = ? AND x_identity_provider_id = ?
+                |]
+                ( Binary msgSalt,
+                  Binary (Saltine.encode userNonce),
+                  Binary encSecPrvKey,
+                  Binary derivedAddrBs,
+                  envXUserUniqueName env,
+                  envXIdentityProviderId env
+                )
+            when (n /= 1) $ fail $ "UPDATE affected " <> show n <> " rows; expected 1"
+            pure "updated"
+
+    case eRes of
+      Left (e :: SomeException) -> die_ $ "import aborted, no changes committed: " <> show e
+      Right action -> do
+        putStrLn $ "OK: " <> action <> " user "
+          <> T.unpack (envXUserUniqueName env)
+          <> " / "
+          <> T.unpack (envXIdentityProviderId env)
+          <> " (address "
+          <> T.unpack (envAddressHex env)
+          <> ")"
+
+-- ----------------------------------------------------------------------------
+-- Envelope
+-- ----------------------------------------------------------------------------
+
+data Envelope = Envelope
+  { envVersion :: Int,
+    envXUserUniqueName :: T.Text,
+    envXIdentityProviderId :: T.Text,
+    envAddressHex :: T.Text,
+    envTransportSalt :: BS.ByteString,
+    envTransportNonce :: BS.ByteString,
+    envTransportCiphertext :: BS.ByteString
+  }
+
+instance A.ToJSON Envelope where
+  toJSON e =
+    A.object
+      [ "version" .= envVersion e,
+        "x_user_unique_name" .= envXUserUniqueName e,
+        "x_identity_provider_id" .= envXIdentityProviderId e,
+        "address_hex" .= envAddressHex e,
+        "transport_salt_b64" .= b64 (envTransportSalt e),
+        "transport_nonce_b64" .= b64 (envTransportNonce e),
+        "transport_ciphertext_b64" .= b64 (envTransportCiphertext e)
+      ]
+    where
+      b64 :: BS.ByteString -> T.Text
+      b64 = T.decodeUtf8 . B64.encode
+
+instance A.FromJSON Envelope where
+  parseJSON = A.withObject "Envelope" $ \o -> do
+    v <- o .: "version"
+    n <- o .: "x_user_unique_name"
+    p <- o .: "x_identity_provider_id"
+    a <- o .: "address_hex"
+    s <- o .: "transport_salt_b64" >>= b64Field "transport_salt_b64"
+    nn <- o .: "transport_nonce_b64" >>= b64Field "transport_nonce_b64"
+    c <- o .: "transport_ciphertext_b64" >>= b64Field "transport_ciphertext_b64"
+    pure
+      Envelope
+        { envVersion = v,
+          envXUserUniqueName = n,
+          envXIdentityProviderId = p,
+          envAddressHex = a,
+          envTransportSalt = s,
+          envTransportNonce = nn,
+          envTransportCiphertext = c
+        }
+    where
+      b64Field :: String -> T.Text -> A.Parser BS.ByteString
+      b64Field fieldName t =
+        case B64.decode (T.encodeUtf8 t) of
+          Right bs -> pure bs
+          Left err -> fail $ fieldName <> " is not valid base64: " <> err
+
+writeEnvelope :: FilePath -> Envelope -> IO ()
+writeEnvelope path env =
+  bracket (openFile path WriteMode) hClose $ \h ->
+    BL.hPut h (A.encode env)
+
+readEnvelope :: FilePath -> IO Envelope
+readEnvelope path = do
+  bs <- BL.readFile path
+  case A.eitherDecode bs of
+    Right e -> pure e
+    Left err -> die_ $ "could not parse envelope file: " <> err
+
+-- ----------------------------------------------------------------------------
+-- Helpers
+-- ----------------------------------------------------------------------------
+
+loadMessage :: Connection -> IO (BS.ByteString, SecretBox.Nonce, BS.ByteString)
+loadMessage conn = do
+  rs <- runSelect conn getMessageQuery
+  case rs of
+    [r] -> pure r
+    [] -> die_ "message table is empty; vault has never had a password set"
+    _ -> die_ "message table has more than one row; refusing to proceed"
+
+-- Read one line from stdin without echo (when stdin is a terminal).
+readPasswordLine :: String -> IO BS.ByteString
+readPasswordLine prompt = do
+  isTty <- hIsTerminalDevice stdin
+  if isTty
+    then do
+      hPutStr stderr prompt
+      hFlush stderr
+      old <- hGetEcho stdin
+      bs <- bracket
+        (hSetEcho stdin False)
+        (\_ -> hSetEcho stdin old)
+        (\_ -> C8.hGetLine stdin)
+      hPutStrLn stderr ""
+      pure bs
+    else C8.hGetLine stdin
+
+die_ :: String -> IO a
+die_ msg = do
+  hPutStrLn stderr $ "ERROR: " <> msg
+  exitWith (ExitFailure 1)

--- a/strato/vault/server/app/Options.hs
+++ b/strato/vault/server/app/Options.hs
@@ -14,6 +14,10 @@ defineFlag "port" (8000 :: Int) "The port which the server runs on"
 defineFlag "keyStoreCacheTimeout" (60 :: Integer) "The number of seconds nonces are held in the global source code cache"
 defineFlag "vaultPasswordFile" ("" :: String) "Path to file containing vault encryption password"
 
+defineFlag "pgPoolSize" (100 :: Int) "Maximum number of connections in the Postgres pool"
+defineFlag "pgPoolIdleTimeout" (30 :: Int) "Idle connection timeout in seconds before pool closes connections"
+defineFlag "pgPoolStripes" (0 :: Int) "Number of pool stripes (0 = use number of CPU capabilities)"
+
 defineFlag "pw" ("" :: String) "Password for vault-proxy"
 defineFlag "key" ("" :: String) "the old blockstanbulPrivateKey to migrate"
 defineFlag "pwOld" ("" :: String) "Password for old vault-wrapper" -- Used for mercata migration

--- a/strato/vault/server/blockapps-vault-wrapper-server.cabal
+++ b/strato/vault/server/blockapps-vault-wrapper-server.cabal
@@ -114,6 +114,27 @@ executable change-vault-password
     , saltine
   default-language: Haskell2010
 
+executable migrate-key
+  main-is: MigrateKey.hs
+  other-modules:
+      Options
+  hs-source-dirs:
+      app
+  build-depends:
+      aeson
+    , base
+    , base64-bytestring
+    , blockapps-vault-wrapper-api
+    , blockapps-vault-wrapper-server
+    , bytestring
+    , hflags
+    , opaleye
+    , postgresql-simple
+    , saltine
+    , strato-model
+    , text
+  default-language: Haskell2010
+
 executable migrate-keys
   main-is: MigrateKeys.hs
   other-modules:

--- a/strato/vault/server/blockapps-vault-wrapper-server.cabal
+++ b/strato/vault/server/blockapps-vault-wrapper-server.cabal
@@ -104,22 +104,14 @@ executable change-vault-password
   hs-source-dirs:
       app
   build-depends:
-      aeson
-    , base
+      base
     , blockapps-vault-wrapper-api
     , blockapps-vault-wrapper-server
     , bytestring
-    , directory
     , hflags
-    , http-client
-    , http-types
     , opaleye
     , postgresql-simple
-    , process
     , saltine
-    , strato-model
-    , text
-    , unix
   default-language: Haskell2010
 
 executable migrate-keys

--- a/strato/vault/server/package.yaml
+++ b/strato/vault/server/package.yaml
@@ -153,6 +153,23 @@ executables:
       - postgresql-simple
       - saltine
 
+  migrate-key:
+    source-dirs: app
+    main: MigrateKey.hs
+    other-modules: [Options]
+    dependencies:
+      - aeson
+      - base64-bytestring
+      - blockapps-vault-wrapper-api
+      - blockapps-vault-wrapper-server
+      - bytestring
+      - hflags
+      - opaleye
+      - postgresql-simple
+      - saltine
+      - strato-model
+      - text
+
 
 tests:
   vault-wrapper-spec:

--- a/strato/vault/server/src/Strato/Strato23/Monad.hs
+++ b/strato/vault/server/src/Strato/Strato23/Monad.hs
@@ -220,7 +220,7 @@ formatTopLocation ((_, x) : _) = "[" ++ srcLocModule x ++ ":" ++ show (srcLocSta
 -- timeout, RDS Proxy backend switch). Returns False for application errors
 -- such as constraint violations, syntax errors, permission denials, etc.
 isTransientSqlError :: SqlError -> Bool
-isTransientSqlError SqlError {sqlState, sqlErrorMsg} =
+isTransientSqlError SqlError {..} =
   let st = BS.unpack sqlState
       msg = BS.unpack sqlErrorMsg
    in -- SQLSTATE class 08 = connection_exception (always transient)

--- a/strato/vault/server/src/Strato/Strato23/Monad.hs
+++ b/strato/vault/server/src/Strato/Strato23/Monad.hs
@@ -13,19 +13,22 @@
 module Strato.Strato23.Monad where
 
 import BlockApps.Logging
+import Control.Concurrent (threadDelay)
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
 import qualified Crypto.Saltine.Core.SecretBox as SecretBox
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as LB
 import Data.Cache
 import Data.Foldable
+import Data.List (isInfixOf, isPrefixOf)
 import Data.Pool (Pool, withResource)
 import Data.Profunctor.Product.Default
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding
-import Database.PostgreSQL.Simple (Connection, withTransaction)
+import Database.PostgreSQL.Simple (Connection, SqlError (..), withTransaction)
 import GHC.Stack
 import Network.HTTP.Client
 import Opaleye
@@ -212,6 +215,38 @@ formatTopLocation :: [(String, SrcLoc)] -> String
 formatTopLocation [] = "[-]"
 formatTopLocation ((_, x) : _) = "[" ++ srcLocModule x ++ ":" ++ show (srcLocStartLine x) ++ "]"
 
+-- | Decide whether a SqlError represents a transient connection-level failure
+-- that's safe to retry (e.g. Aurora failover, dropped connection from idle
+-- timeout, RDS Proxy backend switch). Returns False for application errors
+-- such as constraint violations, syntax errors, permission denials, etc.
+isTransientSqlError :: SqlError -> Bool
+isTransientSqlError SqlError {sqlState, sqlErrorMsg} =
+  let st = BS.unpack sqlState
+      msg = BS.unpack sqlErrorMsg
+   in -- SQLSTATE class 08 = connection_exception (always transient)
+      "08" `isPrefixOf` st
+        -- 57P01 admin_shutdown (Aurora failover), 57P02 crash_shutdown,
+        -- 57P03 cannot_connect_now
+        || st `elem` ["57P01", "57P02", "57P03"]
+        -- Defensive substring matches for cases where SQLSTATE may be empty
+        || "server closed the connection unexpectedly" `isInfixOf` msg
+        || "terminating connection due to administrator command" `isInfixOf` msg
+        || "could not connect to server" `isInfixOf` msg
+
+-- | Retry an IO action on transient SQL errors with exponential backoff.
+-- Delays (microseconds): 50ms, 200ms, 1s. After the final attempt the error
+-- is re-raised unchanged. Non-transient errors are re-raised immediately
+-- without any retry.
+withSqlRetry :: IO a -> IO a
+withSqlRetry = go [50000, 200000, 1000000]
+  where
+    go [] action = action
+    go (delay : rest) action =
+      action `catch` \(e :: SqlError) ->
+        if isTransientSqlError e
+          then threadDelay delay >> go rest action
+          else throwIO e
+
 vaultQuery ::
   (HasCallStack, Default Unpackspec x x, Default FromFields x y) =>
   Query x ->
@@ -219,7 +254,7 @@ vaultQuery ::
 vaultQuery q = do
   traverse_ (logDebugCS callStack . Text.pack) (showSql q)
   pool <- asks dbPool
-  liftIO $ withResource pool (\conn -> runSelect conn q)
+  liftIO $ withSqlRetry $ withResource pool (\conn -> runSelect conn q)
 
 vaultQueryMaybe ::
   (HasCallStack, Default Unpackspec x x, Default FromFields x y) =>
@@ -254,7 +289,7 @@ vaultModify :: HasCallStack => (Connection -> IO x) -> VaultM x
 vaultModify modify = do
   logInfoCS callStack "Updating the database"
   pool <- asks dbPool
-  liftIO $ withResource pool modify
+  liftIO $ withSqlRetry $ withResource pool modify
 
 vaultModify1 :: HasCallStack => (Connection -> IO [x]) -> VaultM x
 vaultModify1 modify = do
@@ -269,7 +304,7 @@ vaultTransaction :: VaultM x -> VaultM x
 vaultTransaction vaultAction = do
     pool <- asks dbPool
     env  <- ask
-    liftIO $ withResource pool $ \conn -> withTransaction conn (runLoggingT (runReaderT vaultAction env))
+    liftIO $ withSqlRetry $ withResource pool $ \conn -> withTransaction conn (runLoggingT (runReaderT vaultAction env))
 
 vaultMaybe :: Text -> Maybe x -> VaultM x
 vaultMaybe msg = maybe (throwIO (CouldNotFind msg)) return

--- a/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
@@ -23,10 +23,7 @@ postSignature userName (MsgHash msgBS) = do
   (_, nonce, pKey, _) <- case cachedPk of
     Just (KeyStore a b c d) -> pure (a, b, c, d)
     Nothing -> do
-      mpk <-
-        vaultTransaction
-          . vaultQueryMaybe
-          $ getUserKeyQuery userName
+      mpk <- vaultQueryMaybe $ getUserKeyQuery userName
       (a, b, c, d) <- case mpk of
         Just pk -> return pk
         Nothing -> vaultWrapperError $ UserError ("User " <> userName <> " doesn't exist")
@@ -45,10 +42,7 @@ postSignature' userName oauthProvider (MsgHash msgBS) = do
   (_, nonce, pKey, _) <- case cachedPk of
     Just (KeyStore a b c d) -> pure (a, b, c, d)
     Nothing -> do
-      mpk <-
-        vaultTransaction
-          . vaultQueryMaybe
-          $ getUserKeyQuery' userName oauthProvider
+      mpk <- vaultQueryMaybe $ getUserKeyQuery' userName oauthProvider
       (a, b, c, d) <- case mpk of
         Just pk -> return pk
         Nothing -> vaultWrapperError $ UserError ("User " <> userName <> " doesn't exist")

--- a/strato/vault/vault-runner/README.md
+++ b/strato/vault/vault-runner/README.md
@@ -72,23 +72,13 @@ from the BlockApps shared Vault to your local vault). See the
 This is an example process to update the Vault password with minimal (2-3 seconds) downtime. The process requires decrypting and re-encrypting the values in database. Proceed carefully.
 
 ### Build and prepare
-```
-cd strato-platform/strato/
-# here install dependencies if needed, using ../install_deps.sh
-stack build blockapps-vault-wrapper-server:exe:change-vault-password
-stack --local-bin-path ~/.local/bin/ install  blockapps-vault-wrapper-server:exe:change-vault-password
-sudo docker cp /home/ec2-user/.local/bin/change-vault-password vault-vault-wrapper-1:/usr/local/bin/change-vault-password
-sudo docker exec vault-vault-wrapper-1 chmod 755 /usr/local/bin/change-vault-password
-```
 
-Copy the required dynamically linked libs (secp256k1, libsodium) into docker container:
+Build on Ubuntu 24.04 to match the vault-wrapper container's base image (for dynamicly linked libraries to work).
 ```
-ldd "$(which change-vault-password)" | grep -E 'libsecp256k1|libsodium' | awk '{print $3}' | while read so; do
-  # resolve symlinks to get the real file
-  real=$(readlink -f "$so")
-  echo "copying $real as $(basename $so)"
-  sudo docker cp "$real" vault-vault-wrapper-1:/usr/local/lib/$(basename $so)
-done
+set -e
+make change-vault-password
+sudo docker cp ~/.local/bin/change-vault-password vault-vault-wrapper-1:/usr/local/bin/change-vault-password
+sudo docker exec vault-vault-wrapper-1 chmod 755 /usr/local/bin/change-vault-password
 ```
 
 ### Backup DB
@@ -115,11 +105,14 @@ sudo docker exec -i \
     --pguser=postgres --password=api --database=oauth
 #
 sudo docker restart -t 0 vault-vault-wrapper-1
-cd strato-getting-started
-
-
-# sudo PASSWORD="${NEW_PASSWORD}" ./vault --set-password
+for i in {1..200}; do
+  if curl --fail -sS -o /dev/null --insecure https://localhost:8093/ping 2>/dev/null; then
+    break
+  fi
+done
 sudo docker exec -i vault-vault-wrapper-1 curl -s -H "Content-Type: application/json" -d @- localhost:8000/strato/v2.3/password <<< \"$NEW_PASSWORD\"
+echo 
+echo "If you see [] above - that's the success. Otherwise repeat the last command in the script"
 ```
 
 Run it:
@@ -141,55 +134,46 @@ rm -rf update-password.sh
     ```
     sudo docker stop vault-vault-wrapper-1
     ```
-
 2. Terminate connections to oauth.
     ```
     sudo docker exec vault-postgres-1 psql -U postgres -d postgres -c \
     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'oauth' AND pid <> pg_backend_pid();"`
     ```
-
 3. Drop the database.
     ```sudo docker exec vault-postgres-1 psql -U postgres -d postgres -c \
     "DROP DATABASE IF EXISTS oauth;"
    ```
-
 4. Recreate it.
     ```
     sudo docker exec vault-postgres-1 psql -U postgres -d postgres -c \
     "CREATE DATABASE oauth OWNER postgres;"
     ```
-
 5. Restore the dump. Execute from the directory with `vault-dump-file.sql` file:
     ```
     sudo docker exec -i vault-postgres-1 \
     psql -U postgres -d oauth \
     < vault-dump-file.sql
     ```
-
 6. Sanity check.
     ```
     sudo docker exec vault-postgres-1 psql -U postgres -d oauth -c \
     "SELECT (SELECT count(*) FROM users) AS users, (SELECT count(*) FROM message) AS message;"
     ```
-
 7. Start the vault.
     ```
     sudo docker start vault-vault-wrapper-1
     ```
-
 8. POST the old password.
     ```
     sudo ./enter-password.sh
     # > enter the old password
     ```
-
 9. Verify.
     ```
     sudo docker exec vault-vault-wrapper-1 \
     curl -sf http://localhost:8000/strato/v2.3/verify-password`
     # Expected: true
     ```
-
 
 ---
 
@@ -264,8 +248,7 @@ SRC_VAULT_PW=...      # current source-vault password
 TRANSPORT_PW=...      # one-time password used only to protect the file in transit
 
 printf '%s\n%s\n' "$SRC_VAULT_PW" "$TRANSPORT_PW" \
-| sudo docker exec -i vault-vault-wrapper-1 \
-    /usr/local/bin/migrate-key \
+  | sudo docker exec -i vault-vault-wrapper-1 /usr/local/bin/migrate-key \
       --x_user_unique_name='alice@example.com' \
       --x_identity_provider_id='https://my-oauth.example.com' \
       --out=/tmp/alice.key.json
@@ -289,9 +272,7 @@ DST_VAULT_PW=...      # destination-vault password
 sudo docker cp ./alice.key.json vault-vault-wrapper-1:/tmp/alice.key.json
 
 printf '%s\n%s\n' "$TRANSPORT_PW" "$DST_VAULT_PW" \
-| sudo docker exec -i vault-vault-wrapper-1 \
-    /usr/local/bin/migrate-key \
-      --in=/tmp/alice.key.json
+  | sudo docker exec -i vault-vault-wrapper-1 /usr/local/bin/migrate-key --in=/tmp/alice.key.json
 # Connection settings come from the container's env vars (postgres_host etc.).
 # If the destination vault uses a different host/user/password/db that is NOT
 # already in the vault-wrapper container's environment, pass the flags

--- a/strato/vault/vault-runner/README.md
+++ b/strato/vault/vault-runner/README.md
@@ -48,8 +48,9 @@ strato-up mynode \
 
 ### Key migration
 
-You may want to migrate the existing keys from BlockApps shared Vault to you local vault.
-> TODO: Steps are TBD.
+You may want to migrate a specific user's key from one Vault instance to another (for example,
+from the BlockApps shared Vault to your local vault). See the
+[Migrating a single key between Vaults](#migrating-a-single-key-between-vaults) section below.
 
 ### Killing the Vault
 
@@ -188,3 +189,129 @@ rm -rf update-password.sh
     curl -sf http://localhost:8000/strato/v2.3/verify-password`
     # Expected: true
     ```
+
+
+---
+
+
+## Migrating a single key between Vaults
+
+The `migrate-key` tool moves a specific user's key from one Vault instance to another
+(different Postgres DB, different vault password) without ever writing the plaintext private
+key to disk. It runs in two modes selected by `--out` vs `--in`:
+
+1. `--out=<path>` (**export**): on the **source** vault, decrypt the user's key with the
+   source vault password and re-encrypt it under a one-time **transport password**. Writes
+   a JSON envelope to `<path>`.
+2. `--in=<path>` (**import**): on the **destination** vault, decrypt the envelope with the
+   transport password and re-encrypt under the destination vault password. Inserts a new
+   user row (or, with `--force`, overwrites an existing one).
+
+Both modes read passwords from **stdin** (two lines, newline-separated). Passwords are never
+accepted on the command line or via environment variables, so they do not appear in `ps` or
+in shell history.
+
+- Export reads: line 1 = source vault password, line 2 = transport password.
+- Import reads: line 1 = transport password, line 2 = destination vault password.
+
+### Postgres connection settings
+
+Postgres connection settings are resolved with the standard CLI > env > default
+precedence:
+
+1. **CLI flag** if explicitly passed: `--pghost`, `--pgport`, `--pguser`,
+   `--password`, `--database`.
+2. **Environment variable** (the same names the vault-wrapper daemon already
+   reads from `docker-compose.vault.yml`):
+   - `postgres_host`
+   - `postgres_port`
+   - `postgres_user`
+   - `postgres_password`
+   - `postgres_vault_wrapper_db`
+3. **Default** if neither is set: `postgres` / `5432` / `postgres` / `api` /
+   `oauth`.
+
+When running `migrate-key` via `docker exec` inside a `vault-wrapper-*`
+container, those env vars are already set by the compose file, so on the
+destination vault you usually don't need any `--pghost`/`--pguser`/`--password`/
+`--database` flags even if the destination vault uses non-default settings.
+
+### Build and prepare
+
+Build on the source host, install into both vault-wrapper containers (source and destination)
+the same way as `change-vault-password` above:
+```
+cd strato-platform/strato/
+stack build blockapps-vault-wrapper-server:exe:migrate-key
+stack --local-bin-path ~/.local/bin/ install blockapps-vault-wrapper-server:exe:migrate-key
+sudo docker cp ~/.local/bin/migrate-key vault-vault-wrapper-1:/usr/local/bin/migrate-key
+sudo docker exec vault-vault-wrapper-1 chmod 755 /usr/local/bin/migrate-key
+```
+Copy the required dynamically linked libs (secp256k1, libsodium):
+```
+ldd "$(which migrate-key)" | grep -E 'libsecp256k1|libsodium' | awk '{print $3}' | while read so; do
+  real=$(readlink -f "$so")
+  echo "copying $real as $(basename $so)"
+  sudo docker cp "$real" vault-vault-wrapper-1:/usr/local/lib/$(basename $so)
+done
+```
+Repeat the two `docker cp` steps on the destination host's vault-wrapper container.
+
+### Export the key from the source vault
+
+```
+SRC_VAULT_PW=...      # current source-vault password
+TRANSPORT_PW=...      # one-time password used only to protect the file in transit
+
+printf '%s\n%s\n' "$SRC_VAULT_PW" "$TRANSPORT_PW" \
+| sudo docker exec -i vault-vault-wrapper-1 \
+    /usr/local/bin/migrate-key \
+      --x_user_unique_name='alice@example.com' \
+      --x_identity_provider_id='https://my-oauth.example.com' \
+      --out=/tmp/alice.key.json
+# Inside the vault-wrapper container, $postgres_host/$postgres_user/$postgres_password
+# /$postgres_vault_wrapper_db are already set by docker-compose.vault.yml, so
+# migrate-key picks them up automatically. To override, pass --pghost / --pguser /
+# --password / --database / --pgport explicitly.
+
+sudo docker cp vault-vault-wrapper-1:/tmp/alice.key.json ./alice.key.json
+sudo docker exec vault-vault-wrapper-1 rm -f /tmp/alice.key.json
+```
+
+Move `alice.key.json` to the destination host (e.g. `scp`).
+
+### Import the key into the destination vault
+
+```
+TRANSPORT_PW=...      # same one-time password used during export
+DST_VAULT_PW=...      # destination-vault password
+
+sudo docker cp ./alice.key.json vault-vault-wrapper-1:/tmp/alice.key.json
+
+printf '%s\n%s\n' "$TRANSPORT_PW" "$DST_VAULT_PW" \
+| sudo docker exec -i vault-vault-wrapper-1 \
+    /usr/local/bin/migrate-key \
+      --in=/tmp/alice.key.json
+# Connection settings come from the container's env vars (postgres_host etc.).
+# If the destination vault uses a different host/user/password/db that is NOT
+# already in the vault-wrapper container's environment, pass the flags
+# explicitly, e.g.:
+#     --pghost=my-pg-host --pguser=myuser --password=mypass --database=mydb
+
+sudo docker exec vault-vault-wrapper-1 rm -f /tmp/alice.key.json
+rm -f ./alice.key.json
+```
+
+If a user with the same `(x_user_unique_name, x_identity_provider_id)` already exists in the
+destination DB, the import aborts. Pass `--force` to overwrite the existing row.
+
+### Safety properties
+
+- The plaintext private key only exists in process memory during the run; it is never written
+  to disk in either mode.
+- The transport file is unreadable without the transport password (NaCl SecretBox / scrypt).
+- On both ends the tool verifies that the decrypted private key derives the same Ethereum
+  address that was recorded on the source side; any mismatch aborts before any DB write.
+- The import runs in a serializable transaction; any failure rolls back with no changes.
+- Both vault passwords are validated against the canonical message row before the tool will
+  touch the `users` table.


### PR DESCRIPTION
This PR is well-tested and good to go to develop. It contains:
- [TESTED] change-vault-password tool 
  - Update password flow: re-encrypt all rows and message, restart vault-wrapper, set new password)
- [TESTED] migrate-key tool
  - Key migration flow: 
    - extract key from a source vault (params: out file path, vault password, tmp transport password, x-user-unique-name (+optionally postgres db connection vars))
    - inject key to target vault (params: in file path, target vault password, tmp transport password (+optionally postgres db connection vars))
- [TESTED] Critical fix to vault PG connection management - to avoid the the db connection pool deadlock that under load was putting the vault into state when it's unable to connect to postgres, eventually crashing ALL nodes connected to the vault (detailed description below)




---
deadlock state description

> Symptom: Under ~2000 parallel calls in a load test, the service kept reporting healthy on /_ping but every DB-backed endpoint hung forever. nginx returned 504s.
> 
> Root cause: vaultTransaction in Monad.hs acquired a connection from the pool via withResource, then ran nested VaultM actions inside (vaultQueryMaybe) that went back to the same pool to acquire a second connection. Each transaction therefore needed 2 connections held simultaneously. With the pool size of 20, once 20 threads entered vaultTransaction concurrently and held every connection as an "outer" slot, none could ever acquire the "inner" slot they were waiting for — classic resource-ordering deadlock with no acquisition timeout. The Signature endpoint was the only caller and triggered this on every cache-miss.
> 
> As a bonus, the withTransaction was a no-op for correctness anyway: the BEGIN/COMMIT ran on connection A while the SELECT it was supposedly wrapping ran on connection B, so the query was never actually inside the transaction. Even if it had been, a single SELECT doesn't need an explicit transaction.
> 
> Fix: Removed the unnecessary vaultTransaction . wrap from both signature handler call sites. Signature requests now hold one pool connection briefly for the SELECT (when not served from cache) instead of two held simultaneously. No semantic change — the transaction was a no-op.
    