### PR TITLE
optimized  /lending/collateral and  /lending/collateral/public

### DIFF
--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -4,7 +4,7 @@ import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx, until } from "../../utils/txHelper";
 import { StratoPaths, constants } from "../../config/constants";
 import * as config from "../../config/config";
-import { getBalance, getTokens, getTokenBalanceForUser } from "./tokens.service";
+import { getTokens, getTokenBalanceForUser } from "./tokens.service";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
 import {
@@ -445,10 +445,67 @@ export const repay = async (
   return { ...result, amountSent: amount };
 };
 
+// --- Collateral-specific caches ---
+const STATIC_CACHE_TTL = 3_600_000; // 1hr — token metadata (name, symbol, decimals, images)
+const COLLATERAL_CACHE_TTL = 30_000; // 30s — asset list, public response
+
+// Collateral asset addresses from assetConfigs — changes only on admin action (30s)
+let _collateralAssets: { list: string[]; expiresAt: number } | null = null;
+
+// Token metadata — name/symbol/decimals/images are static (1hr)
+let _collateralTokenMeta: Map<string, Record<string, any>> | null = null;
+let _collateralTokenMetaExpiry = 0;
+
+// Public collateral endpoint full response cache (30s)
+let _publicCollateralCache: { data: any; expiresAt: number } | null = null;
+
+// Direct Cirrus fetch for collateral tokens — bypasses getTokens()/getBalance() hidden overhead
+const getCollateralTokenData = async (
+  accessToken: string,
+  tokenAddresses: string[],
+  userAddress?: string
+): Promise<any[]> => {
+  if (!tokenAddresses.length) return [];
+  const metaCached = _collateralTokenMeta && Date.now() < _collateralTokenMetaExpiry
+    && tokenAddresses.every(a => _collateralTokenMeta!.has(a));
+
+  const balJoin = userAddress ? `,balances:${Token}-_balances(user:key,balance:value::text)` : '';
+  const select = metaCached
+    ? `address,_totalSupply::text${balJoin}`
+    : `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,images:${Token}-images(value)${balJoin}`;
+
+  const params: Record<string, string> = { address: `in.(${tokenAddresses.join(",")})`, select };
+  if (userAddress) params["balances.key"] = `eq.${userAddress}`;
+
+  const { data } = await cirrus.get(accessToken, `/${Token}`, { params });
+  const tokens = data || [];
+
+  if (metaCached) {
+    return tokens.map((t: any) => ({ ...(_collateralTokenMeta!.get(t.address) || {}), ...t }));
+  }
+
+  _collateralTokenMeta = _collateralTokenMeta || new Map();
+  for (const t of tokens) {
+    _collateralTokenMeta.set(t.address, {
+      _name: t._name, _symbol: t._symbol, _owner: t._owner,
+      customDecimals: t.customDecimals, images: t.images
+    });
+  }
+  _collateralTokenMetaExpiry = Date.now() + STATIC_CACHE_TTL;
+  return tokens;
+};
+
 export const collateralAndBalance = async (
   accessToken: string,
   userAddress: string,
 ) => {
+  const startedAt = performance.now();
+
+  // Speculatively fetch token data using cached asset list (parallel with getPool)
+  const cachedAssets = _collateralAssets && Date.now() < _collateralAssets.expiresAt ? _collateralAssets.list : null;
+  const earlyTokenFetch = cachedAssets
+    ? getCollateralTokenData(accessToken, cachedAssets, userAddress) : null;
+
   const registry = await getPool(accessToken, {
     select:
       `lendingPool:lendingPool_fkey(` +
@@ -468,35 +525,37 @@ export const collateralAndBalance = async (
   }
 
   const isPaused = registry.lendingPool._paused;
-
   const assets = registry.lendingPool.assetConfigs?.map((a: any) => a.asset).filter((asset: string) => asset !== registry.lendingPool.borrowableAsset) || [];
   const userCollaterals = (registry.collateralVault.userCollaterals || []).filter((c: any) => c.user === userAddress);
-  const userTokens = await getBalance(accessToken, userAddress, {
-    address: `in.(${assets.join(",")})`, select: `address,user:key,balance:value::text,token:${Token}(_name,_symbol,_owner,_totalSupply::text,customDecimals,images:${Token}-images(value))`
-  });
 
-  const tokenMap = new Map(userTokens.map((t: any) => [t.address, t]));
+  // Update cached asset list (30s)
+  _collateralAssets = { list: assets, expiresAt: Date.now() + COLLATERAL_CACHE_TTL };
+
+  // Use speculative result if asset list matches, else re-fetch
+  const assetsMatch = cachedAssets && assets.length === cachedAssets.length && assets.every((a: string) => cachedAssets.includes(a));
+  const tokenData = (assetsMatch && earlyTokenFetch)
+    ? await earlyTokenFetch
+    : await getCollateralTokenData(accessToken, assets, userAddress);
+
+  // Build token map — balance from sub-select, metadata from Token fields
+  const tokenMap = new Map(tokenData.map((t: any) => {
+    const bal = t.balances?.find((b: any) => b.user === userAddress)?.balance || "0";
+    const { balances: _, ...meta } = t;
+    return [t.address, { address: t.address, balance: bal, token: meta }];
+  }));
   const collateralMap = new Map(userCollaterals.map((c: any) => [c.asset, c]));
 
-  // Create maps for asset configs and prices
   const assetConfigMap = new Map();
   const priceMap = new Map();
-
-  // Build asset config map
   (registry.lendingPool?.assetConfigs || []).forEach((config: any) => {
     assetConfigMap.set(config.asset, config.AssetConfig);
   });
-
-  // Build price map
   (registry.oracle?.prices || []).forEach((price: any) => {
     priceMap.set(price.asset, price.price);
   });
 
-  return assets
-    .filter((asset: string) => {
-      const token = tokenMap.get(asset) as any;
-      return token;
-    })
+  const result = assets
+    .filter((asset: string) => tokenMap.has(asset))
     .map((asset: string) => {
       const token = tokenMap.get(asset) as any;
       const collateral = collateralMap.get(asset) as any;
@@ -508,7 +567,6 @@ export const collateralAndBalance = async (
       const ltv = assetConfig?.ltv || 0;
       const liquidationThreshold = assetConfig?.liquidationThreshold || 0;
 
-      // Calculate metrics using the helper function
       const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower, unsuppliedBorrowingPower, unsuppliedLTCollateralValue} = calculateCollateralMetrics(
         userBalance,
         collateralizedAmount,
@@ -535,11 +593,27 @@ export const collateralAndBalance = async (
         isPaused,
       };
     });
+
+  console.log(`[lending/collateral] total response time: ${(performance.now() - startedAt).toFixed(2)}ms`);
+  return result;
 };
 
 export const getPublicCollateralInfo = async (
   accessToken: string,
 ) => {
+  const startedAt = performance.now();
+
+  // Full response cache — all public collateral data is global (30s)
+  if (_publicCollateralCache && Date.now() < _publicCollateralCache.expiresAt) {
+    console.log(`[lending/collateral/public] total response time: ${(performance.now() - startedAt).toFixed(2)}ms (cached)`);
+    return _publicCollateralCache.data;
+  }
+
+  // Parallelize getPool + token fetch using cached asset list
+  const cachedAssets = _collateralAssets && Date.now() < _collateralAssets.expiresAt ? _collateralAssets.list : null;
+  const earlyTokenFetch = cachedAssets
+    ? getCollateralTokenData(accessToken, cachedAssets) : null;
+
   const registry = await getPool(accessToken, {
     select:
       `lendingPool:lendingPool_fkey(` +
@@ -557,38 +631,30 @@ export const getPublicCollateralInfo = async (
 
   const isPaused = registry.lendingPool._paused;
   const assets = registry.lendingPool.assetConfigs?.map((a: any) => a.asset).filter((asset: string) => asset !== registry.lendingPool.borrowableAsset) || [];
-  
-  // Fetch token metadata only (no user balances)
-  let tokenMap = new Map();
-  if (assets.length > 0) {
-    const tokens = await getTokens(accessToken, {
-      address: `in.(${assets.join(",")})`,
-      select: `address,_name,_symbol,_owner,_totalSupply::text,customDecimals,images:${Token}-images(value)`
-    });
-    tokenMap = new Map(tokens.map((t: any) => [t.address, { address: t.address, balance: "0", token: t }]));
-  }
 
-  // Create maps for asset configs and prices
+  // Update cached asset list (30s)
+  _collateralAssets = { list: assets, expiresAt: Date.now() + COLLATERAL_CACHE_TTL };
+
+  // Use speculative result if asset list matches, else re-fetch
+  const assetsMatch = cachedAssets && assets.length === cachedAssets.length && assets.every((a: string) => cachedAssets.includes(a));
+  const tokenData = (assetsMatch && earlyTokenFetch)
+    ? await earlyTokenFetch
+    : await getCollateralTokenData(accessToken, assets);
+
+  const tokenMap = new Map(tokenData.map((t: any) => [t.address, t]));
+
   const assetConfigMap = new Map();
   const priceMap = new Map();
-
-  // Build asset config map
   (registry.lendingPool?.assetConfigs || []).forEach((config: any) => {
     assetConfigMap.set(config.asset, config.AssetConfig);
   });
-
-  // Build price map
   (registry.oracle?.prices || []).forEach((price: any) => {
     priceMap.set(price.asset, price.price);
   });
 
-  // Filter assets that have token data
-  const filteredAssets = assets.filter((asset: string) => {
-      const token = tokenMap.get(asset) as any;
-      return token;
-  });
-
-  const result = filteredAssets.map((asset: string) => {
+  const result = assets
+    .filter((asset: string) => tokenMap.has(asset))
+    .map((asset: string) => {
       const token = tokenMap.get(asset) as any;
       const assetConfig = assetConfigMap.get(asset);
       const assetPrice = priceMap.get(asset) || "0";
@@ -598,7 +664,6 @@ export const getPublicCollateralInfo = async (
       const ltv = assetConfig?.ltv || 0;
       const liquidationThreshold = assetConfig?.liquidationThreshold || 0;
 
-      // Calculate metrics using the helper function (all zeros for guests)
       const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower, unsuppliedBorrowingPower, unsuppliedLTCollateralValue} = calculateCollateralMetrics(
         userBalance,
         collateralizedAmount,
@@ -609,7 +674,7 @@ export const getPublicCollateralInfo = async (
 
       return {
         address: asset,
-        ...token?.token,
+        ...token,
         userBalance,
         userBalanceValue,
         collateralizedAmount,
@@ -626,6 +691,8 @@ export const getPublicCollateralInfo = async (
       };
     });
 
+  _publicCollateralCache = { data: result, expiresAt: Date.now() + COLLATERAL_CACHE_TTL };
+  console.log(`[lending/collateral/public] total response time: ${(performance.now() - startedAt).toFixed(2)}ms`);
   return result;
 };
 


### PR DESCRIPTION
## Summary

Optimizes `GET /api/lending/collateral` and `GET /api/lending/collateral/public` response times by eliminating hidden network call overhead and introducing targeted caching.

## Problem

Both endpoints relied on generic helper functions (`getBalance()` and `getTokens()`) from `tokens.service.ts` which internally make **4+ redundant network calls** per request:
- `getLendingRegistry()` — redundant, already fetched via `getPool()`
- `getCompletePriceMap()` — redundant, oracle prices already in `getPool()` response
- `CollateralVault` query — redundant, collateral data already in `getPool()`
- `CDPEngine-vaults` query — unnecessary for collateral endpoints



### New Helper: `getCollateralTokenData()`
Replaces both `getBalance()` and `getTokens()` with a **single direct Cirrus query** to the `Token` table for only the collateral tokens (e.g. wstETH, rETH). Includes optional user balance sub-select when needed.

### Caches Introduced

| Cache | TTL | What it stores |
|---|---|---|
| `_collateralTokenMeta` | **1 hour** | Token metadata — name, symbol, decimals, images (static, only changes on contract redeploy) |
| `_collateralAssets` | **30 seconds** | Collateral asset address list from `assetConfigs` (changes only on admin action) |
| `_publicCollateralCache` | **30 seconds** | Full public endpoint response (all data is global, no user-specific info) |

### `/api/lending/collateral` (authenticated)
- Replaced `getBalance()` (4+ network calls) → `getCollateralTokenData()` (1 Cirrus call)
- **Parallelized**: token fetch runs alongside `getPool()` using cached asset list (speculative fetch — verifies addresses match after `getPool` returns, re-fetches if mismatch)
- User balances, collateral amounts, oracle prices — **always fetched live**

### `/api/lending/collateral/public` (guest)
- **30s full response cache** — instant return on warm cache
- Replaced `getTokens()` (hidden `getPool + getCompletePriceMap`) → `getCollateralTokenData()` (1 Cirrus call)
- **Parallelized**: token fetch runs alongside `getPool()` using cached asset list

### Other
- Added `console.log` for response time measurement on both endpoints

## Data Classification

| Data | Type | Caching |
|---|---|---|
| Token name, symbol, decimals, images | Static | 1hr cache |
| Collateral asset address list | Slow-changing | 30s cache |
| Public endpoint full response | Global | 30s cache |
| User wallet balances | Live | Never cached |
| User collateral amounts | Live | Never cached |
| Oracle prices | Live | Never cached |
| Pool pause status | Live | Never cached |


## Performance Results

### `GET /api/lending/collateral/public`

| Flow | Tested | Localhost Before | Localhost After | Workspace Before | Workspace After |
|---|---|---|---|---|---|
| Anonymous flow | Yes | 1500ms | 0.1ms | 1.72s | 1s |
| STRATO OAuth flow | Yes | 3576ms | 0.01ms | 5.4s | 2s |
| MetaMask Wallet Connect flow | Yes | 3209ms | 0.01ms | 2.44s | 1.28s |
| Both flows | Yes | - | - | - | - |

### `GET /api/lending/collateral`

| Flow | Tested | Localhost Before | Localhost After | Workspace Before | Workspace After |
|---|---|---|---|---|---|
| Anonymous flow | Yes | - | - | - | - |
| STRATO OAuth flow | Yes | 5571ms | 258ms | 5.55s | 3s |
| MetaMask Wallet Connect flow | Yes | 2209ms | 246ms | 2.63s | 2s |
| Both flows | Yes | - | - | - | - |