### PR TITLE
force legacy transaction type for transfers

### DIFF
--- a/mercata/ui/src/pages/Transfer.tsx
+++ b/mercata/ui/src/pages/Transfer.tsx
@@ -162,6 +162,8 @@ const Transfer = () => {
           args: [ensureHexPrefix(recipient), BigInt(weiValue)],
           nonce: Number(nonce),
           gas: 1000000n,
+          type: "legacy",
+          gasPrice: 0n,
         });
       }
 


### PR DESCRIPTION
## Summary
- Force MetaMask token transfers to use a legacy (type-0) transaction in `Transfer.tsx` by setting `type: "legacy"` and `gasPrice: 0n`.
- STRATO's JSON-RPC/RLP decoder only supports legacy txs; an EIP-1559 (`0x02`) tx crashes `eth_sendRawTransaction` with no response, surfacing to users as "RPC submit: RPC endpoint not found or unavailable". MetaMask's per-chain EIP-1559 cache made this fail for some users/nodes and not others.
- This is a client-side fix. The proper long-term fix is node-side (EIP-2718 typed-tx support, plus returning a graceful error instead of hard-crashing the request) — worth a follow-up issue, but out of scope for this PR.

## Test plan
- [x] As a MetaMask user, transfer a token on a STRATO node and confirm it succeeds (no RPC error).
- [ ] Confirm the submitted raw tx is type-0 (not `0x02`-prefixed) in the node JSON-RPC logs.
- [x] Regression: STRATO Wallet (vault) transfers and swaps still work.