### PR TITLE
A more detailed public /health

### DIFF
--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -119,8 +119,33 @@ module.exports = {
   healthStatus: async function (req, res, next) {
     try {
       let health = null, uptime = null, healthStatus = null, healthIssues = [], healthData = null;
-      const [healthInfo, stallInfo, systemInfo, syncInfo] =
-        await utils.getLatestHealth();
+      const [
+        [healthInfo, stallInfo, systemInfo, syncInfo],
+        lastBlock,
+        bestBlockNumber,
+        pbftData,
+        nodeAddress,
+      ] = await Promise.all([
+        utils.getLatestHealth(),
+        BlockDataRef.findOne({
+          where: {
+            pow_verified: true,
+            is_confirmed: true,
+          },
+          order: [["number", "DESC"]],
+          attributes: ["number", "hash", "parent_hash", "nonce"],
+          raw: true,
+        }),
+        // Source `lastBlock.number` from the same place as `strato-barometer syncstats`
+        // (used by `bin/strato-ps`): the BestBlock entry in Redis. Falls back to
+        // BlockDataRef.number if Redis is unavailable.
+        redisBlockDB.getBestBlockNumber().catch((err) => {
+          winston.warn(`Falling back to BlockDataRef for lastBlock.number: ${err.message}`);
+          return null;
+        }),
+        getPbftData(),
+        getNodeAddress(),
+      ]);
 
       if (healthInfo && stallInfo && systemInfo && syncInfo) {
         ({ health, uptime, healthStatus, healthIssues, healthData } = utils.consolidateHealthData(
@@ -139,6 +164,14 @@ module.exports = {
         apiVersion: API_VERSION,
         version: process.env.STRATO_VERSION,
         timestamp: new Date().toISOString(),
+        nodeAddress,
+        lastBlock: {
+          number: bestBlockNumber !== null ? bestBlockNumber : lastBlock.number,
+          hash: lastBlock.hash,
+          parentHash: lastBlock.parent_hash,
+          nonce: lastBlock.nonce,
+        },
+        pbftData: findView(pbftData),
         health: health,
         healthStatus: healthStatus,
         healthIssues: healthIssues,
@@ -153,21 +186,44 @@ module.exports = {
   },
 };
 
-// Fetches the node's blockchain (coinbase) address from strato-api.
-// Returns null if the call fails so /status remains usable.
+// Fetches the node's own blockchain address from Prometheus.
+// The address is carried in the `address` label of the `pbft_node_identity`
+// metric, which the blockstanbul consensus layer emits once it has resolved
+// the node identity (from Vault). Returns null if unavailable so /status
+// remains usable.
 async function getNodeAddress() {
   try {
-    return await rp({
+    if (!process.env["PROMETHEUS_HOST"]) {
+      throw Error(
+        "PROMETHEUS_HOST env var is not set - unable to get prometheus data"
+      );
+    }
+    const resp = await rp({
       method: "GET",
-      uri: `${process.env.stratoRoot}/coinbase`,
-      json: true,
-      timeout: config.healthCheck.requestTimeout - 100,
+      url: `http://${process.env["PROMETHEUS_HOST"]}/prometheus/api/v1/query?query=pbft_node_identity`,
       followRedirects: false,
+      timeout: config.healthCheck.requestTimeout - 100,
+      json: true,
     });
+    return findNodeAddress(resp);
   } catch (err) {
-    winston.warn(`Unable to fetch node coinbase address: ${err.message}`);
+    winston.warn(`Unable to fetch node address: ${err.message}`);
     return null;
   }
+}
+
+// Extracts the node address from a Prometheus `pbft_node_identity` query
+// response. The address lives in the `address` label; returns it with a 0x
+// prefix, or null if not present.
+function findNodeAddress(obj) {
+  if (!(obj && obj.data && obj.data.result && obj.data.result.length)) {
+    return null;
+  }
+  const elem = obj.data.result.find((e) => e && e.metric && e.metric.address);
+  if (!elem) {
+    return null;
+  }
+  return `0x${elem.metric.address}`;
 }
 
 function getPbftData() {

--- a/apex/api/sockets/aggregators/getCoinbase.js
+++ b/apex/api/sockets/aggregators/getCoinbase.js
@@ -1,34 +1,16 @@
-const _ = require('underscore');
 const { GET_COINBASE } = require('../rooms')
-const { emitter, ON_SOCKET_PUBLISH_EVENTS } = require('../eventBroker')
-var rp = require('request-promise');
 
 let coinbase
 
-const options = {
-  uri: `${process.env['stratoRoot']}/coinbase`,
-  json: true
-}
-
-function getCoinbase() {
-  rp(options)
-    .then(function (currentCoinbase) {
-      if (!_.isEqual(coinbase, currentCoinbase)) {
-        console.log("currentCoinbase", currentCoinbase);
-        coinbase = currentCoinbase
-        emitter.emit(ON_SOCKET_PUBLISH_EVENTS, GET_COINBASE, currentCoinbase)
-      }
-    })
-    .catch(function (err) {
-      console.error("Error: ", err);
-      throw err
-    });
-}
-
-getCoinbase()
-// coinbase shouldnt (or cant as of now) change without restarting strato
-// No need to poll for this right now.
-// setInterval(getCoinbase, 3000)
+// DISABLED: the strato-api `/coinbase` endpoint was removed, so this
+// aggregator can no longer fetch the node address from strato. The node
+// address is now surfaced via apex's /status and /health endpoints
+// (sourced from the `pbft_node_identity` Prometheus metric). The socket
+// room/hydrate wiring is left intact so existing subscribers don't break;
+// `coinbase` simply stays undefined.
+//
+// function getCoinbase() { ... } // removed: called dead `${stratoRoot}/coinbase`
+// getCoinbase()
 
 
 function initialHydrate(socket) {

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -454,6 +454,7 @@ sendMessages' wms = do
   putBlockstanbulContext ctx'
 
   recordValidator (_isValidator ctx') (_validatorBehavior ctx')
+  forM_ (_selfAddr ctx') $ recordNodeIdentity . T.pack . formatAddressWithoutColor
 
   return evs
 

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
@@ -51,6 +51,20 @@ recordValidator iv vb = liftIO $ do
   withLabel validatorView "is_validator" (`setGauge` (f iv))
   withLabel validatorView "validator_behavior" (`setGauge` (f vb))
 
+{-# NOINLINE nodeIdentity #-}
+nodeIdentity :: Vector Text Gauge
+nodeIdentity =
+  unsafeRegister
+    . vector "address"
+    . gauge
+    $ Info "pbft_node_identity" "This node's own blockchain address, carried in the 'address' label (value is always 1.0)"
+
+-- | Record this node's own address as a Prometheus gauge. The address is the
+-- 40-char hex string (no 0x prefix) carried in the 'address' label; the gauge
+-- value is always 1.0. Apex reads the label to surface the node address.
+recordNodeIdentity :: MonadIO m => Text -> m ()
+recordNodeIdentity addr = liftIO $ withLabel nodeIdentity addr (`setGauge` 1.0)
+
 {-# NOINLINE authResults #-}
 authResults :: Vector Text Counter
 authResults =


### PR DESCRIPTION
- Expose the node address in /health and /apex-api/status endpoints
- Expose the node-health related non-sensitive blockchain data from /apex-api/status on the /health endpoint (to support the non-oauth nodes using local auth with ory).