### PR TITLE
optimize /earn/yield-vault/:key/info and /user

### DIFF
--- a/mercata/backend/src/api/services/yieldVault.service.ts
+++ b/mercata/backend/src/api/services/yieldVault.service.ts
@@ -1332,17 +1332,26 @@ const computeApy = async (
   }
 };
 
+// Full /info response cache per vault key — all data is global (30s)
+const VAULT_INFO_CACHE_TTL = 30_000;
+const _vaultInfoCache = new Map<string, { data: YieldVaultInfo; expiresAt: number }>();
+
 export const getYieldVaultInfo = async (
   _accessToken: string,
   key: string
 ): Promise<YieldVaultInfo> => {
+  const startedAt = performance.now();
   const def = resolveVaultDef(key);
   const fallback = emptyInfo(def, key);
   if (!def?.address) return fallback;
 
-  // All vault-level reads use the service token so every caller sees the same
-  // public state (deployedAssets, _underlyingDecimals, oracle prices, etc.)
-  // regardless of Cirrus column-level ACL on their personal token.
+  // Return cached response if warm (30s)
+  const cached = _vaultInfoCache.get(key);
+  if (cached && Date.now() < cached.expiresAt) {
+    console.log(`[yield-vault/${key}/info] total response time: ${(performance.now() - startedAt).toFixed(2)}ms (cached)`);
+    return cached.data;
+  }
+
   const serviceToken = await getServiceToken();
 
   const vaultState = await getVaultState(serviceToken, def.address);
@@ -1423,7 +1432,7 @@ export const getYieldVaultInfo = async (
   const tvlUsd = underlyingUsdWad(idleAssets + deployedAssets, assetPrice, decimals);
   const apy = await computeApy(serviceToken, def.address, assetAddress, activeAssets, totalShares);
 
-  return {
+  const result: YieldVaultInfo = {
     key,
     configured: true,
     deployed: true,
@@ -1450,6 +1459,10 @@ export const getYieldVaultInfo = async (
     minIdleRequirement: minIdleRequirement.toString(),
     deployBlockedReason,
   };
+
+  _vaultInfoCache.set(key, { data: result, expiresAt: Date.now() + VAULT_INFO_CACHE_TTL });
+  console.log(`[yield-vault/${key}/info] total response time: ${(performance.now() - startedAt).toFixed(2)}ms`);
+  return result;
 };
 
 export const getYieldVaultUserInfo = async (
@@ -1457,6 +1470,7 @@ export const getYieldVaultUserInfo = async (
   key: string,
   userAddress: string
 ): Promise<YieldVaultUserInfo> => {
+  const startedAt = performance.now();
   const info = await getYieldVaultInfo(accessToken, key);
   const def = resolveVaultDef(key);
   if (!info.deployed) return emptyUserInfo(def, key);
@@ -1509,7 +1523,7 @@ export const getYieldVaultUserInfo = async (
     }
   }
 
-  return {
+  const userResult = {
     ...info,
     walletAssets: walletAssets.toString(),
     userShares: userShares.toString(),
@@ -1522,6 +1536,9 @@ export const getYieldVaultUserInfo = async (
     activeRequestId: activeRequestId.toString(),
     pendingWithdrawal,
   };
+
+  console.log(`[yield-vault/${key}/user] total response time: ${(performance.now() - startedAt).toFixed(2)}ms`);
+  return userResult;
 };
 
 export const depositYieldVault = async (


### PR DESCRIPTION
## Summary

Optimizes `GET /api/earn/yield-vault/:key/info` and `GET /api/earn/yield-vault/:key/user` response times by caching the full `/info` response per vault key (eth-carry, wbtc-carry, usdc-yield).

## Changes

**File:** `yieldVault.service.ts`

### Cache Introduced

| Cache | TTL | What it stores |
|---|---|---|
| `_vaultInfoCache` (Map per vault key) | **30s** | Full `/info` response — all global pool-level data |

### What is Cached (30s) — via `/info` full response

| Data | Why it's safe to cache |
|---|---|
| Vault address, asset address, symbols, name, decimals | Static — never changes after deploy |
| Oracle price, TVL (USD) | Global — same for all users |
| Total assets, idle assets, deployed assets | Global pool state |
| Total shares, exchange rate | Global pool state |
| APY (30d rolling window) | Barely changes within 30s |
| Strategy holdings, base APY | Changes only on strategy rebalance (rare) |
| Pause status, minIdleBps | Admin-only changes |
| Queue/claimable totals | Global pool state |

### What is Fetched LIVE (never cached) — `/user` endpoint

| Data | Why it must be live |
|---|---|
| `walletAssets` | User's token wallet balance |
| `userShares` | User's vault share balance |
| `redeemableAssets`, `positionUsd` | Derived from live user shares |
| `maxDeposit`, `maxRedeem`, `maxWithdraw` | Derived from live user shares + pool state |
| `claimableAssets` | User's claimable amount from vault |
| `activeRequestId`, `pendingWithdrawal` | User's withdrawal queue status |

### How `/user` benefits

`/user` internally calls `/info` first, then fetches user-specific data. With `/info` cached (30s), `/user` skips ~10-15 network calls and only makes ~4-5 live Cirrus calls for user data.


## Testing Completed

### `/api/earn/yield-vault/:key/info`

| Flow | Tested Functionality | localhost before response time | localhost after response time | workspace before response time | workspace after response time |
|------|----------------------|-------------------------------|------------------------------|-------------------------------|-------------------------------|
| Anonymous flow | Yes | 3187ms | 0.01ms | 1.17s | 680ms |
| STRATO OAuth flow | Yes | 4200ms | 0.01ms | 1.9s | 860ms |
| MetaMask Wallet Connect flow | Yes | 3500ms | 0.01ms | 1.5s | 840ms |
| Both flows | Yes | | | | |

### `/api/earn/yield-vault/:key/user`

| Flow | Tested Functionality | localhost before response time | localhost after response time | workspace before response time | workspace after response time |
|------|----------------------|-------------------------------|------------------------------|-------------------------------|-------------------------------|
| Anonymous flow | Yes | - | - | - | - |
| STRATO OAuth flow | Yes | 3613ms | 720ms | 4.42s | 740ms |
| MetaMask Wallet Connect flow | Yes | 3500ms | 680ms | 3.89s | 990ms |
| Both flows | Yes | | | | |
