### PR TITLE
optimized /tokens/v2/net-balance-history

### DIFF
--- a/mercata/backend/src/api/services/tokens.v2.service.ts
+++ b/mercata/backend/src/api/services/tokens.v2.service.ts
@@ -14,6 +14,13 @@ import { calculateLPTokenPrice } from "../helpers/swapping.helper";
 
 const { Token, CollateralVault, CDPEngine, MercataBridge, mercataBridge, DECIMALS, YieldVault } = constants;
 
+// --- net-balance-history caches ---
+const HISTORY_RESPONSE_TTL = 30_000; // 30s — full response per user+duration
+const ACTIVE_REQ_TTL = 5_000;        // 5s — carry vault activeRequestId per user+vault
+
+const _historyCache = new Map<string, { data: BalanceSnapshot[]; expiresAt: number }>();
+const _activeReqCache = new Map<string, { value: string; expiresAt: number }>();
+
 // Queries MercataBridge config for the unanimous externalSymbol for each given strato token address.
 // Returns a map of stratoToken -> externalSymbol.
 // Used to display the equivalent quantity of an external rebasing token in the UI.
@@ -686,16 +693,32 @@ export const getNetBalanceHistory = async (
   userAddress: string,
   historyParams: HistoryParams,
 ): Promise<BalanceSnapshot[]> => {
+  const startedAt = performance.now();
 
-  // Pre-fetch vault config and carry vault active request IDs in parallel
+  // Full response cache keyed by user + duration window
+  const cacheKey = `${userAddress}:${historyParams.interval}:${historyParams.numTicks}:${Math.floor(historyParams.endTimestamp / historyParams.interval)}`;
+  const cached = _historyCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    console.log(`[net-balance-history] total response time: ${(performance.now() - startedAt).toFixed(2)}ms (cached)`);
+    return cached.data;
+  }
+
+  // Pre-fetch vault config (1hr cached) and carry vault active request IDs (5s cached) in parallel
   const carryVaultAddrs = listVaultDefs().filter(v => v.address).map(v => v.address);
   const [vaultConfig, ...activeReqIds] = await Promise.all([
     getVaultHistoryConfig(accessToken),
-    ...carryVaultAddrs.map(addr =>
-      cirrus.get(accessToken, `/${YieldVault}-activeRequestId`, {
+    ...carryVaultAddrs.map(addr => {
+      const reqKey = `${userAddress}:${addr}`;
+      const reqCached = _activeReqCache.get(reqKey);
+      if (reqCached && Date.now() < reqCached.expiresAt) return Promise.resolve(reqCached.value);
+      return cirrus.get(accessToken, `/${YieldVault}-activeRequestId`, {
         params: { address: `eq.${addr}`, key: `eq.${userAddress}`, select: 'value::text' },
-      }).then(r => r.data?.[0]?.value || "0").catch(() => "0")
-    ),
+      }).then(r => {
+        const val = r.data?.[0]?.value || "0";
+        _activeReqCache.set(reqKey, { value: val, expiresAt: Date.now() + ACTIVE_REQ_TTL });
+        return val;
+      }).catch(() => "0");
+    }),
   ]);
 
   const requestFilters: string[] = [];
@@ -751,7 +774,10 @@ export const getNetBalanceHistory = async (
     updatePortfolioInfoMapping,
     processBalanceSnapshot
   );
-  return balanceHistory.map(({timestamp, data}) => ({timestamp, balance: data.netBalance}));
+  const result = balanceHistory.map(({timestamp, data}) => ({timestamp, balance: data.netBalance}));
+  _historyCache.set(cacheKey, { data: result, expiresAt: Date.now() + HISTORY_RESPONSE_TTL });
+  console.log(`[net-balance-history] total response time: ${(performance.now() - startedAt).toFixed(2)}ms`);
+  return result;
 };
 
 export const getBorrowingHistory = async (

--- a/mercata/backend/src/api/services/vault.service.ts
+++ b/mercata/backend/src/api/services/vault.service.ts
@@ -566,19 +566,28 @@ export const getVaultShareTokenAddress = async (
  * Get vault config for history tracking.
  * Returns shareToken, botExecutor, and supportedAssets needed for portfolio history.
  */
+// 1hr cache — config only changes on admin operations
+let _vaultHistoryConfigCache: { data: { shareToken: string; botExecutor: string; supportedAssets: string[] }; expiresAt: number } | null = null;
+const VAULT_HISTORY_CONFIG_TTL = 3_600_000;
+
 export const getVaultHistoryConfig = async (
   accessToken: string
 ): Promise<{ shareToken: string; botExecutor: string; supportedAssets: string[] } | null> => {
+  if (_vaultHistoryConfigCache && Date.now() < _vaultHistoryConfigCache.expiresAt) {
+    return _vaultHistoryConfigCache.data;
+  }
   const vaultAddress = getVaultAddress();
   if (!vaultAddress) return null;
   const vaultData = await getVaultData(accessToken, vaultAddress);
   if (!vaultData) return null;
-  return {
+  const result = {
     shareToken: vaultData.shareToken || "",
     botExecutor: vaultData.botExecutor || "",
     supportedAssets: (vaultData.supportedAssets || [])
       .filter((addr: string) => addr && addr !== "0000000000000000000000000000000000000000"),
   };
+  _vaultHistoryConfigCache = { data: result, expiresAt: Date.now() + VAULT_HISTORY_CONFIG_TTL };
+  return result;
 };
 
 /**


### PR DESCRIPTION


### Problem

Every call to this endpoint was making **4+ fresh Cirrus queries** before the main heavy history queries — 3 for vault config (`getVaultHistoryConfig` → `getVaultData`) and 3 for carry vault `activeRequestId` — even though this data rarely changes.

### Changes

**`vault.service.ts`**
- Cached `getVaultHistoryConfig()` result with **1hr TTL** — config only changes on admin operations

**`tokens.v2.service.ts`**
- Added **30s full response cache** (`_historyCache`) keyed by `user + duration + time-window` — serves identical chart data instantly on repeat calls (tab switches, re-renders, duration toggle-back)
- Added **5s cache** (`_activeReqCache`) for carry vault `activeRequestId` per user+vault — only changes on explicit user withdrawal action
- Added console logs for response time tracking

### What stays live (not cached)

- `/history@storage` and `/history@mapping` Cirrus queries — user-specific historical data, always fresh on cache miss
- All balances, prices, loans, collateral data within history snapshots

### Cache Summary

| Cache | TTL | Data | Why safe |
|---|---|---|---|
| `_vaultHistoryConfigCache` | 1hr | shareToken, botExecutor, supportedAssets | Admin-only config, never changes in normal usage |
| `_historyCache` | 30s | Full response per user+duration | Historical chart data — 30s delay imperceptible |
| `_activeReqCache` | 5s | Carry vault activeRequestId per user+vault | Only changes on explicit user withdrawal action |

### Testing Completed

| Flow | Tested Functionality | localhost before response time | localhost after response time | workspace before response time | workspace after response time |
|------|----------------------|-------------------------------|------------------------------|-------------------------------|-------------------------------|
| Anonymous flow | Yes | - | - | - | - |
| STRATO OAuth flow | Yes | 8.22s | 89ms | 3s | 535ms |
| MetaMask Wallet Connect flow | Yes | 3.85s | 550ms | 3s | 550ms |
| Both flows | Yes | | | | |
