### PR TITLE
fixed redundant api calls on initial app load

### DIFF
--- a/mercata/ui/src/components/dashboard/GuestPromoSection.tsx
+++ b/mercata/ui/src/components/dashboard/GuestPromoSection.tsx
@@ -4,9 +4,9 @@ import { ArrowRight, Loader2 } from "lucide-react";
 import { requestWalletConnection } from "@/lib/auth";
 import { useEarnContext } from "@/context/EarnContext";
 import { useTokenContext } from "@/context/TokenContext";
-import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
 import { useRewards } from "@/hooks/useRewards";
 import { findBestEarnApyInfo, buildEarnApyMap } from "@/utils/earnUtils";
+import type { UserRewardsData } from "@/services/rewardsService";
 import { usdstAddress } from "@/lib/constants";
 
 /** GOLDST / SILVST — images from TokenContext (earningAssets ∪ inactiveTokens) */
@@ -55,13 +55,13 @@ const resolvePromoRows = (
 
 interface GuestPromoSectionProps {
   variant: 1 | 2 | 3; // 1 = logged out, 2 = logged in 0 portfolio, 3 = logged in with portfolio
+  userRewards?: UserRewardsData | null;
 }
 
-const GuestPromoSection = ({ variant }: GuestPromoSectionProps) => {
+const GuestPromoSection = ({ variant, userRewards }: GuestPromoSectionProps) => {
   const navigate = useNavigate();
   const [rewardsButtonHovered, setRewardsButtonHovered] = useState(false);
   const { tokenApys, tokenApysLoaded } = useEarnContext();
-  const { userRewards } = useRewardsUserInfo();
   const { state: rewardsState } = useRewards();
   const { earningAssets, inactiveTokens, loadingEarningAssets } = useTokenContext();
   const tokensLoading = loadingEarningAssets || earningAssets.length === 0;

--- a/mercata/ui/src/context/SwapContext.tsx
+++ b/mercata/ui/src/context/SwapContext.tsx
@@ -449,14 +449,14 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
   // INITIALIZATION
   // ============================================================================
   useEffect(() => {
-    // Pool data is public - always fetch for all users
     fetchPools();
-    
-    // User-specific token data - only fetch when logged in
+  }, [fetchPools]);
+
+  useEffect(() => {
     if (isLoggedIn) {
       fetchSwappableTokens();
     }
-  }, [fetchSwappableTokens, fetchPools, isLoggedIn]);
+  }, [fetchSwappableTokens, isLoggedIn]);
 
   // ============================================================================
   // PROVIDER

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -20,7 +20,6 @@ import { useCDP } from "@/context/CDPContext";
 import { cataAddress, rewardsEnabled } from "@/lib/constants";
 import { BalanceSnapshot } from "@mercata/shared-types";
 import { useUserLeaderboardRank } from "@/hooks/useUserLeaderboardRank";
-import { useRewards } from "@/hooks/useRewards";
 import { useRewardsUserInfo } from "@/hooks/useRewardsUserInfo";
 import { roundByMagnitude, formatRoundedWithCommas } from "@/services/rewardsService";
 import { formatBalance, safeBigInt } from "@/utils/numberUtils";
@@ -94,7 +93,6 @@ const Dashboard = () => {
   });
 
   const { activities: rewardsActivities, loading: rewardsActivitiesLoading } = useRewardsActivities();
-  const { state: rewardsState } = useRewards();
   const { rank: userRank, totalEarned, loading: rankLoading } = useUserLeaderboardRank();
   const { userRewards: rewardsUserInfo } = useRewardsUserInfo();
   const communityBonusFormatted = useMemo(() => {
@@ -296,9 +294,7 @@ const Dashboard = () => {
         <DashboardHeader title="Portfolio" />
 
         <main className="p-4 md:p-6 pb-24 md:pb-6">
-          {!isLoggedIn && <GuestPromoSection variant={1} />}
-          {isLoggedIn && !isLoadingNetBalance && totalBalance === 0 && <GuestPromoSection variant={2} />}
-          {isLoggedIn && (isLoadingNetBalance || totalBalance > 0) && <GuestPromoSection variant={3} />}
+          <GuestPromoSection variant={!isLoggedIn ? 1 : (!isLoadingNetBalance && totalBalance === 0) ? 2 : 3} userRewards={rewardsUserInfo} />
           {showFullDashboard && <LiquidationAlertBanner />}
           {showFullDashboard && (
             <div className={`grid grid-cols-1 ${rewardsEnabled ? 'lg:grid-cols-4' : 'lg:grid-cols-3'} gap-3 md:gap-6 mb-4 md:mb-8`}>


### PR DESCRIPTION
Summary of Dashboard API Duplicate Call Fixes
1. /rewards/overview — called 3x, fixed to 1x
Issue A: Dashboard.tsx called useRewards() but never used the returned rewardsState. Its child GuestPromoSection also called useRewards() independently (and actually uses it). Two independent hook instances = two API calls.

Fix: Removed the unused useRewards() call and import from Dashboard.tsx.

Issue B: GuestPromoSection was rendered via three separate conditional blocks at different React tree positions. When isLoadingNetBalance changed, the component unmounted from one position and remounted at another, firing the effect again.

Fix: Replaced the three conditionals with a single <GuestPromoSection> that computes the variant prop inline, keeping the component at a stable tree position.

2. /rewards/activities/me — called 2x, fixed to 1x
Issue: Both Dashboard.tsx and GuestPromoSection independently called useRewardsUserInfo(). Dashboard needs the data for the community bonus badge; GuestPromoSection needs it for daily points calculation.

Fix: Removed useRewardsUserInfo() from GuestPromoSection and passed userRewards down as a prop from Dashboard (which already has the data).

3. /swap-pools — called 2x, fixed to 1x
Issue: SwapContext had a single initialization useEffect with isLoggedIn in its dependency array. fetchPools() (which doesn't need auth) was called unconditionally inside it. When isLoggedIn transitioned from false to true after the auth check, the entire effect re-ran, calling fetchPools() a second time.

Fix: Split into two independent effects — one for fetchPools() (no isLoggedIn dependency, fires once) and one for fetchSwappableTokens() (fires when isLoggedIn becomes true).