### PR TITLE
Reverse committedBlocks to commit last block in list as BestSequencedBlock

### DIFF
--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -286,7 +286,7 @@ blockstanbulSend' msg = do
           (P2pBlock <$> committedBlocks)
             ++ p2ps
 
-    case committedBlocks of
+    case reverse committedBlocks of
       [] -> pure ()
       (b:_) -> do
         let bh = BDB.blockHeader b


### PR DESCRIPTION
When the sequencer receives blocks out of order, it stores them in the dependent block levelDB to be emitted to the VM later. When the sequencer receives a block that arrives after its direct descendant(s), the sequencer loads all descendant blocks from levelDB and emits them to the VM all at once. Therefore, the block that should be treated as the BestSequencedBlock will always be the last block in the list of emittable blocks. Until now, the _first_ block in that list was the one being stored as BestSequencedBlock, which causes problems on restart: if the last set of blocks a node processes before being restarted contains multiple blocks, the BestSequencedBlock won't be the actual best block in the chain, and it will cause the sequence number to be behind the true head of the chain on restart. This causes the node to stall, since it believes it needs to process block N, but block N has already been marked as "Emitted" in the dependent block levelDB