### PR TITLE
wallet connect issue fixes on dashboard header

### DIFF
--- a/mercata/ui/src/components/dashboard/DashboardHeader.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardHeader.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useToast } from '@/hooks/use-toast';
 import { ModeToggle } from '../mode-toggle';
 import { useEffect } from 'react';
-import { PENDING_STRATO_WALLET_CONNECT_KEY } from '@/lib/auth';
+import { PENDING_STRATO_WALLET_CONNECT_KEY, requestWalletConnection } from '@/lib/auth';
 
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import STRATOICON from '@/assets/icon.png';
@@ -167,9 +167,7 @@ const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
           </Popover>
         ) : (
           <Button
-            onClick={() => {
-              if (stratoConnector) connect({ connector: stratoConnector });
-            }}
+            onClick={requestWalletConnection}
             size="sm"
             className="h-8 md:h-9 px-3 md:px-4 bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90 gap-1.5"
           >


### PR DESCRIPTION
#7105 
**PR Description**
**Issue:**
The "Connect Wallet" button on dashboard pages was directly redirecting to Keycloak login instead of opening the wallet selection modal (MetaMask, STRATO, Coinbase, etc.). The landing page header worked correctly, but dashboard header did not.

**Root Cause:**
In commit 09ec6de (May 22, 2026) by golemshid, the button was changed from using openConnectModal (RainbowKit modal) to directly calling connect({ connector: stratoConnector }) as part of the "Fix STRATO wallet reconnect after login" change.

**Fix:**
Changed the button to use requestWalletConnection() which opens the wallet selection modal, matching the behavior of the landing page header.

**Note:**
The STRATO wallet auto-reconnect after login functionality remains intact. That fix relies on the useEffect in DashboardHeader and the PENDING_STRATO_WALLET_CONNECT_KEY set by stratoWallet.ts connector code — not on the button click handler. When a user selects STRATO from the modal and isn't authenticated, the connector still sets the flag and redirects to Keycloak, and auto-reconnect works as expected after login.