### PR TITLE
strato-api: use -N -maxN4 so it starts on machines with <4 cores

### DIFF
--- a/strato/core/strato-init/src/Blockchain/Init/Generator.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Generator.hs
@@ -92,7 +92,7 @@ createCommandsFile = do
         , "vm-runner +RTS -T -I2 -N1 -RTS"
         , "strato-indexer"
         , "slipstream +RTS -T -RTS"
-        , "strato-api +RTS -T -N4 -RTS"
+        , "strato-api +RTS -T -N -maxN4 -RTS"
         , "strato-network-monitor"
         ]
 


### PR DESCRIPTION
-N4 fails to launch on nodes with fewer than 4 logical CPUs (strato-api isn't built with -rtsopts). -N -maxN4 auto-detects cores, capped at 4, keeping the concurrency win on larger nodes.