### PR TITLE
Fixed encoding of code collections for create/create2

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2456,7 +2456,7 @@ callBuiltin "create" args@(cName : src : argVals) = do
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
   isRunningTests <- Env.runningTests <$> getEnv
-  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
+  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ DT.encodeUtf8 $ T.pack contractSrc
   addNewCodeCollection hsh cc
   newAddress <- getNewAddress creator
   execResults <- create' creator newAddress hsh cc contractName' argVals
@@ -2480,7 +2480,7 @@ callBuiltin "create2" args@(salt : n : src : argVals) = do
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
   isRunningTests <- Env.runningTests <$> getEnv
-  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
+  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ DT.encodeUtf8 $ T.pack contractSrc
   addNewCodeCollection hsh cc
   newAddress <- getNewAddressWithSalt creator salt hsh $ n:argVals
   execResults <- create' creator newAddress hsh cc contractName' argVals

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -486,7 +486,10 @@ runSM maybeCode envBefore gi f = do
     -- TODO should also not happen, but since this is a work in progress they
     -- are a fact of life and should be fixed on demand.
     -- The rest should always be a user error and handled safely
-    Left se -> do
+    Left (e :: SomeException) -> do
+      let se = case fromException e of
+            Just solidEx -> solidEx
+            Nothing -> InternalError "Uncaught internal exception" (show e)
       $logErrorLS "runSM/error" se
       if flags_svmDev
         then do


### PR DESCRIPTION
Also expanded type caught by `try` to `SomeException`, in order to prevent crashes from non-SolidException synchronous exceptions, including UTF-8 decoding failures.