### PR TITLE
external wallet connect issue fixes

### DIFF
--- a/mercata/ui/src/components/bridge/BridgeWalletStatus.tsx
+++ b/mercata/ui/src/components/bridge/BridgeWalletStatus.tsx
@@ -4,6 +4,7 @@ import { ConnectButton, useConnectModal } from '@rainbow-me/rainbowkit';
 import { Copy } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/use-toast';
+import { suppressStratoReconnect, allowStratoReconnect, markExternalWalletActive, clearExternalWalletActive } from '@/lib/stratoWallet';
 
 interface BridgeWalletStatusProps {
   guestMode?: boolean;
@@ -31,8 +32,25 @@ const BridgeWalletStatus: React.FC<BridgeWalletStatusProps> = ({
   const { connectModalOpen, openConnectModal } = useConnectModal();
   const { toast } = useToast();
   const externalModalActiveRef = React.useRef(false);
+  const [pendingExternalModal, setPendingExternalModal] = React.useState(false);
+
+  const isConnectedToStrato = isConnected && connector ? isStratoConnector(connector) : false;
   const hasConnectedWallet =
-    isConnected && (!externalOnly || (connector ? !isStratoConnector(connector) : false));
+    isConnected && (!externalOnly || !isConnectedToStrato);
+
+  React.useEffect(() => {
+    if (!pendingExternalModal || isConnected || !openConnectModal) return;
+    externalModalActiveRef.current = true;
+    markExternalWalletActive();
+    openConnectModal();
+    setPendingExternalModal(false);
+    allowStratoReconnect();
+  }, [pendingExternalModal, isConnected, openConnectModal]);
+
+  React.useEffect(() => {
+    if (!pendingExternalModal) return;
+    return () => { allowStratoReconnect(); };
+  }, [pendingExternalModal]);
 
   const hideStratoWalletOption = React.useCallback(() => {
     const stratoOption = document.querySelector<HTMLElement>(
@@ -84,6 +102,9 @@ const BridgeWalletStatus: React.FC<BridgeWalletStatusProps> = ({
 
   React.useEffect(() => {
     if (!connectModalOpen) {
+      if (externalModalActiveRef.current && !isConnected) {
+        clearExternalWalletActive();
+      }
       externalModalActiveRef.current = false;
       restoreStratoWalletOption();
       return;
@@ -112,15 +133,23 @@ const BridgeWalletStatus: React.FC<BridgeWalletStatusProps> = ({
     }
   };
 
+  const handleExternalConnect = () => {
+    if (isConnectedToStrato) {
+      suppressStratoReconnect();
+      setPendingExternalModal(true);
+      disconnect();
+    } else {
+      externalModalActiveRef.current = true;
+      openConnectModal?.();
+    }
+  };
+
   const connectControl = externalOnly ? (
     <button
       type="button"
       disabled={guestMode}
       className={CONNECT_BUTTON_CLASS}
-      onClick={() => {
-        externalModalActiveRef.current = true;
-        openConnectModal?.();
-      }}
+      onClick={handleExternalConnect}
     >
       {connectLabel}
     </button>
@@ -133,7 +162,7 @@ const BridgeWalletStatus: React.FC<BridgeWalletStatusProps> = ({
       {hasConnectedWallet ? (
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 w-full">
           <div
-            onClick={() => disconnect()}
+            onClick={() => { clearExternalWalletActive(); disconnect(); }}
             className="relative group cursor-pointer flex-1"
           >
             <div className="px-3 sm:px-4 py-2 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-xl font-semibold group-hover:opacity-0 transition-opacity w-full text-center h-[38px] sm:h-[42px] flex items-center justify-center text-sm sm:text-base">

--- a/mercata/ui/src/lib/stratoWallet.ts
+++ b/mercata/ui/src/lib/stratoWallet.ts
@@ -5,6 +5,30 @@ import { PENDING_STRATO_WALLET_CONNECT_KEY, redirectToLogin } from "@/lib/auth";
 import { type Address, type EIP1193Provider, type Hex, keccak256, toRlp } from "viem";
 import { getStratoChainId, rpcUrl } from "@/lib/stratoChain";
 
+const EXTERNAL_WALLET_KEY = "bridge-external-wallet";
+
+let _suppressReconnect = false;
+
+export function suppressStratoReconnect() {
+  _suppressReconnect = true;
+}
+
+export function allowStratoReconnect() {
+  _suppressReconnect = false;
+}
+
+export function markExternalWalletActive() {
+  localStorage.setItem(EXTERNAL_WALLET_KEY, "1");
+}
+
+export function clearExternalWalletActive() {
+  localStorage.removeItem(EXTERNAL_WALLET_KEY);
+}
+
+export function isExternalWalletActive(): boolean {
+  return localStorage.getItem(EXTERNAL_WALLET_KEY) === "1";
+}
+
 function toMinimalHex(n: number | bigint): Hex {
   if (n === 0 || n === 0n) return "0x";
   const hex = typeof n === "bigint" ? n.toString(16) : n.toString(16);
@@ -226,6 +250,7 @@ function stratoConnector(walletDetails: Record<string, unknown> = {}) {
     },
 
     async isAuthorized() {
+      if (_suppressReconnect || isExternalWalletActive()) return false;
       if (currentAddress) return true;
       const stored = getStoredStratoConnection(config.state);
       if (stored) {


### PR DESCRIPTION
**Fix: External Wallet Connect Button**
**Issue:** When a user is logged in via STRATO (Keycloak) and visits the Fund or Withdrawal page, clicking "Connect External Wallet" does nothing — no modal opens, no error shown. The button works fine on first app load but breaks after a page refresh. It also behaves inconsistently across environments — works on some nodes but not others, depending on whether CHAIN_ID is configured.

**Root Cause:** RainbowKit's openConnectModal function is only available when wagmi has no active 
connection (isConnected = false). After a page refresh, the custom stratoWallet connector detects the active Keycloak session and auto-reconnects, making isConnected = true. This causes openConnectModal to be undefined, so the button click silently does nothing.

**Fix:**
**stratoWallet.ts** — Added a suppress flag for isAuthorized(). When the flag is set, stratoWallet skips auto-reconnection, allowing wagmi's isConnected to become false so the RainbowKit modal can open. Also added a localStorage flag to remember when an external wallet is active, so it persists across page refreshes instead of being overridden by stratoWallet auto-reconnect.

**BridgeWalletStatus.tsx** — On button click: suppress stratoWallet auto-reconnect → disconnect wagmi → wait for isConnected to become false → open native RainbowKit modal → clear suppress flag. On explicit disconnect of the external wallet, the localStorage flag is cleared so stratoWallet resumes normal behavior.

The Keycloak session is cookie-based and completely unaffected by the wagmi disconnect — the user stays logged in to STRATO throughout.