### PR TITLE
fix: include deactivated activities in claimable rewards calculation

### DIFF
--- a/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
+++ b/mercata/ui/src/components/rewards/UserRewardsSummary.tsx
@@ -149,8 +149,8 @@ export const UserRewardsSummary = ({
   const unclaimedRewardsStr = userRewards.unclaimedRewards || "0";
   const activitiesWithStake = userRewards.activities.filter(
     (a) =>
-      safeBigInt(a.userInfo?.stake || "0") > 0n &&
-      safeBigInt(a.activity?.emissionRate || "0") > 0n
+      safeBigInt(a.userInfo?.stake || "0") > 0n 
+    // && safeBigInt(a.activity?.emissionRate || "0") > 0n
   );
 
   const hasBonusRewards = !!userRewards.bonusRewards && safeBigInt(userRewards.bonusRewards) > 0n;


### PR DESCRIPTION
**Summary:**

The Dashboard rewards total (from the leaderboard endpoint) includes all earned rewards across all activities, regardless of status. However, the Rewards page was filtering out activities with emissionRate = 0 (deactivated/ended seasons) when calculating the claimable amount — causing those unsettled rewards to be invisible and unclaimable.

**Fix:** Removed the emissionRate > 0 filter so deactivated activities' pending rewards are included in the "Total Claimable" display. The calculation function already handles emissionRate = 0 correctly.