### PR TITLE
Use abi.encode for creating issueIds in AdminRegistry

### DIFF
--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -139,7 +139,11 @@ contract record AdminRegistry is Ownable {
     }
 
     function _getIssueId(address _target, string _func, variadic _args) internal returns (string) {
-        return keccak256(_target, _func, _args);
+        string issueId = keccak256(_target, _func, _args);
+        if (currentIssues[issueId]) {
+            return issueId;
+        }
+        return keccak256(abi.encode(_target, _func, _args));
     }
 
     function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {


### PR DESCRIPTION
The way issueIds are derived in the AdminRegistry is to pass them directly to `keccak256`. However, SolidVM's encoding for arguments to `keccak256` is type-dependent, so, for example, address(0) is encoded differently than uint(0). This works fine when calling `castVoteOnIssue` from the `onlyOwner` modifier, since the type signature of the target function is known; or when the values of the arguments can be unambiguously parsed into a single type: the string "f00bar" can only be interpreted as a string literal, due to the character 'r'. When the value can be interpreted as multiple types, e.g. the value 0x1002, SolidVM picks the most general type. For other operations, SolidVM can fix the ambiguity on the fly with internal type conversion, but since `keccak256` is also type-generic, it uses the more general type, thus leading to a different byte representation of the issue, leading to a different issueId.

This PR mitigates this issue by wrapping the arguments in `abi.encode()` before passing the final encoding to `keccak256`.  `abi.encode()` sidesteps the issue somewhat because it pads all static values to 32 bytes, making the byte representation for address(0x1002) and uint(0x1002) identical. However, to prevent existing issues from becoming locked/frozen in the AdminRegistry, `_getIssueId` will first check to see if an issueId derived from the old encoding is already a current issue, and if not, it uses the new encoding. Over time, as issues using the old encoding are executed, the use of the new encoding will become universal, at which point the check can be removed.