### PR TITLE
Added MPC shard generation and storage to Vault

### DIFF
--- a/strato/vault/api/blockapps-vault-wrapper-api.cabal
+++ b/strato/vault/api/blockapps-vault-wrapper-api.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:
       Strato.Strato23.API
       Strato.Strato23.API.Key
+      Strato.Strato23.API.MPC
       Strato.Strato23.API.Password
       Strato.Strato23.API.Ping
       Strato.Strato23.API.Signature

--- a/strato/vault/api/src/Strato/Strato23/API.hs
+++ b/strato/vault/api/src/Strato/Strato23/API.hs
@@ -5,6 +5,7 @@ module Strato.Strato23.API
   ( VaultWrapperAPI,
     VaultCoreAPI,
     module Strato.Strato23.API.Key,
+    module Strato.Strato23.API.MPC,
     module Strato.Strato23.API.Password,
     module Strato.Strato23.API.Ping,
     module Strato.Strato23.API.Signature,
@@ -15,6 +16,7 @@ where
 
 import Servant
 import Strato.Strato23.API.Key
+import Strato.Strato23.API.MPC
 import Strato.Strato23.API.Password
 import Strato.Strato23.API.Ping
 import Strato.Strato23.API.Signature
@@ -31,5 +33,7 @@ type VaultWrapperAPI =
     :<|> PostSignature'
     :<|> PostPassword
     :<|> VerifyPassword
+    :<|> PostMPCKey'
+    :<|> GetMPCKey'
 
 type VaultCoreAPI = GetKey :<|> PostKey :<|> GetSharedKey :<|> GetUsers :<|> PostSignature

--- a/strato/vault/api/src/Strato/Strato23/API/MPC.hs
+++ b/strato/vault/api/src/Strato/Strato23/API/MPC.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | MPC (2-of-2) key shard storage. These routes are entirely separate from the
+-- existing key/signature routes so backwards compatibility is preserved. The
+-- wallet generates a key, splits it 2-of-2, keeps one shard, and stores the other
+-- (the "Vault shard") here; at signing time it fetches the Vault shard back,
+-- reconstructs the key client-side, signs, and discards it. Vault never assembles
+-- the key or signs — it is a dumb encrypted-shard store.
+module Strato.Strato23.API.MPC where
+
+import Data.Aeson.Types
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as C8
+import Data.OpenApi (ToSchema (..), binarySchema)
+import Data.OpenApi.Internal.Schema (named)
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics
+import qualified LabeledError
+import Servant.API
+import Strato.Strato23.API.Types (Address)
+
+-- | A key shard (raw secp256k1 scalar bytes, hex-encoded in JSON) plus the
+-- account's address. Used both to store the Vault shard (POST body) and to return
+-- it (GET response).
+data MPCKeyShare = MPCKeyShare
+  { mksShard :: B.ByteString,
+    mksAddress :: Address
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MPCKeyShare where
+  toJSON (MPCKeyShare shard addr) =
+    object
+      [ "shard" .= (T.pack . C8.unpack . B16.encode $ shard),
+        "address" .= addr
+      ]
+
+instance FromJSON MPCKeyShare where
+  parseJSON (Object o) = do
+    s <- o .: "shard"
+    a <- o .: "address"
+    return $ MPCKeyShare (LabeledError.b16Decode "FromJSON<MPCKeyShare>" . C8.pack $ T.unpack s) a
+  parseJSON x = error $ "parseJSON MPCKeyShare: expected object, got " ++ show x
+
+instance ToSchema MPCKeyShare where
+  declareNamedSchema = const . pure $ named "MPCKeyShare" binarySchema
+
+-- | Confirmation returned after storing a shard (no shard echoed back).
+data MPCKeyMeta = MPCKeyMeta {mkmAddress :: Address}
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MPCKeyMeta where
+  toJSON (MPCKeyMeta a) = object ["status" .= ("success" :: Text), "address" .= a]
+
+instance FromJSON MPCKeyMeta where
+  parseJSON (Object o) = MPCKeyMeta <$> o .: "address"
+  parseJSON x = error $ "parseJSON MPCKeyMeta: expected object, got " ++ show x
+
+instance ToSchema MPCKeyMeta where
+  declareNamedSchema = const . pure $ named "MPCKeyMeta" binarySchema
+
+--------------------------------------------------------------------------------
+-- Routes (JWT-gated like the other v2.3 routes: nginx validates the bearer token
+-- and injects the user-name / identity-provider headers).
+--------------------------------------------------------------------------------
+
+-- | Store the Vault shard for the authenticated user. Fails if one already exists.
+type PostMPCKey' =
+  "mpckey"
+    :> Header' '[Required, Strict] "X-USER-UNIQUE-NAME" Text
+    :> Header' '[Required, Strict] "X-IDENTITY-PROVIDER-ID" Text
+    :> ReqBody '[JSON] MPCKeyShare
+    :> Post '[JSON] MPCKeyMeta
+
+-- | Return the Vault shard for the authenticated user (for client-side signing).
+type GetMPCKey' =
+  "mpckey"
+    :> Header' '[Required, Strict] "X-USER-UNIQUE-NAME" Text
+    :> Header' '[Required, Strict] "X-IDENTITY-PROVIDER-ID" Text
+    :> Get '[JSON] MPCKeyShare

--- a/strato/vault/server/blockapps-vault-wrapper-server.cabal
+++ b/strato/vault/server/blockapps-vault-wrapper-server.cabal
@@ -31,6 +31,7 @@ library
       Strato.Strato23.Monad
       Strato.Strato23.Server
       Strato.Strato23.Server.Key
+      Strato.Strato23.Server.MPC
       Strato.Strato23.Server.Password
       Strato.Strato23.Server.Ping
       Strato.Strato23.Server.Signature

--- a/strato/vault/server/src/Strato/Strato23/Database/Create.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Create.hs
@@ -31,6 +31,22 @@ CREATE INDEX IF NOT EXISTS indexed_address ON users (address);
 CREATE INDEX IF NOT EXISTS indexed_nameId  ON users (x_user_unique_name , x_identity_provider_id);
 |]
 
+mpcKeysTable :: Query
+mpcKeysTable =
+  [sql|
+CREATE TABLE IF NOT EXISTS mpc_keys(
+  id serial              PRIMARY KEY,
+  x_user_unique_name     varchar(512) NOT NULL,
+  x_identity_provider_id varchar(512) NOT NULL,
+  salt bytea             NOT NULL,
+  nonce bytea            NOT NULL,
+  enc_shard bytea        NOT NULL,
+  address bytea          NOT NULL,
+  UNIQUE (x_user_unique_name, x_identity_provider_id)
+);
+CREATE INDEX IF NOT EXISTS indexed_mpc_nameId ON mpc_keys (x_user_unique_name, x_identity_provider_id);
+|]
+
 messageTable :: Query
 messageTable =
   [sql|

--- a/strato/vault/server/src/Strato/Strato23/Database/Migrations.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Migrations.hs
@@ -10,7 +10,7 @@ import Data.Int (Int64)
 import Data.Maybe (listToMaybe)
 import Database.PostgreSQL.Simple
 import Database.PostgreSQL.Simple.SqlQQ
-import Strato.Strato23.Database.Create (createTables, messageTable)
+import Strato.Strato23.Database.Create (createTables, messageTable, mpcKeysTable)
 
 data MigrationErrorBehavior = Throw | Catch
 
@@ -38,7 +38,8 @@ migrations =
     (Throw, removePublicKey),
     (Throw, insertOauthProvider),
     (Throw, modifytOauthProvider),
-    (Throw, removeEncKey)
+    (Throw, removeEncKey),
+    (Throw, mpcKeysTable)
   ]
 
 getSchemaVersion :: Query

--- a/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
@@ -131,6 +131,50 @@ postUserKeyQuery' userName oauthProvider KeyStore {..} conn = do
             }
       return True
 
+-- MPC key shards (separate table; mirrors the user-key queries by name+provider).
+getMpcShardQuery' :: T.Text -> T.Text -> Query (O.Field PGBytea, O.Field PGBytea, O.Field PGBytea, O.Field PGBytea)
+getMpcShardQuery' username oauthRealm = proc () -> do
+  (_, name, oauth, salt, nonce, encShard, address) <- selectTable mpcKeysTable -< ()
+  restrict -< (name .== toFields username .&& oauth .== toFields oauthRealm)
+  returnA -< (salt, nonce, encShard, address)
+
+postMpcKeyQuery' ::
+  T.Text ->
+  T.Text ->
+  ByteString -> -- salt
+  SecretBox.Nonce ->
+  ByteString -> -- encrypted shard
+  Address ->
+  Connection ->
+  IO Bool
+postMpcKeyQuery' userName oauthProvider salt nonce encShard addr conn = do
+  (ids :: [Int32]) <- runSelect conn $ proc () -> do
+    (rid, name, oauth, _, _, _, _) <- selectTable mpcKeysTable -< ()
+    restrict -< (name .== toFields userName .&& oauth .== toFields oauthProvider)
+    returnA -< rid
+  case listToMaybe ids of
+    Just _ -> return False
+    Nothing -> do
+      void $
+        runInsert
+          conn
+          Insert
+            { iTable = mpcKeysTable,
+              iRows =
+                [ ( Nothing,
+                    toFields userName,
+                    toFields oauthProvider,
+                    toFields salt,
+                    toFields nonce,
+                    toFields encShard,
+                    toFields addr
+                  )
+                ],
+              iReturning = rCount,
+              iOnConflict = Nothing
+            }
+      return True
+
 getMessageQuery :: Query (O.Field PGBytea, O.Field PGBytea, O.Field PGBytea)
 getMessageQuery = proc () -> do
   (id', salt, nonce, enc_msg) <- selectTable messageTable -< ()

--- a/strato/vault/server/src/Strato/Strato23/Database/Tables.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Tables.hs
@@ -50,6 +50,39 @@ usersTable =
         requiredTableField "address"
       )
 
+-- MPC key shards: the Vault-held shard of a 2-of-2 split key, encrypted at rest
+-- with the same SecretBox master key as the `users` table. Kept entirely separate
+-- from `users` so the existing key/signature flows are untouched.
+mpcKeysTable ::
+  Table
+    ( Maybe (Field PGInt4),
+      Field PGText,
+      Field PGText,
+      Field PGBytea,
+      Field PGBytea,
+      Field PGBytea,
+      Field PGBytea
+    )
+    ( Field PGInt4,
+      Field PGText,
+      Field PGText,
+      Field PGBytea,
+      Field PGBytea,
+      Field PGBytea,
+      Field PGBytea
+    )
+mpcKeysTable =
+  Table "mpc_keys" $
+    p7
+      ( optionalTableField "id",
+        requiredTableField "x_user_unique_name",
+        requiredTableField "x_identity_provider_id",
+        requiredTableField "salt",
+        requiredTableField "nonce",
+        requiredTableField "enc_shard",
+        requiredTableField "address"
+      )
+
 messageTable ::
   Table
     ( Maybe (Field PGInt4),

--- a/strato/vault/server/src/Strato/Strato23/Server.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server.hs
@@ -15,6 +15,7 @@ import Servant.OpenApi (toOpenApi)
 import Strato.Strato23.API
 import Strato.Strato23.Monad
 import Strato.Strato23.Server.Key
+import Strato.Strato23.Server.MPC
 import Strato.Strato23.Server.Password
 import Strato.Strato23.Server.Ping
 import Strato.Strato23.Server.Signature
@@ -31,6 +32,8 @@ vaultWrapper =
     :<|> postSignature'
     :<|> postPassword
     :<|> verifyPassword
+    :<|> postMPCKey'
+    :<|> getMPCKey'
 
 serveVaultWrapper :: VaultWrapperEnv -> Servant.Server VaultWrapperAPI
 serveVaultWrapper env = hoistServer serverProxy (enterVaultWrapper env) vaultWrapper

--- a/strato/vault/server/src/Strato/Strato23/Server/MPC.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/MPC.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Handlers for the MPC (2-of-2) shard store. Vault holds one shard of a split
+-- key, encrypted at rest with the same SecretBox master key as user keys. It never
+-- reconstructs the key or signs — the wallet fetches its shard back and signs
+-- client-side. These handlers are independent of the existing user-key flows.
+module Strato.Strato23.Server.MPC where
+
+import Blockchain.Strato.Model.Address (Address)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Strato.Strato23.API.MPC
+import Strato.Strato23.Crypto
+import Strato.Strato23.Database.Queries (getMpcShardQuery', postMpcKeyQuery')
+import Strato.Strato23.Monad
+
+-- | Store the user's Vault shard (encrypted under the vault master key). One shard
+-- per (user, identity-provider); refuses to overwrite an existing one.
+postMPCKey' :: Text -> Text -> MPCKeyShare -> VaultM MPCKeyMeta
+postMPCKey' userName oauthProvider (MPCKeyShare shard addr) = withSecretKey $ \key -> do
+  (salt, nonce) <- newSaltAndNonce
+  let encShard = encrypt key nonce shard
+  created <- vaultModify $ postMpcKeyQuery' userName oauthProvider salt nonce encShard addr
+  if not created
+    then vaultWrapperError $ AlreadyExists ("MPC key for " <> userName <> " already exists")
+    else return $ MPCKeyMeta addr
+
+-- | Return the user's Vault shard (decrypted) so the wallet can reconstruct and
+-- sign client-side.
+getMPCKey' :: Text -> Text -> VaultM MPCKeyShare
+getMPCKey' userName oauthProvider = withSecretKey $ \key -> do
+  (_ :: ByteString, nonce, encShard, addr :: Address) <-
+    toUserError ("MPC key for " <> userName <> " doesn't exist")
+      . vaultQuery1
+      $ getMpcShardQuery' userName oauthProvider
+  case decrypt key nonce encShard of
+    Nothing -> vaultWrapperError IncorrectPasswordError
+    Just shard -> return $ MPCKeyShare shard addr

--- a/vault-nginx/nginx.tpl.conf
+++ b/vault-nginx/nginx.tpl.conf
@@ -134,6 +134,12 @@ http {
         proxy_read_timeout 10s;
         proxy_pass http://__VAULT_WRAPPER_HOST__/strato/v2.3/signature;
       }
+
+      location /strato/v2.3/mpckey {
+        rewrite_by_lua_file lua/openid.lua;
+        proxy_read_timeout 10s;
+        proxy_pass http://__VAULT_WRAPPER_HOST__/strato/v2.3/mpckey;
+      }
       
 #      location /strato/v2.3/password {
 #        rewrite_by_lua_file lua/openid.lua;


### PR DESCRIPTION
Vault: add MPC (2-of-2) key shard store

Summary

Adds an opt-in MPC (2-of-2) key shard store to the Vault wrapper service (strato/vault). Vault holds one shard of a client-split secp256k1 key, encrypted at rest with the same scheme as existing user keys; the client holds the other shard and reconstructs/signs on its own device. Vault never assembles the key or signs — it is a dumb, authenticated, encrypted-shard store.

This is purely additive and backwards-compatible: a brand-new table and two new users table, key routes, and /signature flow completely untouched.

Adds an opt-in MPC (2-of-2) key shard store to the Vault wrapper service (stratod of a client-split secp256k1 key, encrypted at rest with the same scheme asexisting user keys; the client holds the other shard and reconstructs/signs on its own device. Vault never assembles the key or signs — it is a dumb, authenticated, encrypted-shard store.

This is purely additive and backwards-compatible: a brand-new table and two new routes, leaving the existing users table, key routes, and /signature flow completely untouched.

▎ The wallet/client side that generates the key, splits it, and signs lives in a separate PR. This PR is the server-side enabler and can be reviewed/merged independently.

Why

Today an OAuth-backed account's full private key lives in Vault, so a Vault DB breach — or a stolen OAuth token — is sufficient to sign. With a 2-of-2 split, neither party holds the whole key at rest: Vault stores only its shard, the user's device stores the other, and both are required to produce a signature. This is the first step toward true threshold ECDSA (which would later remove reconstruction entirely).

Design

- Additive secret sharing: the client generates d, splits it d = a + b (mod n), keeps shard a, and stores shard b here.
- Reconstruct-to-sign on the client: at signing time the client fetches shard b, reconstructs the full private key using both shards, signs, and discards it. Vault’s only job is to store/return shard b.
- Vault encrypts shard b at rest with the existing NaCl SecretBox master key (same encrypt/decrypt used for users.enc_sec_prv_key).

Changes

New table: mpc_keys

Keyed by (x_user_unique_name, x_identity_provider_id) like users, but entirely separate:

CREATE TABLE IF NOT EXISTS mpc_keys(
  id serial              PRIMARY KEY,
  x_user_unique_name     varchar(512) NOT NULL,
  x_identity_provider_id varchar(512) NOT NULL,
  salt bytea             NOT NULL,
  nonce bytea            NOT NULL,
  enc_shard bytea        NOT NULL,
  address bytea          NOT NULL,
  UNIQUE (x_user_unique_name, x_identity_provider_id)
);
CREATE INDEX IF NOT EXISTS indexed_mpc_nameId ON mpc_keys (x_user_unique_name, x_identity_provider_id);

- Database/Tables.hs — mpcKeysTable (Opaleye table).
- Database/Create.hs — mpcKeysTable :: Query (the CREATE TABLE IF NOT EXISTS).
- Database/Migrations.hs — appended (Throw, mpcKeysTable) to the migration list. Existing nodes run only the new tail; fresh nodes get it in order. Idempotent via IF NOT EXISTS, and the
schema-version counter bumps automatically.
- Database/Queries.hs — postMpcKeyQuery' (insert-if-absent) and getMpcShardQuery' (select by name+provider).

New routes (JWT-gated, under /strato/v2.3)

Mirror the existing ' routes: nginx validates the bearer token and injects X-USER-UNIQUE-NAME / X-IDENTITY-PROVIDER-ID.

- API/MPC.hs (new) — MPCKeyShare { shard, address }, MPCKeyMeta { address }, and route types PostMPCKey' / GetMPCKey'.
- API.hs — added PostMPCKey' / GetMPCKey' to VaultWrapperAPI (+ re-export the module).
- Server/MPC.hs (new) — postMPCKey' (encrypt + store; 409 if one already exists) and getMPCKey' (decrypt + return).
- Server.hs — wired the two handlers into vaultWrapper.

POST /strato/v2.3/mpckey — store the Vault shard (one per identity)
Authorization: Bearer <jwt>
Content-Type: application/json

{ "shard": "<hex>", "address": "<hex>" }
→ 200 { "status": "success", "address": "<hex>" } · 409 if a shard already exists for this identity.

GET /strato/v2.3/mpckey — return the Vault shard (for client-side signing)
Authorization: Bearer <jwt>
→ 200 { "shard": "<hex>", "address": "<hex>" } · 400 if no shard exists for this

nginx

- vault-nginx/nginx.tpl.conf — added a location /strato/v2.3/mpckey block mirroruns openid.lua for token validation + identity-header injection).

Backwards compatibility

- New table, new routes, new modules only. No changes to users, the existing key routes, or their behavior.
- hpack auto-discovers the new modules (both api and server use source-dirs: src with no explicit exposed-modules).

Security notes

- Shard b is encrypted at rest with the vault master key (NaCl SecretBox / XSalsa20-Poly1305) — identical to how user private keys are stored.
- Routes are JWT-gated; GET returns shard b only to the authenticated identity. Shard b is useless on its own (the client's shard a is required to reconstruct), so an intercepted response or
a DB leak alone cannot sign.
- One shard per (user, identity-provider); POST refuses to overwrite an existing shard.

Caveats & follow-ups

- True threshold ECDSA (no reconstruction) and DKG are intentionally out of scope here; this shard store is the foundation for them.