### PR TITLE
Fix unnecessary mainnet RPC calls on testnet nodes eg. Buildtest , workspace

### DIFF
--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -78,8 +78,6 @@ import { useUser } from "@/context/UserContext";
 
 
 const queryClient = new QueryClient();
-const proxiedChainIds = new Set([mainnet.id, sepolia.id, base.id, baseSepolia.id, linea.id, lineaSepolia.id]);
-const baseChains = [mainnet, polygon, sepolia, base, baseSepolia, linea, lineaSepolia] as const;
 
 const AuthGate = ({ children }: { children: ReactNode }) => {
   const { loading } = useUser();
@@ -163,6 +161,12 @@ const App = () => {
     if (!loading) {
       const appName = "STRATO";
       const stratoChain = getStratoChain();
+      const networkName = (window as { ENV?: { NETWORK_NAME?: string } }).ENV?.NETWORK_NAME || "";
+      const isProduction = networkName === "upquark";
+      const baseChains = isProduction
+        ? [mainnet, polygon, base, linea]
+        : [sepolia, baseSepolia, lineaSepolia];
+      const proxiedChainIds: Set<number> = new Set(baseChains.filter(c => c.id !== polygon.id).map(c => c.id));
       const chains = stratoChain ? [...baseChains, stratoChain] : baseChains;
       const transports: Record<number, Transport> = Object.fromEntries(
         chains.map((chain) => [
@@ -190,7 +194,7 @@ const App = () => {
 
       const config = createConfig({
         connectors,
-        chains: chains as unknown as readonly [typeof mainnet, ...(typeof baseChains)],
+        chains: chains as unknown as readonly [typeof mainnet, ...(typeof mainnet)[]],
         transports,
       });
 


### PR DESCRIPTION
**Root cause:** The baseChains array in App.tsx was hardcoded with all chains (mainnet + testnet) regardless of the environment. When a user connected MetaMask on a testnet node, the wallet defaulted to Mainnet (chain 1). Wagmi automatically polls the wallet's connected chain, so it sent RPC requests to /api/rpc/1. The backend proxied these to eth.merkle.io (the default Mainnet RPC, since RPC_URL_MAINNET is not configured on testnet nodes). This provider rate-limited the requests (HTTP 429), returning an HTML error page instead of JSON. The RPC controller detected the non-JSON response and returned a 502 error, causing repeated error toasts in the UI.

**Fix:** Made baseChains environment-aware using window.ENV.NETWORK_NAME. Production (upquark) registers only mainnet chains (mainnet, polygon, base, linea), and testnet registers only testnet chains (sepolia, baseSepolia, lineaSepolia). This prevents wagmi from polling chains that don't belong to the current environment.