### PR TITLE
Fixed 401s when using OAuth login with extension installed

### DIFF
--- a/strato-wallet/src/core/csrf-bypass.ts
+++ b/strato-wallet/src/core/csrf-bypass.ts
@@ -4,6 +4,15 @@
 // allowlist (curl/axios/node-fetch/…). An extension fetch can't set User-Agent
 // directly, so we use declarativeNetRequest to set an API-client UA on the node
 // API paths the wallet POSTs to: BLOC, strato-api, and the vault signature.
+//
+// This rule MUST only touch the wallet's OWN requests. All wallet node requests
+// run in the background service worker (dApp: inpage -> content -> background ->
+// rpc-engine; UI: runtime.onMessage -> background), so they carry tabId === -1.
+// We scope the rule to tabIds:[-1] so it never rewrites the User-Agent on a host
+// page's own requests. Without this scoping the broad urlFilters also matched a
+// page's requests — e.g. smd-ui's authenticated POST /strato/v2.3/transaction —
+// stripping its real browser UA so nginx stopped treating it as a session-cookie
+// request and returned 401. tabIds is only supported on session-scoped rules.
 
 const API_USER_AGENT = "STRATO-Wallet-Extension axios/1.0";
 
@@ -11,9 +20,19 @@ const API_USER_AGENT = "STRATO-Wallet-Extension axios/1.0";
 const PATHS = ["/bloc/", "/strato-api/", "/strato/v2.3/"];
 
 export async function installCsrfBypassRule(): Promise<void> {
+  const ids = PATHS.map((_, i) => i + 1);
+
+  // Older builds installed these as *dynamic* rules (persistent, and unscoped by
+  // tabId, so they leaked onto host-page requests). Clear them so an upgraded
+  // install doesn't keep rewriting page requests via the stale rule.
   try {
-    const ids = PATHS.map((_, i) => i + 1);
-    await browser.declarativeNetRequest.updateDynamicRules({
+    await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds: ids });
+  } catch (e) {
+    console.error("Failed to clear legacy CSRF-bypass dynamic rules", e);
+  }
+
+  try {
+    await browser.declarativeNetRequest.updateSessionRules({
       removeRuleIds: ids,
       addRules: PATHS.map((urlFilter, i) => ({
         id: i + 1,
@@ -24,7 +43,10 @@ export async function installCsrfBypassRule(): Promise<void> {
             { header: "user-agent", operation: "set", value: API_USER_AGENT },
           ],
         },
-        condition: { urlFilter, requestMethods: ["post"] },
+        // tabIds:[-1] restricts the rule to requests not tied to a browser tab —
+        // i.e. the wallet's own background service-worker fetches — so host-page
+        // (e.g. smd-ui) requests to the same paths keep their real User-Agent.
+        condition: { urlFilter, requestMethods: ["post"], tabIds: [-1] },
       })),
     });
   } catch (e) {


### PR DESCRIPTION
I encountered a bug yesterday, where I was getting 401 errors when trying to post a transaction from SMD using the traditional STRATO OAuth wallet. After some debugging, I determined the issue was caused by something in the new STRATO wallet Chrome extension. When posting the transaction from an incognito window, the transaction succeeded, and when signing through the Chrome extension, it worked too. The problem turned out to be a rules issue in the extension that caused the extension to strip the Authorization header from the request, even though the request wasn't being sent by the extension. This PR fixes that issue