### PR TITLE
fix: show actual balance in bridge out summary instead of capped value

### DIFF
--- a/mercata/ui/src/components/bridge/BridgeOut.tsx
+++ b/mercata/ui/src/components/bridge/BridgeOut.tsx
@@ -118,14 +118,23 @@ const BridgeOut: React.FC<BridgeOutProps> = ({ isSaving = false, guestMode = fal
 
   const balanceImpact = useMemo(() => {
     try {
-      const maxAmountWei = BigInt(maxAmount || "0");
+      const tokenBalanceWei = balanceData?.balance?.toString() || "0";
+      const actualBalance = computeMaxTransferable(
+        tokenBalanceWei,
+        selectedToken?.stratoToken === usdstAddress,
+        voucherBalance,
+        usdstBalance,
+        FEE_WEI,
+        () => {}
+      );
+      const balanceWei = BigInt(actualBalance || "0");
       const amountWei = safeParseUnits(amount || "0", DECIMAL);
-      const afterWei = maxAmountWei > amountWei ? maxAmountWei - amountWei : 0n;
-      return { before: maxAmountWei.toString(), after: afterWei.toString() };
+      const afterWei = balanceWei > amountWei ? balanceWei - amountWei : 0n;
+      return { before: balanceWei.toString(), after: afterWei.toString() };
     } catch {
       return { before: "0", after: "0" };
     }
-  }, [maxAmount, amount]);
+  }, [balanceData?.balance, selectedToken?.stratoToken, usdstBalance, voucherBalance, amount]);
 
   const hasValidAmount = !!amount && !amountError && !feeError;
 


### PR DESCRIPTION
#7210

<img width="717" height="712" alt="Screenshot 2026-07-08 at 4 59 47 PM" src="https://github.com/user-attachments/assets/324f44b3-c32a-4b43-b042-76aa89256c75" />
