### PR TITLE
feat: hide Borrow/Lending/Safety/Liquidations tabs, add Bad Debt to Advanced

### DIFF
--- a/mercata/ui/src/lib/rewards/activityLinks.ts
+++ b/mercata/ui/src/lib/rewards/activityLinks.ts
@@ -64,14 +64,14 @@ export const getActivityLink = (activityName: string): string | null => {
     return '/dashboard/swap';
   }
 
-  // Borrow activities - goes to the Advanced page, Borrow tab
+  // Borrow activities - goes to the Borrow page (CDP vaults)
   if (lowerName.includes('borrow')) {
-    return '/dashboard/advanced?tab=borrow';
+    return '/dashboard/borrow';
   }
   
-  // Lending activities - goes to the Advanced page, Lending Pools tab
+  // Lending activities - goes to the Advanced page (hidden tab, defaults to swap)
   if (lowerName.includes('lend')) {
-    return '/dashboard/advanced?tab=lending';
+    return '/dashboard/advanced';
   }
 
   // Deposit activities - goes to the Deposits page
@@ -84,9 +84,9 @@ export const getActivityLink = (activityName: string): string | null => {
     return '/dashboard/withdrawals';
   }
 
-  // Safety Module activities - goes to the Advanced page, Safety tab
+  // Safety Module activities - goes to the Advanced page (hidden tab, defaults to swap)
   if (lowerName.includes('safety')) {
-    return '/dashboard/advanced?tab=safety';
+    return '/dashboard/advanced';
   }
 
   // No match found

--- a/mercata/ui/src/pages/Advanced.tsx
+++ b/mercata/ui/src/pages/Advanced.tsx
@@ -1,52 +1,68 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DashboardHeader from '../components/dashboard/DashboardHeader';
 import DashboardSidebar from '../components/dashboard/DashboardSidebar';
 import MobileBottomNav from '../components/dashboard/MobileBottomNav';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import LendingPoolSection from '@/components/dashboard/LendingPoolSection';
+import { Card, CardContent } from "@/components/ui/card";
 import SwapPoolsSection from '@/components/dashboard/SwapPoolsSection';
-import LiquidationsSection from '@/components/dashboard/LiquidationsSection';
-import SafetyModuleSection from '@/components/dashboard/SafetyModuleSection';
+import BadDebtView from '@/components/cdp/BadDebtView';
 import { useUser } from '@/context/UserContext';
-import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 import GuestSignInBanner from '@/components/ui/GuestSignInBanner';
-import { safeParseUnits } from "@/utils/numberUtils";
-import { formatUnits } from "ethers";
-import { useToast } from "@/hooks/use-toast";
-import { useLendingContext } from "@/context/LendingContext";
-import { useTokenContext } from "@/context/TokenContext";
-import { CollateralData } from "@/interface";
-import PositionSection from "@/components/Positions";
-import CollateralModal from "@/components/borrow/CollateralModal";
-import { WITHDRAW_COLLATERAL_FEE, SUPPLY_COLLATERAL_FEE } from "@/lib/constants";
-import BorrowForm from "@/components/borrow/BorrowForm";
-import RepayForm from "@/components/borrow/RepayForm";
-import CollateralManagementTable from "@/components/borrow/CollateralManagementTable";
-import { useSmartPolling } from "@/hooks/useSmartPolling";
-import LiquidationAlertBanner from '@/components/ui/LiquidationAlertBanner';
 import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
 
-type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "safety" | "psm";
+// Hidden imports - temporarily disabled 
+// import { CardHeader, CardTitle } from "@/components/ui/card";
+// import LendingPoolSection from '@/components/dashboard/LendingPoolSection';
+// import LiquidationsSection from '@/components/dashboard/LiquidationsSection';
+// import SafetyModuleSection from '@/components/dashboard/SafetyModuleSection';
+// import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
+// import { safeParseUnits } from "@/utils/numberUtils";
+// import { formatUnits } from "ethers";
+// import { useToast } from "@/hooks/use-toast";
+// import { useLendingContext } from "@/context/LendingContext";
+// import { useTokenContext } from "@/context/TokenContext";
+// import { CollateralData } from "@/interface";
+// import PositionSection from "@/components/Positions";
+// import CollateralModal from "@/components/borrow/CollateralModal";
+// import { WITHDRAW_COLLATERAL_FEE, SUPPLY_COLLATERAL_FEE } from "@/lib/constants";
+// import BorrowForm from "@/components/borrow/BorrowForm";
+// import RepayForm from "@/components/borrow/RepayForm";
+// import CollateralManagementTable from "@/components/borrow/CollateralManagementTable";
+// import { useSmartPolling } from "@/hooks/useSmartPolling";
+// import LiquidationAlertBanner from '@/components/ui/LiquidationAlertBanner';
+
+type TopTab = "swap" | "psm" | "bad-debt";
+// Hidden type - temporarily disabled 
+// type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "safety" | "psm";
 
 const Advanced = () => {
   const [searchParams] = useSearchParams();
-  const [activeTab, setActiveTab] = useState<TopTab>("borrow");
+  const [activeTab, setActiveTab] = useState<TopTab>("swap");
+  const { isLoggedIn } = useUser();
+
+  useEffect(() => {
+    const tabParam = searchParams.get('tab');
+
+    if (tabParam && ['swap', 'psm', 'bad-debt'].includes(tabParam)) {
+      setActiveTab(tabParam as TopTab);
+    }
+    // Hidden route validation - temporarily disabled 
+    // if (tabParam && ['lending', 'swap', 'liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
+    //   setActiveTab(tabParam as TopTab);
+    // }
+  }, [searchParams]);
+
+/* Hidden state and functions - temporarily disabled 
   const [borrowActiveTab, setBorrowActiveTab] = useState<"borrow" | "repay">("borrow");
-  const { isLoggedIn, userAddress } = useUser();
+  const { userAddress } = useUser();
   const { toast } = useToast();
   const { usdstBalance, voucherBalance, fetchUsdstBalance } = useTokenContext();
   const { userRewards, loading: rewardsLoading } = useRewardsUserInfo();
 
+  // Subtab handling for borrow tab
   useEffect(() => {
-    const tabParam = searchParams.get('tab');
     const subtabParam = searchParams.get('subtab');
-
-    if (tabParam && ['lending', 'swap', 'liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
-      setActiveTab(tabParam as TopTab);
-    }
-
     if (subtabParam && ['borrow', 'repay'].includes(subtabParam)) {
       setBorrowActiveTab(subtabParam as "borrow" | "repay");
     }
@@ -182,6 +198,7 @@ const Advanced = () => {
   };
 
   const guestMode = !isLoggedIn;
+  */
 
   return (
     <div className="min-h-screen bg-background pb-16 md:pb-0">
@@ -194,26 +211,47 @@ const Advanced = () => {
           <Card className="mb-2 md:mb-6 bg-transparent border-0 rounded-none shadow-none">
             <CardContent className="p-0 md:pt-4">
               <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TopTab)} className="w-full">
-                <TabsList className="grid w-full grid-cols-6 mb-3 md:mb-4 h-auto gap-0.5 md:gap-1">
-                  <TabsTrigger value="borrow" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                    Borrow
-                  </TabsTrigger>
-                  <TabsTrigger value="lending" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                    Lending
-                  </TabsTrigger>
+                <TabsList className="grid w-full grid-cols-3 mb-3 md:mb-4 h-auto gap-0.5 md:gap-1">
                   <TabsTrigger value="swap" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                    Swap
-                  </TabsTrigger>
-                  <TabsTrigger value="safety" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                    Safety
+                    Swap Pools
                   </TabsTrigger>
                   <TabsTrigger value="psm" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                     PSM
                   </TabsTrigger>
-                  <TabsTrigger value="liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                    Liquidations
+                  <TabsTrigger value="bad-debt" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                    Bad Debt
                   </TabsTrigger>
                 </TabsList>
+                <TabsContent value="swap">
+                  {!isLoggedIn && (
+                    <GuestSignInBanner message="Sign in to add liquidity to swap pools and earn rewards" />
+                  )}
+                  <SwapPoolsSection />
+                </TabsContent>
+                <TabsContent value="psm">
+                  {!isLoggedIn && (
+                    <GuestSignInBanner message="Sign in to use the Direct Mint PSM" />
+                  )}
+                  <DirectMintPSMSection />
+                </TabsContent>
+                <TabsContent value="bad-debt">
+                  <BadDebtView guestMode={!isLoggedIn} />
+                </TabsContent>
+
+                {/* Hidden tabs - temporarily disabled      
+                <TabsTrigger value="borrow" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  Borrow
+                </TabsTrigger>
+                <TabsTrigger value="lending" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  Lending
+                </TabsTrigger>
+                <TabsTrigger value="safety" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  Safety
+                </TabsTrigger>
+                <TabsTrigger value="liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  Liquidations
+                </TabsTrigger>
+
                 <TabsContent value="borrow">
                   {!isLoggedIn && (
                     <GuestSignInBanner message="Sign in to borrow USDST" />
@@ -304,23 +342,11 @@ const Advanced = () => {
                   )}
                   <LendingPoolSection />
                 </TabsContent>
-                <TabsContent value="swap">
-                  {!isLoggedIn && (
-                    <GuestSignInBanner message="Sign in to add liquidity to swap pools and earn rewards" />
-                  )}
-                  <SwapPoolsSection />
-                </TabsContent>
                 <TabsContent value="safety">
                   {!isLoggedIn && (
                     <GuestSignInBanner message="Sign in to stake USDST in the Safety Module" />
                   )}
                   <SafetyModuleSection />
-                </TabsContent>
-                <TabsContent value="psm">
-                  {!isLoggedIn && (
-                    <GuestSignInBanner message="Sign in to use the Direct Mint PSM" />
-                  )}
-                  <DirectMintPSMSection />
                 </TabsContent>
                 <TabsContent value="liquidations">
                   {!isLoggedIn && (
@@ -328,6 +354,7 @@ const Advanced = () => {
                   )}
                   <LiquidationsSection />
                 </TabsContent>
+                */}
               </Tabs>
             </CardContent>
           </Card>

--- a/mercata/ui/src/pages/Advanced.tsx
+++ b/mercata/ui/src/pages/Advanced.tsx
@@ -11,11 +11,12 @@ import { useUser } from '@/context/UserContext';
 import GuestSignInBanner from '@/components/ui/GuestSignInBanner';
 import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
 
-// Hidden imports - temporarily disabled 
+// Hidden imports - temporarily disabled per issue #7228
 // import { CardHeader, CardTitle } from "@/components/ui/card";
 // import LendingPoolSection from '@/components/dashboard/LendingPoolSection';
 // import LiquidationsSection from '@/components/dashboard/LiquidationsSection';
 // import SafetyModuleSection from '@/components/dashboard/SafetyModuleSection';
+// import LiquidationsView from '@/components/cdp/LiquidationsView'; // Moved from Borrow page per issue #7228
 // import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 // import { safeParseUnits } from "@/utils/numberUtils";
 // import { formatUnits } from "ethers";
@@ -33,8 +34,8 @@ import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
 // import LiquidationAlertBanner from '@/components/ui/LiquidationAlertBanner';
 
 type TopTab = "swap" | "psm" | "bad-debt";
-// Hidden type - temporarily disabled 
-// type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "safety" | "psm";
+// Hidden type - temporarily disabled   
+// type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "cdp-liquidations" | "safety" | "psm";
 
 const Advanced = () => {
   const [searchParams] = useSearchParams();
@@ -48,7 +49,7 @@ const Advanced = () => {
       setActiveTab(tabParam as TopTab);
     }
     // Hidden route validation - temporarily disabled 
-    // if (tabParam && ['lending', 'swap', 'liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
+    // if (tabParam && ['lending', 'swap', 'liquidations', 'cdp-liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
     //   setActiveTab(tabParam as TopTab);
     // }
   }, [searchParams]);
@@ -238,7 +239,7 @@ const Advanced = () => {
                   <BadDebtView guestMode={!isLoggedIn} />
                 </TabsContent>
 
-                {/* Hidden tabs - temporarily disabled      
+                {/* Hidden tabs - temporarily disabled 
                 <TabsTrigger value="borrow" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                   Borrow
                 </TabsTrigger>
@@ -353,6 +354,17 @@ const Advanced = () => {
                     <GuestSignInBanner message="Sign in to view and liquidate unhealthy positions" />
                   )}
                   <LiquidationsSection />
+                </TabsContent>
+
+                // CDP Liquidations tab - Moved from Borrow page per issue #7228
+                <TabsTrigger value="cdp-liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  CDP Liquidations
+                </TabsTrigger>
+                <TabsContent value="cdp-liquidations">
+                  {!isLoggedIn && (
+                    <GuestSignInBanner message="Sign in to view and liquidate CDP positions" />
+                  )}
+                  <LiquidationsView guestMode={!isLoggedIn} />
                 </TabsContent>
                 */}
               </Tabs>

--- a/mercata/ui/src/pages/Advanced.tsx
+++ b/mercata/ui/src/pages/Advanced.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import SwapPoolsSection from '@/components/dashboard/SwapPoolsSection';
 import BadDebtView from '@/components/cdp/BadDebtView';
+import LiquidationsView from '@/components/cdp/LiquidationsView';
 import { useUser } from '@/context/UserContext';
 import GuestSignInBanner from '@/components/ui/GuestSignInBanner';
 import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
@@ -16,7 +17,6 @@ import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
 // import LendingPoolSection from '@/components/dashboard/LendingPoolSection';
 // import LiquidationsSection from '@/components/dashboard/LiquidationsSection';
 // import SafetyModuleSection from '@/components/dashboard/SafetyModuleSection';
-// import LiquidationsView from '@/components/cdp/LiquidationsView'; // Moved from Borrow page per issue #7228
 // import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
 // import { safeParseUnits } from "@/utils/numberUtils";
 // import { formatUnits } from "ethers";
@@ -33,9 +33,9 @@ import DirectMintPSMSection from '@/components/dashboard/DirectMintPSMSection';
 // import { useSmartPolling } from "@/hooks/useSmartPolling";
 // import LiquidationAlertBanner from '@/components/ui/LiquidationAlertBanner';
 
-type TopTab = "swap" | "psm" | "bad-debt";
-// Hidden type - temporarily disabled   
-// type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "cdp-liquidations" | "safety" | "psm";
+type TopTab = "swap" | "psm" | "bad-debt" | "liquidations";
+// Hidden type - temporarily disabled per issue #7228
+// type TopTab = "borrow" | "lending" | "swap" | "liquidations" | "safety" | "psm";
 
 const Advanced = () => {
   const [searchParams] = useSearchParams();
@@ -45,11 +45,11 @@ const Advanced = () => {
   useEffect(() => {
     const tabParam = searchParams.get('tab');
 
-    if (tabParam && ['swap', 'psm', 'bad-debt'].includes(tabParam)) {
+    if (tabParam && ['swap', 'psm', 'bad-debt', 'liquidations'].includes(tabParam)) {
       setActiveTab(tabParam as TopTab);
     }
-    // Hidden route validation - temporarily disabled 
-    // if (tabParam && ['lending', 'swap', 'liquidations', 'cdp-liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
+    // Hidden route validation - temporarily disabled per issue #7228
+    // if (tabParam && ['lending', 'swap', 'liquidations', 'safety', 'borrow', 'psm'].includes(tabParam)) {
     //   setActiveTab(tabParam as TopTab);
     // }
   }, [searchParams]);
@@ -212,7 +212,7 @@ const Advanced = () => {
           <Card className="mb-2 md:mb-6 bg-transparent border-0 rounded-none shadow-none">
             <CardContent className="p-0 md:pt-4">
               <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TopTab)} className="w-full">
-                <TabsList className="grid w-full grid-cols-3 mb-3 md:mb-4 h-auto gap-0.5 md:gap-1">
+                <TabsList className="grid w-full grid-cols-4 mb-3 md:mb-4 h-auto gap-0.5 md:gap-1">
                   <TabsTrigger value="swap" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                     Swap Pools
                   </TabsTrigger>
@@ -221,6 +221,9 @@ const Advanced = () => {
                   </TabsTrigger>
                   <TabsTrigger value="bad-debt" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                     Bad Debt
+                  </TabsTrigger>
+                  <TabsTrigger value="liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                    Liquidations
                   </TabsTrigger>
                 </TabsList>
                 <TabsContent value="swap">
@@ -238,8 +241,14 @@ const Advanced = () => {
                 <TabsContent value="bad-debt">
                   <BadDebtView guestMode={!isLoggedIn} />
                 </TabsContent>
+                <TabsContent value="liquidations">
+                  {!isLoggedIn && (
+                    <GuestSignInBanner message="Sign in to view and liquidate CDP positions" />
+                  )}
+                  <LiquidationsView guestMode={!isLoggedIn} />
+                </TabsContent>
 
-                {/* Hidden tabs - temporarily disabled 
+                {/* Hidden tabs - temporarily disabled per issue #7228 
                 <TabsTrigger value="borrow" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                   Borrow
                 </TabsTrigger>
@@ -249,8 +258,8 @@ const Advanced = () => {
                 <TabsTrigger value="safety" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
                   Safety
                 </TabsTrigger>
-                <TabsTrigger value="liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                  Liquidations
+                <TabsTrigger value="lending-liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
+                  Lending Liquidations
                 </TabsTrigger>
 
                 <TabsContent value="borrow">
@@ -349,22 +358,11 @@ const Advanced = () => {
                   )}
                   <SafetyModuleSection />
                 </TabsContent>
-                <TabsContent value="liquidations">
+                <TabsContent value="lending-liquidations">
                   {!isLoggedIn && (
                     <GuestSignInBanner message="Sign in to view and liquidate unhealthy positions" />
                   )}
                   <LiquidationsSection />
-                </TabsContent>
-
-                // CDP Liquidations tab - Moved from Borrow page per issue #7228
-                <TabsTrigger value="cdp-liquidations" className="text-[10px] md:text-sm py-1.5 md:py-2 px-0.5 md:px-3">
-                  CDP Liquidations
-                </TabsTrigger>
-                <TabsContent value="cdp-liquidations">
-                  {!isLoggedIn && (
-                    <GuestSignInBanner message="Sign in to view and liquidate CDP positions" />
-                  )}
-                  <LiquidationsView guestMode={!isLoggedIn} />
                 </TabsContent>
                 */}
               </Tabs>

--- a/mercata/ui/src/pages/Borrow.tsx
+++ b/mercata/ui/src/pages/Borrow.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect } from "react";
-import { useSearchParams } from 'react-router-dom';
 import { useUser } from "@/context/UserContext";
 import { useCDP } from '@/context/CDPContext';
 import { useRewardsUserInfo } from '@/hooks/useRewardsUserInfo';
@@ -8,13 +7,16 @@ import { useTokenContext } from '@/context/TokenContext';
 import DashboardSidebar from "../components/dashboard/DashboardSidebar";
 import DashboardHeader from "../components/dashboard/DashboardHeader";
 import MobileBottomNav from "../components/dashboard/MobileBottomNav";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Mint from '@/components/cdp/v2/components/Mint/Mint';
 import DebtPosition from '@/components/cdp/v2/components/DebtPosition';
 import VaultsList from '@/components/cdp/VaultsList';
-import BadDebtView from '@/components/cdp/BadDebtView';
-import LiquidationsView from '@/components/cdp/LiquidationsView';
 import GuestSignInBanner from '@/components/ui/GuestSignInBanner';
+
+// Hidden imports - temporarily disabled 
+// import { useSearchParams } from 'react-router-dom';
+// import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+// import BadDebtView from '@/components/cdp/BadDebtView';
+// import LiquidationsView from '@/components/cdp/LiquidationsView';
 
 const Borrow = () => {
   const { isLoggedIn } = useUser();
@@ -22,8 +24,6 @@ const Borrow = () => {
   const { refetch: refetchRewards } = useRewardsUserInfo();
   const { fetchTokens } = useUserTokens();
   const { fetchUsdstBalance, refreshNetBalance } = useTokenContext();
-  const [searchParams] = useSearchParams();
-  const [activeTab, setActiveTab] = useState('vaults');
   const [vaultsRefreshTrigger, setVaultsRefreshTrigger] = useState(0);
   const [mintPlannerRefreshTrigger, setMintPlannerRefreshTrigger] = useState(0);
 
@@ -31,12 +31,17 @@ const Borrow = () => {
     document.title = "Borrow | STRATO";
   }, []);
 
+  /* Hidden state and route handling - temporarily disabled 
+  const [searchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState('vaults');
+
   useEffect(() => {
     const subtabParam = searchParams.get('subtab');
     if (subtabParam && ['vaults', 'bad-debt', 'liquidations'].includes(subtabParam)) {
       setActiveTab(subtabParam);
     }
   }, [searchParams]);
+  */
 
   const refreshAllCDPComponents = useCallback(async () => {
     setVaultsRefreshTrigger(prev => prev + 1);
@@ -66,6 +71,32 @@ const Borrow = () => {
         <DashboardHeader title="Borrow" />
 
         <main className="p-4 md:p-6">
+          {/* Tabs removed - only showing Vaults content directly per issue #7228 */}
+          {!isLoggedIn && (
+            <GuestSignInBanner message="Sign in to create vaults and mint USDST" />
+          )}
+          <div className="flex flex-col lg:flex-row gap-6">
+            <div className={isLoggedIn ? "w-full lg:w-[60%]" : "w-full"}>
+              <Mint
+                onSuccess={handleQuickMintSuccess}
+                refreshTrigger={mintPlannerRefreshTrigger}
+                guestMode={!isLoggedIn}
+              />
+            </div>
+            {isLoggedIn && (
+              <div className="w-full lg:w-[40%] space-y-6">
+                <DebtPosition refreshTrigger={vaultsRefreshTrigger} />
+                <VaultsList
+                  refreshTrigger={vaultsRefreshTrigger}
+                  onVaultActionSuccess={handleVaultActionSuccess}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Hidden tabs - temporarily disabled 
+          To re-enable: uncomment this section, the imports, and the state/useEffect above
+          
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="grid w-full grid-cols-3 mb-3 md:mb-4 h-auto">
               <TabsTrigger value="vaults" className="text-xs md:text-sm py-2 px-1 md:px-3">
@@ -111,6 +142,7 @@ const Borrow = () => {
               <LiquidationsView guestMode={!isLoggedIn} />
             </TabsContent>
           </Tabs>
+          */}
         </main>
       </div>
 


### PR DESCRIPTION
#7228 

Temporarily hides Borrow, Lending, Safety Module, and Liquidations tabs from Advanced page. Removes Bad Debt and Liquidations tabs from Borrow page (now shows Vaults only). Adds Bad Debt tab to Advanced page. All hidden code is preserved as comments for easy re-enabling. Updates activity links to redirect removed tab routes appropriately.