### PR TITLE
Activity feed updates

### DIFF
--- a/mercata/backend/src/api/services/activityFilterConfigs.ts
+++ b/mercata/backend/src/api/services/activityFilterConfigs.ts
@@ -7,6 +7,8 @@ export const ACTIVITY_FILTER_CONFIGS: Record<string, FilterConfig> = {
   "Token:Transfer": { type: "or", attributes: ["from", "to"], excludeProtocolAddresses: ["from", "to"] },
   "YieldVault:Transfer": { type: "or", attributes: ["from", "to"], excludeProtocolAddresses: ["from", "to"] },
   "SaveUSDSTVault:Transfer": { type: "or", attributes: ["from", "to"], excludeProtocolAddresses: ["from", "to"] },
+  "SaveUSDSTVault:Deposit": { type: "single", attribute: "owner" },
+  "SaveUSDSTVault:Withdraw": { type: "or", attributes: ["owner", "receiver"] },
   "MercataBridge:DepositCompleted": { type: "single", attribute: "stratoRecipient" },
   "StratoNativeBridge:NativeDepositCompleted": { type: "single", attribute: "stratoRecipient" },
   "MercataBridge:WithdrawalRequested": { type: "single", attribute: "user" },

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -360,6 +360,7 @@ export async function getInternalAddresses() {
   // Network-specific addresses (set by initNetworkConfig)
   addresses.push(rewards || '', escrow, vaultFactory);
   addresses.push(stratoStaking, validatorRegistry);
+  addresses.push(saveUsdstVault, usdcYieldVault, ethCarryVault, wbtcCarryVault);
 
   // Lending Registry --> lendingPool, collateralVault, liquidityPool
   const { data: [lending] } = await cirrus.get(accessToken, "/BlockApps-LendingRegistry", {

--- a/mercata/ui/src/components/dashboard/ActivityFeedCards.tsx
+++ b/mercata/ui/src/components/dashboard/ActivityFeedCards.tsx
@@ -32,6 +32,7 @@ type YieldVaultDef = {
   address: string;
   name: string;
   shareSymbol: string;
+  assetSymbol: string;
 };
 
 type YieldVaultInfo = {
@@ -67,14 +68,18 @@ const ActivityFeedCards = ({ isMyActivity }: ActivityFeedCardsProps) => {
         event_name: config.event_name,
       }));
 
-      // Filter by selected activity type if not "all"
+      // Filter by selected activity type if not "all".
+      // Types sharing a display name (e.g. "Send") are queried together as one group.
       if (selectedActivityType !== "all") {
         const selectedConfig = activityTypes[selectedActivityType];
         if (selectedConfig) {
-          activityTypePairs = [{
-            contract_name: selectedConfig.contract_name,
-            event_name: selectedConfig.event_name,
-          }];
+          const selectedLabel = selectedConfig.displayName || selectedActivityType;
+          activityTypePairs = Object.entries(activityTypes)
+            .filter(([key, config]) => (config.displayName || key) === selectedLabel)
+            .map(([, config]) => ({
+              contract_name: config.contract_name,
+              event_name: config.event_name,
+            }));
         }
       }
 
@@ -157,10 +162,19 @@ const ActivityFeedCards = ({ isMyActivity }: ActivityFeedCardsProps) => {
 
       const yieldVaultAddresses = new Set(
         response.events
+          .filter(event => event.contract_name === "YieldVault")
+          .map(event => normalizeAddress(event.address))
+          .filter(Boolean)
+      );
+      const yieldVaultTransferAddresses = new Set(
+        response.events
           .filter(event => event.contract_name === "YieldVault" && event.event_name === "Transfer")
           .map(event => normalizeAddress(event.address))
           .filter(Boolean)
       );
+
+      // Vault address (normalized) -> underlying asset symbol (e.g. USDC)
+      const vaultAssetSymbolMap = new Map<string, string>();
 
       if (yieldVaultAddresses.size > 0) {
         try {
@@ -168,8 +182,16 @@ const ActivityFeedCards = ({ isMyActivity }: ActivityFeedCardsProps) => {
           const matchingVaults = (res.data || []).filter((vault) =>
             yieldVaultAddresses.has(normalizeAddress(vault.address))
           );
+          matchingVaults.forEach((vault) => {
+            if (vault.assetSymbol) {
+              vaultAssetSymbolMap.set(normalizeAddress(vault.address), vault.assetSymbol);
+            }
+          });
+          // Vault name labels (via /info) are only needed for share Transfer cards.
           const vaultInfos = await Promise.all(
-            matchingVaults.map((vault) =>
+            matchingVaults.filter((vault) =>
+              yieldVaultTransferAddresses.has(normalizeAddress(vault.address))
+            ).map((vault) =>
               api.get<YieldVaultInfo>(`/earn/yield-vault/${vault.key}/info`).then((infoRes) => infoRes.data).catch(() => ({
                 vaultAddress: vault.address,
                 name: vault.name,
@@ -271,6 +293,9 @@ const ActivityFeedCards = ({ isMyActivity }: ActivityFeedCardsProps) => {
           if (event.contract_name === "YieldVault" && event.event_name === "Transfer") {
             const symbol = tokenSymbolMap.get(normalizeAddress(event.address)) || tokenSymbolMap.get(event.address);
             if (symbol) tokenSymbolsMap.set(event.address, symbol);
+          } else if (event.contract_name === "YieldVault") {
+            const assetSymbol = vaultAssetSymbolMap.get(normalizeAddress(event.address));
+            if (assetSymbol) tokenSymbolsMap.set(event.address, assetSymbol);
           }
           const cardData = config.handler(event, tokenSymbolsMap, userAddress, tokenImagesMap);
           // Add iconConfig from the activity type config
@@ -304,13 +329,17 @@ const ActivityFeedCards = ({ isMyActivity }: ActivityFeedCardsProps) => {
     setCurrentPage(1); // Reset to first page on refresh
   }, []);
 
-  // Get activity type display names from config, sorted alphabetically
+  // Get activity type display names from config, deduplicated (merged types
+  // like "Send" share a label) and sorted alphabetically
   const activityTypeOptions = [
     { value: "all", label: "All types" },
-    ...Object.entries(activityTypes).map(([key, config]) => ({
-      value: key,
-      label: config.displayName || key,
-    })).sort((a, b) => a.label.localeCompare(b.label)),
+    ...Object.entries(activityTypes)
+      .map(([key, config]) => ({
+        value: key,
+        label: config.displayName || key,
+      }))
+      .filter((option, index, options) => options.findIndex(o => o.label === option.label) === index)
+      .sort((a, b) => a.label.localeCompare(b.label)),
   ];
 
   const paginationItems = (() => {

--- a/mercata/ui/src/components/dashboard/activityTypes.tsx
+++ b/mercata/ui/src/components/dashboard/activityTypes.tsx
@@ -258,8 +258,8 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "YieldVaultTransfer": {
     contract_name: "YieldVault",
     event_name: "Transfer",
-    displayName: "YieldVault Send",
-    iconConfig: { icon: Send, color: "bg-cyan-500" },
+    displayName: "Send",
+    iconConfig: { icon: Send, color: "bg-blue-500" },
     handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null): ActivityCardData => {
       const vaultName = tokenSymbols.get(event.address) || tokenSymbols.get(normalizeAddress(event.address));
       const from = event.attributes.from || event.attributes.From || "";
@@ -290,7 +290,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: vaultName ? `${vaultName} Send` : "YieldVault Send",
+        title: "Send",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -311,8 +311,8 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "SaveUSDSTVaultTransfer": {
     contract_name: "SaveUSDSTVault",
     event_name: "Transfer",
-    displayName: "SaveUSDST Send",
-    iconConfig: { icon: Send, color: "bg-cyan-500" },
+    displayName: "Send",
+    iconConfig: { icon: Send, color: "bg-blue-500" },
     handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null): ActivityCardData => {
       const from = event.attributes.from || event.attributes.From || "";
       const to = event.attributes.to || event.attributes.To || "";
@@ -323,7 +323,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
           label: "Amount",
           value: formatValue(value),
           type: "amount",
-          badge: "shares",
+          badge: "SaveUSDST shares",
           rawAmount: getFullAmount(value),
         },
         {
@@ -341,7 +341,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "SaveUSDST Send",
+        title: "Send",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -359,10 +359,119 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       };
     },
   },
+  "SaveUSDSTDeposit": {
+    contract_name: "SaveUSDSTVault",
+    event_name: "Deposit",
+    displayName: "SaveUSDST Deposit",
+    iconConfig: { icon: Download, color: "bg-cyan-500" },
+    getTokenAddress: () => [usdstAddress],
+    handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => {
+      const owner = event.attributes.owner || event.attributes.Owner || "";
+      const assets = event.attributes.assets || event.attributes.Assets || "0";
+      const shares = event.attributes.shares || event.attributes.Shares || "0";
+      const usdstSymbol = tokenSymbols.get(usdstAddress) || "USDST";
+
+      const fields: ActivityField[] = [
+        {
+          label: "Deposited",
+          value: formatValue(assets, usdstAddress),
+          type: "amount",
+          badge: usdstSymbol,
+          image: tokenImages?.get(usdstAddress),
+          imageFallback: usdstSymbol,
+          rawAmount: getFullAmount(assets),
+        },
+        {
+          label: "Shares Minted",
+          value: formatValue(shares),
+          type: "text",
+          badge: "shares",
+        },
+        {
+          label: "Depositor",
+          value: owner,
+          type: "address",
+          isUserAddress: isUserAddress(owner, userAddress),
+        },
+      ];
+
+      return {
+        title: "SaveUSDST Deposit",
+        fields,
+        timestamp: event.block_timestamp || "",
+        eventId: event.id?.toString(),
+        layout: {
+          type: "two-line",
+          line1: {
+            fieldLabels: ["Deposited"],
+            renderer: "amount-with-token",
+          },
+          line2: {
+            fieldLabels: ["Depositor", "Shares Minted"],
+          },
+        },
+      };
+    },
+  },
+  "SaveUSDSTWithdraw": {
+    contract_name: "SaveUSDSTVault",
+    event_name: "Withdraw",
+    displayName: "SaveUSDST Withdraw",
+    iconConfig: { icon: Upload, color: "bg-cyan-600" },
+    getTokenAddress: () => [usdstAddress],
+    handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => {
+      const owner = event.attributes.owner || event.attributes.Owner || "";
+      const receiver = event.attributes.receiver || event.attributes.Receiver || "";
+      const assets = event.attributes.assets || event.attributes.Assets || "0";
+      const usdstSymbol = tokenSymbols.get(usdstAddress) || "USDST";
+
+      const fields: ActivityField[] = [
+        {
+          label: "Withdrawn",
+          value: formatValue(assets, usdstAddress),
+          type: "amount",
+          badge: usdstSymbol,
+          image: tokenImages?.get(usdstAddress),
+          imageFallback: usdstSymbol,
+          rawAmount: getFullAmount(assets),
+        },
+        {
+          label: "Owner",
+          value: owner,
+          type: "address",
+          isUserAddress: isUserAddress(owner, userAddress),
+        },
+        {
+          label: "Receiver",
+          value: receiver,
+          type: "address",
+          isUserAddress: isUserAddress(receiver, userAddress),
+        },
+      ];
+
+      return {
+        title: "SaveUSDST Withdraw",
+        fields,
+        timestamp: event.block_timestamp || "",
+        eventId: event.id?.toString(),
+        layout: {
+          type: "two-line",
+          line1: {
+            fieldLabels: ["Withdrawn"],
+            renderer: "amount-with-token",
+          },
+          line2: {
+            fieldLabels: ["Owner", "Receiver"],
+            renderer: "addresses-with-arrow",
+          },
+        },
+      };
+    },
+  },
   "Deposit": {
     contract_name: "MercataBridge",
     event_name: "DepositCompleted",
-    displayName: "Deposit",
+    displayName: "Non-native Deposit",
     iconConfig: { icon: Download, color: "bg-green-500" },
     getTokenAddress: (event: Event) => {
       const token = event.attributes.stratoToken || event.attributes.strato_token;
@@ -420,7 +529,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ].filter(Boolean) as ActivityField[];
 
       return {
-        title: "Deposit",
+        title: "Non-native Deposit",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -447,13 +556,15 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       const token = event.attributes.stratoToken || event.attributes.strato_token;
       return token ? [token] : [];
     },
-    handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData =>
-      activityTypes.Deposit.handler(event, tokenSymbols, userAddress, tokenImages),
+    handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => ({
+      ...activityTypes.Deposit.handler(event, tokenSymbols, userAddress, tokenImages),
+      title: "Native Deposit",
+    }),
   },
   "Withdraw": {
     contract_name: "MercataBridge",
     event_name: "WithdrawalRequested",
-    displayName: "Bridge Out",
+    displayName: "Non-native Bridge Out",
     iconConfig: { icon: Upload, color: "bg-red-500" },
     getTokenAddress: (event: Event) => {
       const token = event.attributes.token || event.attributes.Token;
@@ -524,7 +635,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       }
 
       return {
-        title: "Bridge Out",
+        title: "Non-native Bridge Out",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -567,7 +678,10 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
         },
       } as Event;
 
-      return activityTypes.Withdraw.handler(normalizedEvent, tokenSymbols, userAddress, tokenImages);
+      return {
+        ...activityTypes.Withdraw.handler(normalizedEvent, tokenSymbols, userAddress, tokenImages),
+        title: "Native Bridge Out",
+      };
     },
   },
   "CDPMint": {
@@ -801,7 +915,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "RewardsClaimed": {
     contract_name: "Rewards",
     event_name: "RewardsClaimed",
-    displayName: "Rewards Claimed",
+    displayName: "Reward Points Claimed",
     iconConfig: { icon: Gift, color: "bg-gradient-to-br from-emerald-400 to-teal-500" },
     getTokenAddress: (event: Event) => {
       // The reward token address is stored in the Rewards contract, not in the event
@@ -833,7 +947,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "Rewards Claimed",
+        title: "Reward Points Claimed",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -1128,7 +1242,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "LiquidityDeposited": {
     contract_name: "LendingPool",
     event_name: "Deposited",
-    displayName: "Savings",
+    displayName: "Lending Pool Deposit",
     iconConfig: { icon: Coins, color: "bg-emerald-500" },
     getTokenAddress: (event: Event) => {
       const asset = event.attributes.asset || event.attributes.Asset;
@@ -1161,7 +1275,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "Savings",
+        title: "Lending Pool Deposit",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -1367,7 +1481,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "VaultDeposited": {
     contract_name: "Vault",
     event_name: "Deposited",
-    displayName: "Vault Deposit",
+    displayName: "Diversified Vault Deposit",
     iconConfig: { icon: Download, color: "bg-teal-500" },
     getTokenAddress: (event: Event) => {
       const asset = event.attributes.asset || event.attributes.Asset;
@@ -1405,7 +1519,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "Vault Deposit",
+        title: "Diversified Vault Deposit",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -1425,7 +1539,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "VaultWithdrawn": {
     contract_name: "Vault",
     event_name: "Withdrawn",
-    displayName: "Vault Withdrawal",
+    displayName: "Diversified Vault Withdrawal",
     iconConfig: { icon: Upload, color: "bg-amber-500" },
     handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => {
       const user = event.attributes.user || event.attributes.User || "";
@@ -1455,7 +1569,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "Vault Withdrawal",
+        title: "Diversified Vault Withdrawal",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -1475,7 +1589,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
   "VaultWithdrawalPayout": {
     contract_name: "Vault",
     event_name: "WithdrawalPayout",
-    displayName: "Vault Payout",
+    displayName: "Diversified Vault Payout",
     iconConfig: { icon: Banknote, color: "bg-yellow-500" },
     getTokenAddress: (event: Event) => {
       const asset = event.attributes.asset || event.attributes.Asset;
@@ -1507,7 +1621,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
       ];
 
       return {
-        title: "Vault Payout",
+        title: "Diversified Vault Payout",
         fields,
         timestamp: event.block_timestamp || "",
         eventId: event.id?.toString(),
@@ -1598,10 +1712,6 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
     event_name: "Deposit",
     displayName: "YieldVault Deposit",
     iconConfig: { icon: Download, color: "bg-cyan-500" },
-    getTokenAddress: (event: Event) => {
-      const asset = (event as any).asset_address;
-      return asset ? [asset] : [];
-    },
     handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => {
       const owner = event.attributes.owner || event.attributes.Owner || "";
       const assets = event.attributes.assets || event.attributes.Assets || "0";
@@ -1612,7 +1722,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
           label: "Deposited",
           value: formatValue(assets),
           type: "amount",
-          badge: "assets",
+          badge: tokenSymbols.get(event.address) || "assets",
           rawAmount: getFullAmount(assets),
         },
         {
@@ -1663,7 +1773,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
           label: "Withdrawn",
           value: formatValue(assets),
           type: "amount",
-          badge: "assets",
+          badge: tokenSymbols.get(event.address) || "assets",
           rawAmount: getFullAmount(assets),
         },
         {
@@ -1772,7 +1882,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
           label: "Claimed",
           value: formatValue(assets),
           type: "amount",
-          badge: "assets",
+          badge: tokenSymbols.get(event.address) || "assets",
           rawAmount: getFullAmount(assets),
         },
         {


### PR DESCRIPTION
-Registered SaveUSDST vault Deposit/Withdraw events in the backend activity configs
-Added "SaveUSDST Deposit" and "SaveUSDST Withdraw" cards to the activity feed
-Added vault addresses to the internal-address list so deposits/withdrawals stop showing as "Send"
-YieldVault cards now show the real asset symbol (e.g. USDC) instead of "assets"
-Merged token and vault-share transfers into a single "Send" type
-Renamed: Savings → Lending Pool Deposit, Deposit → Non-native Deposit, Bridge Out → Non-native Bridge Out, Rewards Claimed → Reward Points Claimed, Vault → Diversified Vault (deposit/withdrawal/payout), and native bridge cards now titled Native Deposit / Native Bridge Out