### PR TITLE
fix(strato-snapshot): use caller's cwd for workdir instead of repo path

### DIFF
--- a/bin/strato-snapshot
+++ b/bin/strato-snapshot
@@ -16,14 +16,16 @@ SNAPSHOT_ARCHIVE_EXT="tar.zst"
 # (purged at start of every run) prevents the unbounded accumulation of
 # /tmp/tmp.* dirs that a per-run mktemp would leave behind, especially since
 # helpers run in command-substitution subshells whose temp paths the parent's
-# EXIT trap cannot track. Kept under the repo folder rather than $TMPDIR: a
+# EXIT trap cannot track. Kept under the caller's cwd rather than $TMPDIR: a
 # separate data drive can be slower and may lack free space for a full snapshot.
-# Default: <repo>/.snapshot-work. Override with STRATO_SNAPSHOT_WORKDIR.
+# (SCRIPT_DIR is not a good base here: once installed via `make install`, it
+# points at ~/.local/bin, not the repo.)
+# Default: $PWD/.snapshot-work. Override with STRATO_SNAPSHOT_WORKDIR.
 init_workdir() {
   if [[ -n "${STRATO_SNAPSHOT_WORKDIR:-}" ]]; then
     WORKDIR="$STRATO_SNAPSHOT_WORKDIR"
   else
-    WORKDIR="$SCRIPT_DIR/../.snapshot-work"
+    WORKDIR="$PWD/.snapshot-work"
   fi
   # Purge any leftovers from prior (possibly crashed) runs, then recreate.
   rm -rf "$WORKDIR" 2>/dev/null || true
@@ -376,11 +378,11 @@ verify_checksum() {
 
 # Persistent directory for downloaded snapshot archives, so an already-downloaded
 # archive whose checksum still matches S3 can be reused instead of re-downloaded.
-# NOT purged between runs (unlike WORKDIR). Kept under the repo folder rather
+# NOT purged between runs (unlike WORKDIR). Kept under the caller's cwd rather
 # than $TMPDIR so downloads never land on a different (slower/smaller) data drive.
 # Override with STRATO_SNAPSHOT_DOWNLOAD_DIR.
 snapshot_download_dir() {
-  local dir="${STRATO_SNAPSHOT_DOWNLOAD_DIR:-$SCRIPT_DIR/../.snapshot-downloads}"
+  local dir="${STRATO_SNAPSHOT_DOWNLOAD_DIR:-$PWD/.snapshot-downloads}"
   mkdir -p "$dir" 2>/dev/null || { printf '\n'; return 1; }
   (cd "$dir" && pwd)
 }


### PR DESCRIPTION
Change the default work directory base from SCRIPT_DIR to PWD. After `make install`, SCRIPT_DIR resolves to ~/.local/bin instead of the repo, so the previous default created work directories in the wrong location.