### PR TITLE
Ensure forceWipe stops ethereum-jsonrpc before restart

### DIFF
--- a/forceWipe
+++ b/forceWipe
@@ -14,4 +14,4 @@ do
 	docker volume rm $volume
 done
 
-killall strato-api strato-p2p strato-sequencer strato-network-monitor vm-runner slipstream ethereum-discover strato-indexer blockapps-vault-wrapper-server
+killall strato-api strato-p2p strato-sequencer strato-network-monitor vm-runner slipstream ethereum-discover ethereum-jsonrpc strato-indexer blockapps-vault-wrapper-server


### PR DESCRIPTION
forceWipe is used before clean node restarts, but it did not stop the host ethereum-jsonrpc process. That could leave the old process bound to its port and cause the restarted node to fail with port bind errors.