### PR TITLE
Fix Wallet Logic

### DIFF
--- a/app/ui/src/components/bridge/BridgeIn.tsx
+++ b/app/ui/src/components/bridge/BridgeIn.tsx
@@ -35,7 +35,7 @@ import {
 import { normalizeError } from "@/lib/bridge/utils";
 import EarnApyTooltip from "@/components/earn/EarnApyTooltip";
 import { buildEarnApyMap } from "@/utils/earnUtils";
-import { ensureHexPrefix, formatBalance, safeParseUnits, formatUnits, truncateDecimals } from "@/utils/numberUtils";
+import { ensureHexPrefix, formatBalance, safeParseUnits, formatUnits, truncateAddress, truncateDecimals } from "@/utils/numberUtils";
 import { handleAmountInputChange, computeMaxTransferable } from "@/utils/transferValidation";
 import { useBridgeContext } from "@/context/BridgeContext";
 import { useEarnContext } from "@/context/EarnContext";
@@ -297,7 +297,7 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false, fundingMode: ext
   const { signTypedDataAsync } = useSignTypedData();
   const { openConnectModal } = useConnectModal();
   const { toast } = useToast();
-  const { userAddress, externalEvmWalletAddress, isExternalEvmWalletConnected, isAppAuthenticated } = useUser();
+  const { userAddress, stratoAddress, externalEvmWalletAddress, isExternalEvmWalletConnected, isAppAuthenticated } = useUser();
   const { fetchUsdstBalance, usdstBalance, voucherBalance } = useTokenContext();
   const { activeTokens, fetchTokens } = useUserTokens();
   const {
@@ -469,7 +469,11 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false, fundingMode: ext
   const expectedChainId = currentNetwork?.chainId ? parseInt(currentNetwork.chainId) : null;
   const externalSender = externalEvmWalletAddress;
   const externalSenderHex = externalSender ? (externalSender as `0x${string}`) : undefined;
-  const stratoRecipient = userAddress;
+  // Must match the identity the backend resolves for this user, since deposit history
+  // and balances are filtered by it: with a vault session the X-Wallet-Address header is
+  // suppressed and the backend uses the vault address; without one it uses the wallet.
+  const stratoRecipient = isAppAuthenticated ? stratoAddress : externalEvmWalletAddress;
+  const stratoRecipientHex = ensureHexPrefix(stratoRecipient);
   const hasExternalWallet = isConnected && isExternalEvmWalletConnected && !!externalSenderHex;
   const isCorrectNetwork = hasExternalWallet && !!chainId && !!expectedChainId && chainId === expectedChainId;
   const isNativeRedemption = selectedToken?.routeType === "native";
@@ -1391,9 +1395,23 @@ const BridgeIn: React.FC<BridgeInProps> = ({ guestMode = false, fundingMode: ext
 
         {/* STEP 3 */}
         <section className="space-y-3">
-          <div className="flex items-center gap-2">
-            <span className="w-6 h-6 rounded-full bg-blue-500/10 text-blue-500 text-xs font-bold flex items-center justify-center shrink-0">3</span>
-            <h3 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">You Receive On STRATO</h3>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="w-6 h-6 rounded-full bg-blue-500/10 text-blue-500 text-xs font-bold flex items-center justify-center shrink-0">3</span>
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">You Receive On STRATO</h3>
+            </div>
+            {stratoRecipientHex && (
+              <button
+                type="button"
+                className="text-[11px] text-muted-foreground font-mono hover:text-foreground transition-colors"
+                onClick={() => {
+                  navigator.clipboard.writeText(stratoRecipientHex);
+                  toast({ title: "Copied", description: "STRATO address copied to clipboard", duration: 1500 });
+                }}
+              >
+                {truncateAddress(stratoRecipientHex)}
+              </button>
+            )}
           </div>
 
           <div className="relative">

--- a/app/ui/src/components/dashboard/DashboardHeader.tsx
+++ b/app/ui/src/components/dashboard/DashboardHeader.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'next-themes';
 import { LogOutIcon, Copy, ChevronLeft } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import { useAccount, useDisconnect } from 'wagmi';
+import { useDisconnect } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/use-toast';
@@ -23,10 +23,9 @@ interface DashboardHeaderProps {
 const GRADIENT_BUTTON_CLASS = "w-full bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90";
 
 const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
-  const { userAddress, userName, logout, isLoggedIn } = useUser();
+  const { userAddress, userName, logout, isLoggedIn, externalEvmWalletAddress, isExternalEvmWalletConnected } = useUser();
   const { isTestnet } = useNetwork();
   const { resolvedTheme } = useTheme();
-  const { address: walletAddress, isConnected } = useAccount();
   const { disconnect } = useDisconnect();
   const { toast } = useToast();
   const navigate = useNavigate();
@@ -144,7 +143,7 @@ const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
               </div>
             </PopoverContent>
           </Popover>
-        ) : isConnected ? (
+        ) : isLoggedIn && isExternalEvmWalletConnected ? (
           <Popover>
             <PopoverTrigger asChild>
               <button className="w-8 h-8 md:w-9 md:h-9 rounded-full bg-[#f6851b] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity">
@@ -161,8 +160,8 @@ const DashboardHeader = ({ title, subtitle }: DashboardHeaderProps) => {
                   <div className="min-w-0">
                     <p className="font-medium text-sm truncate">External Wallet</p>
                     <div className="flex items-center gap-1.5 text-[10px] md:text-xs text-muted-foreground font-mono">
-                      <span className="truncate">{truncateAddress(walletAddress, 8, 4)}</span>
-                      <button onClick={() => copyAddress(walletAddress, 'Wallet')} className="hover:text-foreground shrink-0">
+                      <span className="truncate">{truncateAddress(externalEvmWalletAddress, 8, 4)}</span>
+                      <button onClick={() => copyAddress(externalEvmWalletAddress, 'Wallet')} className="hover:text-foreground shrink-0">
                         <Copy size={10} />
                       </button>
                     </div>

--- a/app/ui/src/context/UserContext.tsx
+++ b/app/ui/src/context/UserContext.tsx
@@ -10,6 +10,8 @@ import { ADMIN_VOTE_EXECUTED_ISSUES_PER_PAGE } from "@/lib/constants";
 import { readAttribution, clearAttribution } from "@/lib/attribution";
 import { trackWalletConnected } from "@/lib/tracking";
 import { ensureStratoChainInWallet } from "@/lib/stratoChain";
+import { clearExternalWalletActive } from "@/lib/stratoWallet";
+import { ensureHexPrefix } from "@/utils/numberUtils";
 
 interface UserContextType {
   userAddress: string | null;
@@ -281,10 +283,12 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const externalEvmWalletAddress = !isStratoConnector(account.connector) ? externalWalletAddress : null;
   const isExternalEvmWalletConnected = !!externalEvmWalletAddress;
   const shouldUseExternalWallet = !sessionExpiryLogoutStartedRef.current && !loading && !isLoggedIn && isExternalWalletConnected;
-  // Uniform address source: the connected wagmi account (both the STRATO/vault
-  // connector and external EVM wallets publish their address there), falling back
-  // to the vault-derived address only for the brief window before wagmi hydrates.
-  const userAddress = externalWalletAddress ?? stratoAddress;
+  // The vault identity wins whenever a vault session exists: the backend suppresses the
+  // X-Wallet-Address header and resolves data for the vault address, so the UI must not
+  // display or filter by an external wallet connected on the Fund page. Guests fall back
+  // to the wagmi account. The vault address arrives without a 0x prefix, unlike wagmi's.
+  const stratoAddressHex = ensureHexPrefix(stratoAddress) ?? null;
+  const userAddress = isLoggedIn ? stratoAddressHex : externalWalletAddress ?? stratoAddressHex;
   const effectiveLoggedIn = isLoggedIn || shouldUseExternalWallet;
 
   useEffect(() => {
@@ -329,6 +333,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
         const d = unsignedTx.data;
         return walletClient.signTypedData({
+          account: walletClient.account,
           domain: {
             name: "STRATO",
             version: "1",
@@ -366,6 +371,12 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   const handleLogout = useCallback(() => {
+    // Mark the logout before any state clears, so the render between setUserName(null) and
+    // wagmi's async disconnect does not treat the still-connected wallet as a guest login.
+    sessionExpiryLogoutStartedRef.current = true;
+    // Without this the flag outlives the session and blocks STRATO auto-reconnect on the
+    // next login in this browser.
+    clearExternalWalletActive();
     try {
       disconnect();
     } catch {


### PR DESCRIPTION
## Fix incorrect recipient address in Fund flow

- `BridgeIn` now sends deposits to the identity the backend actually resolves — `stratoAddress` with a vault session, the external wallet without one — instead of `userAddress`, and surfaces that address in the later step so it can be verified before depositing.
- `UserContext` returns `userAddress` to the vault whenever a vault session exists, so the header, lending metrics, swap history and activity feed stop displaying and filtering by an external wallet connected on the Fund page.
- Logout clears the external-wallet flag and marks the session first, so the STRATO wallet reconnects on the next login and the external-wallet avatar no longer flashes during sign-out.
- Display the strato receipient address abreivatied in the Fund UI for higher user confidence